### PR TITLE
feat: add website, upgrade CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
+    branches: [develop]
+  push:
     branches: [main]
 
 env:
@@ -11,78 +11,50 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-targets
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings
+
   test:
-    name: Test (${{ matrix.rust }})
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [stable, nightly]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: clippy, rustfmt
-
-      - name: Cache cargo registry & build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ matrix.rust }}-
-
-      - name: Check formatting
-        if: matrix.rust == 'stable'
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        if: matrix.rust == 'stable'
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Run tests
-        run: cargo test --all-features --verbose
-
-      - name: Build release
-        run: cargo build --release --verbose
-
-  lint:
-    name: Lint & Format (stable)
+    name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
 
-      - name: Install Rust toolchain (stable)
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-  msrv:
-    name: Check MSRV
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain (MSRV)
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.75.0"
-
-      - name: Build
-        run: cargo build
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,64 @@
+name: Deploy Website to Cloudflare Pages
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-website.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: website
+
+      - name: Build
+        run: npm run build
+        working-directory: website
+
+      - name: Verify build output
+        run: |
+          if [ ! -d "website/build" ] || [ -z "$(ls -A website/build)" ]; then
+            echo "::error::Build output is empty or missing."
+            exit 1
+          fi
+
+      - name: Fetch secrets from Infisical
+        uses: Infisical/secrets-action@v1.0.9
+        with:
+          method: "oidc"
+          identity-id: "6bd2b8d8-a9a3-4331-8b37-bf2764fc320b"
+          project-slug: "github-actions"
+          env-slug: "prod"
+          domain: "https://infisical.ajianaz.dev"
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          preCommands: npx wrangler pages project create cora --production-branch=develop || true
+          command: pages deploy website/build/ --project-name=cora --commit-dirty=true --branch=develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,105 +3,186 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
-
-permissions:
-  contents: write
+      - 'v*'
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  RUST_BACKTRACE: 1
 
 jobs:
   build-release:
-    name: Build (${{ matrix.target }})
-    runs-on: ${{ matrix.runner }}
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-latest
-            artifact_name: cora
-            asset_name: cora-linux-aarch64
-          - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
-            artifact_name: cora
-            asset_name: cora-linux-x86_64
-          - target: aarch64-apple-darwin
-            runner: macos-latest
-            artifact_name: cora
-            asset_name: cora-macos-aarch64
-          - target: x86_64-apple-darwin
-            runner: macos-latest
-            artifact_name: cora
-            asset_name: cora-macos-x86_64
-          - target: x86_64-pc-windows-msvc
-            runner: windows-latest
-            artifact_name: cora.exe
-            asset_name: cora-windows-x86_64
+          # Linux x86_64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: cora-x86_64-unknown-linux-gnu
+            ext: tar.gz
+          # Linux ARM64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact: cora-aarch64-unknown-linux-gnu
+            ext: tar.gz
+          # macOS Apple Silicon
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: cora-aarch64-apple-darwin
+            ext: tar.gz
+          # Windows x86_64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: cora-x86_64-pc-windows-msvc
+            ext: zip
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation dependencies (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Package binary
+      - name: Strip binary (Unix)
+        if: runner.os != 'Windows'
+        run: strip target/${{ matrix.target }}/release/cora
+
+      - name: Extract version
+        id: version
         shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact_name }}
+          mkdir -p release
+          cp target/${{ matrix.target }}/release/cora release/${{ matrix.artifact }}
+          cd release
+          tar czf ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }} ${{ matrix.artifact }}
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          mkdir release
+          cp target/${{ matrix.target }}/release/cora.exe release/${{ matrix.artifact }}.exe
+          cd release
+          7z a ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }} ${{ matrix.artifact }}.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.asset_name }}
-          path: ${{ matrix.asset_name }}.tar.gz
+          name: ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}
+          path: release/${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}
 
-  publish-github-release:
-    name: Publish GitHub Release
-    needs: build-release
+  publish-crates:
+    name: Publish to crates.io
+    needs: []
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Fetch CARGO_REGISTRY_TOKEN from Infisical
+        uses: Infisical/secrets-action@v1.0.9
+        with:
+          method: "oidc"
+          identity-id: "6bd2b8d8-a9a3-4331-8b37-bf2764fc320b"
+          project-slug: "github-actions"
+          env-slug: "prod"
+          domain: "https://infisical.ajianaz.dev"
+
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ env.CARGO_REGISTRY_TOKEN }}
+
+  release:
+    name: Create GitHub Release
+    needs: [build-release, publish-crates]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          path: artifacts/
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la release-artifacts/
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        run: |
+          cat > release-notes.md << 'EOF'
+          ## What's New in VERSION
+
+          ### 🚀 Features
+
+          - **AI Code Review** — diff, branch comparison, full project scan
+          - **BYOK** — bring your own API key (OpenAI, Anthropic, Groq, Ollama, Z.AI)
+          - **Pre-commit Hooks** — `cora hook install` for automatic review on every commit
+          - **Incremental Scan** — `cora scan --incremental` with SHA256 content hash cache
+          - **SARIF Output** — upload findings to GitHub Code Scanning
+          - **Streaming** — real-time review output with `--stream`
+          - **Shell Completions** — `cora completion bash|zsh|fish|powershell`
+          - **5 Providers** — OpenAI, Anthropic, Groq, Ollama, Z.AI with auto-detection
+          - **Project Config** — `.cora.yaml` per-project configuration
+          - **MIT License** — fully open source
+
+          ### 📦 Platforms
+
+          | Platform | File |
+          |----------|------|
+          | Linux (x86_64) | `cora-VERSION-x86_64-unknown-linux-gnu.tar.gz` |
+          | Linux (ARM64) | `cora-VERSION-aarch64-unknown-linux-gnu.tar.gz` |
+          | macOS (Apple Silicon) | `cora-VERSION-aarch64-apple-darwin.tar.gz` |
+          | Windows (x86_64) | `cora-VERSION-x86_64-pc-windows-msvc.zip` |
+
+          ### 🚀 Quick Start
+
+          ```bash
+          # Install via cargo
+          cargo install cora
+
+          # Or download binary
+          curl -fsSL https://github.com/ajianaz/cora-cli/releases/latest/download/cora-x86_64-unknown-linux-gnu-v0.1.1.tar.gz | tar xz
+
+          # Init project
+          cora init
+
+          # Review staged changes
+          CORA_API_KEY=your-key cora review --staged
+          ```
+
+          **Full changelog:** https://github.com/ajianaz/cora-cli/blob/main/CHANGELOG.md
+
+          EOF
+          sed -i "s/VERSION/${{ steps.version.outputs.VERSION }}/g" release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
-          files: artifacts/**/*.tar.gz
+          tag_name: ${{ steps.version.outputs.VERSION }}
+          name: Release ${{ steps.version.outputs.VERSION }}
+          body_path: release-notes.md
+          files: release-artifacts/*
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.VERSION, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-crates-io:
-    name: Publish to crates.io
-    needs: build-release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CRATES_TOKEN }}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.svelte-kit
+build

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,1600 @@
+{
+  "name": "cora-website",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cora-website",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@sveltejs/adapter-auto": "^7.0.1",
+        "@sveltejs/adapter-static": "^3.0.10",
+        "@sveltejs/kit": "^2.57.0",
+        "@sveltejs/vite-plugin-svelte": "^7.0.0",
+        "@tailwindcss/vite": "^4.3.0",
+        "svelte": "^5.55.2",
+        "svelte-check": "^4.4.6",
+        "tailwindcss": "^4.3.0",
+        "typescript": "^6.0.2",
+        "vite": "^8.0.7"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/adapter-auto": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-7.0.1.tgz",
+      "integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.0.0"
+      }
+    },
+    "node_modules/@sveltejs/adapter-static": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.10.tgz",
+      "integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
+      "dev": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.0.0"
+      }
+    },
+    "node_modules/@sveltejs/kit": {
+      "version": "2.61.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.61.1.tgz",
+      "integrity": "sha512-Ny8s1SR1TyQS2hD2Rvw0XKzU2Nw1eUF52dTb6T2bdcgz7wSC+Nyb5IwjWYlR4b2dvbbR5NJDiQwHg3rnNseghg==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@sveltejs/acorn-typescript": "^1.0.9",
+        "@types/cookie": "^0.6.0",
+        "acorn": "^8.16.0",
+        "cookie": "^0.6.0",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.2",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.5",
+        "mrmime": "^2.0.0",
+        "set-cookie-parser": "^3.0.0",
+        "sirv": "^3.0.0"
+      },
+      "bin": {
+        "svelte-kit": "svelte-kit.js"
+      },
+      "engines": {
+        "node": ">=18.13"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": "^5.3.3 || ^6.0.0",
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
+      "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
+      "dev": true,
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.0",
+        "vitefu": "^1.1.2"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "svelte": "^5.46.4",
+        "vite": "^8.0.0-beta.7 || ^8.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "dev": true,
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
+      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true
+    },
+    "node_modules/esrap": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ]
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.0.tgz",
+      "integrity": "sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.9",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
+      "integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cora-website",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "prepare": "svelte-kit sync || echo ''",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^7.0.1",
+    "@sveltejs/adapter-static": "^3.0.10",
+    "@sveltejs/kit": "^2.57.0",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "@tailwindcss/vite": "^4.3.0",
+    "svelte": "^5.55.2",
+    "svelte-check": "^4.4.6",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.2",
+    "vite": "^8.0.7"
+  }
+}

--- a/website/src/app.css
+++ b/website/src/app.css
@@ -1,0 +1,264 @@
+@import 'tailwindcss';
+
+:root {
+	--color-bg: #0a0a0b;
+	--color-surface: #131315;
+	--color-surface-2: #1a1a1d;
+	--color-border: #27272a;
+	--color-border-light: #3f3f46;
+	--color-text: #fafafa;
+	--color-text-muted: #a1a1aa;
+	--color-text-dim: #71717a;
+	--color-accent: #f59e0b;
+	--color-accent-hover: #d97706;
+	--color-accent-dim: rgba(245, 158, 11, 0.15);
+	--color-success: #22c55e;
+	--color-error: #ef4444;
+	--color-warning: #eab308;
+	--color-info: #3b82f6;
+}
+
+* {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+body {
+	font-family: 'Inter', system-ui, -apple-system, sans-serif;
+	background-color: var(--color-bg);
+	color: var(--color-text);
+	line-height: 1.6;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+code, pre, .font-mono {
+	font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+}
+
+a {
+	color: var(--color-accent);
+	text-decoration: none;
+	transition: color 0.2s;
+}
+
+a:hover {
+	color: var(--color-accent-hover);
+}
+
+/* Hero gradient text */
+.hero-gradient {
+	background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 50%, #f59e0b 100%);
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	background-clip: text;
+}
+
+/* Amber glow */
+.glow-amber {
+	box-shadow: 0 0 30px rgba(245, 158, 11, 0.15), 0 0 60px rgba(245, 158, 11, 0.05);
+}
+
+/* Grid background */
+.grid-bg {
+	background-image:
+		linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+	background-size: 64px 64px;
+}
+
+/* Terminal block */
+.terminal-block {
+	background: linear-gradient(135deg, #1a1a1d 0%, #0f0f10 100%);
+	border: 1px solid var(--color-border);
+	border-radius: 12px;
+	padding: 1.25rem 1.5rem;
+	position: relative;
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 0.875rem;
+	line-height: 1.7;
+	overflow-x: auto;
+}
+
+.terminal-block::before {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 1px;
+	background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
+	opacity: 0.4;
+}
+
+/* Feature card */
+.feature-card {
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	border-radius: 12px;
+	padding: 2rem;
+	transition: all 0.3s ease;
+}
+
+.feature-card:hover {
+	border-color: var(--color-border-light);
+	transform: translateY(-2px);
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+/* CTA buttons */
+.cta-primary {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.75rem 1.5rem;
+	background: var(--color-accent);
+	color: #0a0a0b;
+	font-weight: 600;
+	border-radius: 8px;
+	transition: all 0.2s ease;
+	border: none;
+	cursor: pointer;
+	font-size: 0.9rem;
+}
+
+.cta-primary:hover {
+	background: var(--color-accent-hover);
+	color: #0a0a0b;
+	box-shadow: 0 0 20px rgba(245, 158, 11, 0.3);
+}
+
+.cta-secondary {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.75rem 1.5rem;
+	background: transparent;
+	color: var(--color-text);
+	font-weight: 500;
+	border-radius: 8px;
+	border: 1px solid var(--color-border);
+	transition: all 0.2s ease;
+	cursor: pointer;
+	font-size: 0.9rem;
+}
+
+.cta-secondary:hover {
+	border-color: var(--color-border-light);
+	background: var(--color-surface);
+	color: var(--color-text);
+}
+
+/* Separator */
+.separator-gradient {
+	height: 1px;
+	background: linear-gradient(90deg, transparent, var(--color-border), transparent);
+}
+
+/* Compare table */
+.compare-table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.compare-table th,
+.compare-table td {
+	padding: 0.75rem 1rem;
+	border-bottom: 1px solid var(--color-border);
+	text-align: left;
+}
+
+.compare-table th {
+	color: var(--color-text-muted);
+	font-weight: 500;
+	font-size: 0.85rem;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.compare-table td {
+	font-size: 0.9rem;
+}
+
+.compare-table tr:hover td {
+	background: var(--color-surface-2);
+}
+
+.highlight-col {
+	color: var(--color-accent);
+	font-weight: 600;
+}
+
+/* Animations */
+@keyframes fadeInUp {
+	from {
+		opacity: 0;
+		transform: translateY(20px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.animate-fade-in {
+	animation: fadeInUp 0.6s ease-out forwards;
+}
+
+.animate-fade-in-delay-1 {
+	animation: fadeInUp 0.6s ease-out 0.1s forwards;
+	opacity: 0;
+}
+
+.animate-fade-in-delay-2 {
+	animation: fadeInUp 0.6s ease-out 0.2s forwards;
+	opacity: 0;
+}
+
+.animate-fade-in-delay-3 {
+	animation: fadeInUp 0.6s ease-out 0.3s forwards;
+	opacity: 0;
+}
+
+/* Syntax highlighting */
+.cmd-highlight {
+	color: var(--color-accent);
+}
+
+.cmd-string {
+	color: var(--color-success);
+}
+
+.cmd-flag {
+	color: var(--color-info);
+}
+
+.cmd-comment {
+	color: var(--color-text-dim);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+
+::-webkit-scrollbar-track {
+	background: var(--color-bg);
+}
+
+::-webkit-scrollbar-thumb {
+	background: var(--color-border);
+	border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: var(--color-border-light);
+}
+
+/* Selection */
+::selection {
+	background: var(--color-accent);
+	color: #0a0a0b;
+}

--- a/website/src/app.d.ts
+++ b/website/src/app.d.ts
@@ -1,0 +1,13 @@
+// See https://svelte.dev/docs/kit/types#app.d.ts
+// for information about these interfaces
+declare global {
+	namespace App {
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface PageState {}
+		// interface Platform {}
+	}
+}
+
+export {};

--- a/website/src/app.html
+++ b/website/src/app.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import '../app.css';
+
+	let { children } = $props();
+</script>
+
+{@render children()}

--- a/website/src/routes/+layout.ts
+++ b/website/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const ssr = false;

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -1,0 +1,438 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let currentSlide = $state(0);
+	let mounted = $state(false);
+
+	const slides = [
+		{
+			cmd: 'cora init',
+			output: '✓ Created .cora.yaml in /home/dev/my-project\n✓ Default provider: auto-detect\n✓ Ready to review. Run: cora review --staged'
+		},
+		{
+			cmd: 'cora review --staged',
+			output: '🔍 Reviewing 3 files (142 additions, 23 deletions)...\n\n⚠️ src/auth/login.ts:45  — SQL injection risk in query builder\n⚠️ src/api/handler.ts:22 — Unhandled promise rejection\n✅ src/utils/format.ts:12  — Good error handling pattern\n\nFound 2 issues in 2.3s'
+		},
+		{
+			cmd: 'cora review --branch feature/auth',
+			output: '🔍 Comparing feature/auth → main (12 files, 847 changes)...\n\n❌ src/auth/oauth.ts:89   — Hardcoded client secret\n❌ src/auth/session.ts:34  — Session fixation vulnerability\n⚠️ src/auth/middleware.ts:12 — Missing rate limiting\n✅ src/auth/csrf.ts:8      — CSRF token implementation looks good\n\nFound 3 issues in 8.1s'
+		},
+		{
+			cmd: 'cora scan --incremental',
+			output: `⚡ Incremental scan — checking 4 modified files...\n\n✅ src/index.ts     — No issues\n✅ src/config.ts    — No issues\n⚠️ src/logger.ts:18 — Console.log left in production code\n✅ src/parser.ts    — No issues\n\n1 issue found in 1.2s (cached: 147 files)`
+		},
+		{
+			cmd: 'cora hook install',
+			output: '🪝 Installing pre-commit hook...\n✓ Hook installed to .git/hooks/pre-commit\n✓ Hook will run: cora review --staged --fail-on error\n\nNext commit will be automatically reviewed.'
+		}
+	];
+
+	onMount(() => {
+		mounted = true;
+		const interval = setInterval(() => {
+			currentSlide = (currentSlide + 1) % slides.length;
+		}, 4000);
+		return () => clearInterval(interval);
+	});
+
+	const features = [
+		{
+			icon: '🔍',
+			title: 'AI Code Review',
+			subtitle: 'Diff, branch, or full scan',
+			description: 'Three review modes: staged diff (<3s), branch comparison, full project scan. LLM-powered analysis catches bugs, security issues, and style violations.'
+		},
+		{
+			icon: '🔑',
+			title: 'Bring Your Own Key',
+			subtitle: 'No subscriptions, no lock-in',
+			description: 'Uses YOUR OpenAI, Anthropic, Groq, Ollama, or Z.AI API key. No data stored on our servers. You control the model, you control the cost.'
+		},
+		{
+			icon: '🪝',
+			title: 'Pre-commit Hooks',
+			subtitle: 'Review before you push',
+			description: 'Install once: <code class="cmd-highlight">cora hook install</code>. Every commit gets reviewed automatically. Block bad code from entering your branch.'
+		},
+		{
+			icon: '📊',
+			title: 'SARIF Output',
+			subtitle: 'GitHub Code Scanning integration',
+			description: 'Upload review findings directly to GitHub\'s Security tab. Track issues across PRs. Works with any CI/CD pipeline.'
+		},
+		{
+			icon: '⚡',
+			title: 'Incremental Scan',
+			subtitle: 'Only scan what changed',
+			description: 'SHA256 content hash cache. First scan indexes your codebase. Subsequent scans only review new or modified files.'
+		},
+		{
+			icon: '🏠',
+			title: 'Self-Hosted',
+			subtitle: 'Your code stays yours',
+			description: 'Runs entirely on your machine. No cloud, no telemetry, no data leaving your network. Perfect for Gitea and air-gapped environments.'
+		}
+	];
+
+	const quickStart = [
+		{
+			step: '1',
+			label: 'Install',
+			cmd: 'cargo install cora',
+			desc: 'Single binary, no dependencies'
+		},
+		{
+			step: '2',
+			label: 'Initialize',
+			cmd: 'cora init',
+			desc: 'Creates .cora.yaml config'
+		},
+		{
+			step: '3',
+			label: 'Review',
+			cmd: 'CORA_API_KEY=your-key cora review --staged',
+			desc: 'Review your staged changes'
+		},
+		{
+			step: '4',
+			label: 'Done',
+			cmd: null,
+			desc: 'No account. No subscription. No cloud.'
+		}
+	];
+
+	const comparisonRows = [
+		['Install', '1 binary', 'GitHub App', 'Copilot Sub', 'Docker + DB'],
+		['BYOK', '✅', '❌', '❌', 'N/A'],
+		['Self-hosted', '✅', '❌', '❌', '✅'],
+		['Gitea Support', '✅', '❌', '❌', '✅'],
+		['Pre-commit Hook', '✅', '❌', '❌', '✅'],
+		['CLI', '✅', '❌', '❌', '✅'],
+		['SARIF', '✅', '✅', '✅', '✅'],
+		['Cost', 'Free + API', '$12-24/user/mo', '$10-39/mo', 'Free/$150+'],
+		['License', 'MIT', 'Apache 2.0', 'Proprietary', 'LGPL']
+	];
+</script>
+
+<svelte:head>
+	<title>cora — AI Code Review CLI</title>
+	<meta name="description" content="cora is a CLI-first AI code reviewer. BYOK, zero config, runs in your terminal. Your code never leaves your machine." />
+</svelte:head>
+
+<div class="grid-bg min-h-screen">
+
+	<!-- Hero Section -->
+	<section class="relative pt-24 pb-20 px-6">
+		<div class="max-w-4xl mx-auto text-center">
+			<div class="animate-fade-in">
+				<a
+					href="https://github.com/nousresearch/cora-cli/releases"
+					target="_blank"
+					rel="noopener"
+					class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full border border-[var(--color-border)] text-sm text-[var(--color-text-muted)] hover:border-[var(--color-border-light)] hover:text-[var(--color-text)] transition-all mb-8"
+				>
+					<span class="w-2 h-2 rounded-full bg-[var(--color-success)]"></span>
+					v0.1.1 released
+					<span class="text-[var(--color-text-dim)]">→</span>
+				</a>
+			</div>
+
+			<h1 class="text-5xl md:text-7xl font-extrabold tracking-tight leading-tight mb-6 animate-fade-in-delay-1">
+				Ship better code.<br />
+				<span class="hero-gradient">Get it reviewed by AI.</span>
+			</h1>
+
+			<p class="text-lg md:text-xl text-[var(--color-text-muted)] max-w-2xl mx-auto mb-10 animate-fade-in-delay-2">
+				cora is a CLI-first AI code reviewer. BYOK, zero config, runs in your terminal.
+				Your code never leaves your machine.
+			</p>
+
+			<div class="animate-fade-in-delay-3">
+				<div class="terminal-block max-w-lg mx-auto mb-8">
+					<div class="flex items-center gap-2 mb-3">
+						<span class="w-3 h-3 rounded-full bg-red-500/60"></span>
+						<span class="w-3 h-3 rounded-full bg-yellow-500/60"></span>
+						<span class="w-3 h-3 rounded-full bg-green-500/60"></span>
+					</div>
+					<div class="text-left">
+						<span class="cmd-comment">$</span> <span class="cmd-highlight">cargo install</span> <span class="cmd-string">cora</span>
+					</div>
+				</div>
+
+				<div class="flex flex-wrap justify-center gap-4">
+					<a href="https://github.com/nousresearch/cora-cli" class="cta-primary" target="_blank" rel="noopener">
+						<svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+						GitHub
+					</a>
+					<a href="/docs" class="cta-secondary">
+						Documentation
+						<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+					</a>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<div class="separator-gradient max-w-6xl mx-auto"></div>
+
+	<!-- Terminal Demo Section -->
+	<section class="py-20 px-6">
+		<div class="max-w-3xl mx-auto">
+			<h2 class="text-2xl font-bold text-center mb-10 text-[var(--color-text-muted)]">See it in action</h2>
+			<div class="terminal-block glow-amber">
+				<div class="flex items-center gap-2 mb-4">
+					<span class="w-3 h-3 rounded-full bg-red-500/60"></span>
+					<span class="w-3 h-3 rounded-full bg-yellow-500/60"></span>
+					<span class="w-3 h-3 rounded-full bg-green-500/60"></span>
+					<span class="ml-4 text-xs text-[var(--color-text-dim)]">cora</span>
+				</div>
+				{#if mounted}
+					{#key currentSlide}
+						<div class="transition-all duration-300">
+							<div class="mb-4">
+								<span class="cmd-comment">$</span>
+								<span class="cmd-highlight">{slides[currentSlide].cmd}</span>
+							</div>
+							<pre class="whitespace-pre-wrap text-[var(--color-text-muted)] text-xs leading-relaxed">{slides[currentSlide].output}</pre>
+						</div>
+					{/key}
+				{/if}
+				<div class="flex justify-center gap-2 mt-6">
+					{#each slides as _, i}
+						<button
+							class="w-2 h-2 rounded-full transition-all {i === currentSlide ? 'bg-[var(--color-accent)] w-6' : 'bg-[var(--color-border)]'}"
+							onclick={() => currentSlide = i}
+							aria-label="Slide {i + 1}"
+						></button>
+					{/each}
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<div class="separator-gradient max-w-6xl mx-auto"></div>
+
+	<!-- Problem → Solution Section -->
+	<section class="py-20 px-6">
+		<div class="max-w-5xl mx-auto">
+			<h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Your PRs ship with bugs<br/>you could have caught</h2>
+			<p class="text-[var(--color-text-muted)] text-center mb-16 max-w-2xl mx-auto">Code review is the bottleneck. Manual reviews are slow, inconsistent, and don't scale.</p>
+
+			<div class="grid md:grid-cols-2 gap-8">
+				<!-- Before -->
+				<div class="rounded-xl border border-[var(--color-border)] p-8">
+					<div class="text-sm font-semibold text-[var(--color-error)] mb-4 uppercase tracking-wider">Before cora</div>
+					<ul class="space-y-3 text-[var(--color-text-muted)]">
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-error)] mt-1">✗</span>
+							<span>Manual review — hours per PR</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-error)] mt-1">✗</span>
+							<span>Slow feedback — bugs found in production</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-error)] mt-1">✗</span>
+							<span>Inconsistent standards — every reviewer is different</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-error)] mt-1">✗</span>
+							<span>Review fatigue — important issues get missed</span>
+						</li>
+					</ul>
+				</div>
+				<!-- After -->
+				<div class="rounded-xl border border-[var(--color-accent)]/30 bg-[var(--color-accent-dim)] p-8">
+					<div class="text-sm font-semibold text-[var(--color-accent)] mb-4 uppercase tracking-wider">With cora</div>
+					<ul class="space-y-3 text-[var(--color-text)]">
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-success)] mt-1">✓</span>
+							<span>Instant AI review — seconds per diff</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-success)] mt-1">✓</span>
+							<span>Catch bugs before they merge</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-success)] mt-1">✓</span>
+							<span>Consistent rules — same standards every time</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<span class="text-[var(--color-success)] mt-1">✓</span>
+							<span>Pre-commit hooks — automatic review gate</span>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<div class="separator-gradient max-w-6xl mx-auto"></div>
+
+	<!-- Features Section -->
+	<section class="py-20 px-6">
+		<div class="max-w-6xl mx-auto">
+			<h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Everything you need,<br/>nothing you don't</h2>
+			<p class="text-[var(--color-text-muted)] text-center mb-16 max-w-2xl mx-auto">Built for developers who value simplicity and control.</p>
+
+			<div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+				{#each features as feature}
+					<div class="feature-card">
+						<div class="text-3xl mb-4">{feature.icon}</div>
+						<h3 class="text-lg font-semibold mb-1">{feature.title}</h3>
+						<p class="text-sm text-[var(--color-accent)] mb-3">{feature.subtitle}</p>
+						<p class="text-sm text-[var(--color-text-muted)] leading-relaxed">{@html feature.description}</p>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</section>
+
+	<div class="separator-gradient max-w-6xl mx-auto"></div>
+
+	<!-- Quick Start Section -->
+	<section class="py-20 px-6">
+		<div class="max-w-4xl mx-auto">
+			<h2 class="text-3xl md:text-4xl font-bold text-center mb-4">Start in 30 seconds</h2>
+			<p class="text-[var(--color-text-muted)] text-center mb-16">No account required. No subscription. No cloud.</p>
+
+			<div class="grid md:grid-cols-2 gap-6">
+				{#each quickStart as item}
+					<div class="flex gap-4 items-start">
+						<div class="flex-shrink-0 w-10 h-10 rounded-lg bg-[var(--color-accent-dim)] border border-[var(--color-accent)]/30 flex items-center justify-center text-[var(--color-accent)] font-bold text-sm">
+							{item.step}
+						</div>
+						<div class="flex-1">
+							<div class="font-semibold mb-1">{item.label}</div>
+							{#if item.cmd}
+								<div class="terminal-block text-xs py-2 px-3 mt-2">
+									<span class="cmd-comment">$</span> <span class="cmd-highlight">{item.cmd}</span>
+								</div>
+							{:else}
+								<p class="text-[var(--color-text-muted)] text-sm mt-2">{item.desc}</p>
+							{/if}
+						</div>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</section>
+
+	<div class="separator-gradient max-w-6xl mx-auto"></div>
+
+	<!-- Comparison Table -->
+	<section class="py-20 px-6">
+		<div class="max-w-5xl mx-auto">
+			<h2 class="text-3xl md:text-4xl font-bold text-center mb-4">How cora compares</h2>
+			<p class="text-[var(--color-text-muted)] text-center mb-16 max-w-2xl mx-auto">Side-by-side with popular code review tools.</p>
+
+			<div class="rounded-xl border border-[var(--color-border)] overflow-hidden overflow-x-auto">
+				<table class="compare-table">
+					<thead>
+						<tr class="bg-[var(--color-surface)]">
+							<th>Feature</th>
+							<th class="highlight-col">cora</th>
+							<th>CodeRabbit</th>
+							<th>Copilot Review</th>
+							<th>SonarQube</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each comparisonRows as row}
+							<tr>
+								{#each row as cell, i}
+									<td class={i === 1 ? 'highlight-col' : ''}>{cell}</td>
+								{/each}
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</section>
+
+	<div class="separator-gradient max-w-6xl mx-auto"></div>
+
+	<!-- Architecture Section -->
+	<section class="py-20 px-6">
+		<div class="max-w-5xl mx-auto">
+			<h2 class="text-3xl md:text-4xl font-bold text-center mb-16">How it works</h2>
+
+			<div class="flex flex-col md:flex-row items-center justify-center gap-4 mb-12">
+				<!-- Developer -->
+				<div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-6 py-4 text-center">
+					<div class="text-2xl mb-2">👨‍💻</div>
+					<div class="font-semibold text-sm">Developer</div>
+				</div>
+				<!-- Arrow -->
+				<div class="text-[var(--color-accent)] text-2xl rotate-90 md:rotate-0">→</div>
+				<!-- cora CLI -->
+				<div class="rounded-xl border border-[var(--color-accent)]/30 bg-[var(--color-accent-dim)] px-6 py-4 text-center glow-amber">
+					<div class="text-2xl mb-2">🔧</div>
+					<div class="font-semibold text-sm text-[var(--color-accent)]">cora CLI</div>
+				</div>
+				<!-- Arrow -->
+				<div class="text-[var(--color-accent)] text-2xl rotate-90 md:rotate-0">→</div>
+				<!-- LLM API -->
+				<div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-6 py-4 text-center">
+					<div class="text-2xl mb-2">🧠</div>
+					<div class="font-semibold text-sm">LLM API</div>
+					<div class="text-xs text-[var(--color-text-dim)] mt-1">OpenAI · Anthropic · Groq · Ollama</div>
+				</div>
+				<!-- Arrow -->
+				<div class="text-[var(--color-accent)] text-2xl rotate-90 md:rotate-0">→</div>
+				<!-- Results -->
+				<div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-6 py-4 text-center">
+					<div class="text-2xl mb-2">📋</div>
+					<div class="font-semibold text-sm">Review Results</div>
+				</div>
+			</div>
+
+			<!-- Storage -->
+			<div class="flex justify-center mb-8">
+				<div class="terminal-block text-sm py-3 px-4">
+					<span class="cmd-comment">~/.cora/</span>
+					<span class="text-[var(--color-text-dim)]">→ config.toml · cache · reviews</span>
+				</div>
+			</div>
+
+			<!-- Tech badges -->
+			<div class="flex flex-wrap justify-center gap-3">
+				{#each ['Rust', 'Tokio', 'Git2', 'Clap', 'MIT'] as badge}
+					<span class="px-3 py-1 rounded-full border border-[var(--color-border)] text-xs text-[var(--color-text-muted)]">{badge}</span>
+				{/each}
+			</div>
+		</div>
+	</section>
+
+	<div class="separator-gradient max-w-6xl mx-auto"></div>
+
+	<!-- CTA Section -->
+	<section class="py-24 px-6">
+		<div class="max-w-3xl mx-auto text-center">
+			<h2 class="text-4xl md:text-5xl font-extrabold mb-6">Ready to ship better code?</h2>
+			<p class="text-[var(--color-text-muted)] text-lg mb-10">Open source · MIT · Start in 30 seconds</p>
+			<div class="flex flex-wrap justify-center gap-4">
+				<a href="https://github.com/nousresearch/cora-cli" class="cta-primary" target="_blank" rel="noopener">
+					<svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+					Star on GitHub
+				</a>
+				<a href="/docs" class="cta-secondary">
+					Read the Docs
+					<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+				</a>
+			</div>
+		</div>
+	</section>
+
+	<!-- Footer -->
+	<footer class="border-t border-[var(--color-border)] py-8 px-6">
+		<div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-dim)]">
+			<span>cora · MIT License · Built with Rust</span>
+			<div class="flex items-center gap-6">
+				<a href="https://github.com/nousresearch/cora-cli" class="text-[var(--color-text-dim)] hover:text-[var(--color-text)]" target="_blank" rel="noopener">GitHub</a>
+				<a href="/docs" class="text-[var(--color-text-dim)] hover:text-[var(--color-text)]">Docs</a>
+			</div>
+		</div>
+	</footer>
+</div>

--- a/website/src/routes/docs/+layout.svelte
+++ b/website/src/routes/docs/+layout.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	let { children } = $props();
+
+	const navLinks = [
+		{ href: '/docs/cli-reference', label: 'CLI Reference' },
+		{ href: '/docs/configuration', label: 'Configuration' },
+		{ href: '/docs/providers', label: 'Providers' },
+		{ href: '/docs/examples', label: 'Examples' }
+	];
+</script>
+
+<svelte:head>
+	<title>Docs — cora</title>
+</svelte:head>
+
+<div class="grid-bg min-h-screen flex">
+	<!-- Sidebar -->
+	<aside class="w-64 flex-shrink-0 border-r border-[var(--color-border)] bg-[var(--color-surface)] sticky top-0 h-screen overflow-y-auto hidden lg:block">
+		<div class="p-6">
+			<a href="/" class="flex items-center gap-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors mb-8">
+				<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+				<span class="text-sm">Back to Home</span>
+			</a>
+
+			<div class="mb-4">
+				<a href="/docs" class="text-lg font-bold text-[var(--color-accent)]">cora docs</a>
+			</div>
+
+			<nav class="space-y-1">
+				{#each navLinks as link}
+					<a
+						href={link.href}
+						class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all {$page.url.pathname === link.href ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)] font-medium' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface-2)]'}"
+					>
+						{link.label}
+					</a>
+				{/each}
+			</nav>
+		</div>
+	</aside>
+
+	<!-- Mobile nav -->
+	<div class="lg:hidden fixed top-0 left-0 right-0 z-50 bg-[var(--color-surface)] border-b border-[var(--color-border)] px-4 py-3">
+		<div class="flex items-center justify-between">
+			<a href="/" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)]">
+				← Home
+			</a>
+			<span class="text-[var(--color-accent)] font-semibold">Docs</span>
+			<div class="flex gap-3">
+				{#each navLinks as link}
+					<a href={link.href} class="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-accent)]">{$page.url.pathname === link.href ? '✓ ' : ''}{link.label.split(' ')[0]}</a>
+				{/each}
+			</div>
+		</div>
+	</div>
+
+	<!-- Main content -->
+	<main class="flex-1 min-w-0 lg:p-0">
+		<div class="max-w-4xl mx-auto px-6 py-12 lg:py-16 lg:px-12">
+			{@render children()}
+		</div>
+	</main>
+</div>

--- a/website/src/routes/docs/+page.svelte
+++ b/website/src/routes/docs/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+
+	goto('/docs/cli-reference', { replaceState: true });
+</script>

--- a/website/src/routes/docs/cli-reference/+page.svelte
+++ b/website/src/routes/docs/cli-reference/+page.svelte
@@ -1,0 +1,134 @@
+<svelte:head>
+	<title>CLI Reference — cora docs</title>
+	<meta name="description" content="Complete CLI reference for cora - AI code review tool commands, flags, and options." />
+</svelte:head>
+
+<h1 class="text-3xl md:text-4xl font-bold mb-2">CLI Reference</h1>
+<p class="text-[var(--color-text-muted)] mb-10">Complete command reference for the cora CLI.</p>
+
+<!-- Global Flags -->
+<section class="mb-12">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">$</span> Global Flags
+	</h2>
+	<div class="rounded-xl border border-[var(--color-border)] overflow-hidden">
+		<table class="compare-table">
+			<thead>
+				<tr class="bg-[var(--color-surface)]">
+					<th class="w-1/3">Flag</th>
+					<th>Description</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code class="cmd-flag">--config</code> <code class="text-[var(--color-text-dim)]">&lt;path&gt;</code></td>
+					<td>Override config file path (default: <code>.cora.yaml</code>)</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-flag">--json</code></td>
+					<td>Output results as JSON</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-flag">--verbose</code></td>
+					<td>Enable debug logging</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</section>
+
+<!-- Commands -->
+<section class="mb-12">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">⚡</span> Commands
+	</h2>
+	<div class="rounded-xl border border-[var(--color-border)] overflow-hidden">
+		<table class="compare-table">
+			<thead>
+				<tr class="bg-[var(--color-surface)]">
+					<th class="w-1/3">Command</th>
+					<th>Description</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code class="cmd-highlight">cora init</code></td>
+					<td>Create <code>.cora.yaml</code> config file</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora review --staged</code></td>
+					<td>Review staged git changes (default)</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora review --branch</code> <code class="text-[var(--color-text-dim)]">&lt;name&gt;</code></td>
+					<td>Compare current branch against target</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora review --diff</code> <code class="text-[var(--color-text-dim)]">&lt;base&gt;..&lt;head&gt;</code></td>
+					<td>Review specific diff range</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora review --file</code> <code class="text-[var(--color-text-dim)]">&lt;path&gt;</code></td>
+					<td>Review single file</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora scan</code> <code class="cmd-flag">[--incremental]</code></td>
+					<td>Full project scan</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora hook install</code></td>
+					<td>Install pre-commit hook</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora hook uninstall</code></td>
+					<td>Remove pre-commit hook</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora auth login</code></td>
+					<td>Save API key to <code>~/.cora/config.toml</code></td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora auth status</code></td>
+					<td>Check current auth status</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora providers</code></td>
+					<td>List supported AI providers</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora completion</code> <code class="text-[var(--color-text-dim)]">&lt;shell&gt;</code></td>
+					<td>Generate shell completions (bash/zsh/fish/powershell)</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">cora upload-sarif</code> <code class="text-[var(--color-text-dim)]">&lt;file&gt;</code></td>
+					<td>Upload SARIF to GitHub Code Scanning</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</section>
+
+<!-- Quick examples -->
+<section>
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">💡</span> Quick Examples
+	</h2>
+	<div class="space-y-4">
+		<div class="terminal-block">
+			<span class="cmd-comment"># Review staged changes (what's about to be committed)</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span>
+		</div>
+		<div class="terminal-block">
+			<span class="cmd-comment"># Compare your feature branch against main</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--branch</span> <span class="cmd-string">main</span>
+		</div>
+		<div class="terminal-block">
+			<span class="cmd-comment"># Full project scan with incremental caching</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">cora scan</span> <span class="cmd-flag">--incremental</span>
+		</div>
+		<div class="terminal-block">
+			<span class="cmd-comment"># Install pre-commit hook</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">cora hook</span> <span class="cmd-string">install</span>
+		</div>
+	</div>
+</section>

--- a/website/src/routes/docs/configuration/+page.svelte
+++ b/website/src/routes/docs/configuration/+page.svelte
@@ -1,0 +1,122 @@
+<svelte:head>
+	<title>Configuration — cora docs</title>
+	<meta name="description" content="Configure cora - config resolution, .cora.yaml, environment variables, and CLI flags." />
+</svelte:head>
+
+<h1 class="text-3xl md:text-4xl font-bold mb-2">Configuration</h1>
+<p class="text-[var(--color-text-muted)] mb-10">cora uses a layered config system. Later sources override earlier ones.</p>
+
+<!-- Config Resolution Order -->
+<section class="mb-12">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">📋</span> Config Resolution Order
+	</h2>
+	<p class="text-[var(--color-text-muted)] mb-6">Settings are resolved in this order (highest priority first):</p>
+
+	<div class="space-y-3">
+		{#each [
+			{ num: '1', label: 'CLI flags', desc: '--provider, --model, --base-url, etc.', accent: true },
+			{ num: '2', label: '.cora.yaml', desc: 'Project root config file', accent: false },
+			{ num: '3', label: '~/.cora/config.toml', desc: 'User-level config', accent: false },
+			{ num: '4', label: 'Environment variables', desc: 'CORA_API_KEY, CORA_PROVIDER, etc.', accent: false },
+			{ num: '5', label: 'Built-in defaults', desc: 'Sensible defaults for all settings', accent: false }
+		] as item}
+			<div class="flex items-center gap-4 px-4 py-3 rounded-lg {item.accent ? 'bg-[var(--color-accent-dim)] border border-[var(--color-accent)]/30' : 'bg-[var(--color-surface)] border border-[var(--color-border)]'}">
+				<span class="flex-shrink-0 w-8 h-8 rounded-full {item.accent ? 'bg-[var(--color-accent)] text-[var(--color-bg)]' : 'bg-[var(--color-surface-2)] text-[var(--color-text-muted)]'} flex items-center justify-center text-sm font-bold">
+					{item.num}
+				</span>
+				<div>
+					<div class="font-semibold text-sm">{item.label}</div>
+					<div class="text-xs text-[var(--color-text-muted)]">{item.desc}</div>
+				</div>
+			</div>
+		{/each}
+	</div>
+</section>
+
+<!-- .cora.yaml Example -->
+<section class="mb-12">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">📄</span> .cora.yaml Example
+	</h2>
+	<p class="text-[var(--color-text-muted)] mb-4">Create this file in your project root. Run <code class="cmd-highlight">cora init</code> to generate it.</p>
+
+	<div class="terminal-block">
+<pre class="whitespace-pre text-sm"><span class="cmd-comment"># cora project config</span>
+<span class="cmd-highlight">review:</span>
+  <span class="cmd-flag">severity:</span> <span class="cmd-string">warning</span>          <span class="cmd-comment"># minimum severity: info, warning, error</span>
+  <span class="cmd-flag">max_issues:</span> <span class="text-[var(--color-text)]">20</span>             <span class="cmd-comment"># max issues to report</span>
+  <span class="cmd-flag">focus:</span> <span class="cmd-string">security,performance</span>  <span class="cmd-comment"># focus areas</span>
+
+<span class="cmd-highlight">ignore:</span>
+  <span class="text-[var(--color-text)]">- "vendor/**"</span>
+  <span class="text-[var(--color-text)]">- "*.min.js"</span>
+  <span class="text-[var(--color-text)]">- "migrations/**"</span>
+
+<span class="cmd-highlight">providers:</span>
+  <span class="cmd-flag">openai:</span>
+    <span class="cmd-flag">model:</span> <span class="cmd-string">gpt-4o</span>
+  <span class="cmd-flag">anthropic:</span>
+    <span class="cmd-flag">model:</span> <span class="cmd-string">claude-sonnet-4-20250514</span></pre>
+	</div>
+</section>
+
+<!-- Environment Variables -->
+<section class="mb-12">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">🔑</span> Environment Variables
+	</h2>
+	<div class="rounded-xl border border-[var(--color-border)] overflow-hidden">
+		<table class="compare-table">
+			<thead>
+				<tr class="bg-[var(--color-surface)]">
+					<th class="w-1/3">Variable</th>
+					<th>Description</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code class="cmd-highlight">CORA_API_KEY</code></td>
+					<td>API key for the active provider</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">CORA_PROVIDER</code></td>
+					<td>Active provider (openai, anthropic, groq, ollama, zai)</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">CORA_MODEL</code></td>
+					<td>Model name override</td>
+				</tr>
+				<tr>
+					<td><code class="cmd-highlight">CORA_BASE_URL</code></td>
+					<td>Custom API base URL</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</section>
+
+<!-- Provider env vars -->
+<section>
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">🔐</span> Provider-Specific Env Vars
+	</h2>
+	<p class="text-[var(--color-text-muted)] mb-4">Each provider has its own API key variable. cora checks these for auto-detection.</p>
+	<div class="terminal-block">
+<pre class="whitespace-pre text-sm"><span class="cmd-comment"># OpenAI</span>
+<span class="cmd-flag">OPENAI_API_KEY</span>=<span class="cmd-string">sk-...</span>
+<span class="cmd-flag">OPENAI_BASE_URL</span>=<span class="cmd-string">https://api.openai.com/v1</span>
+
+<span class="cmd-comment"># Anthropic</span>
+<span class="cmd-flag">ANTHROPIC_API_KEY</span>=<span class="cmd-string">sk-ant-...</span>
+
+<span class="cmd-comment"># Groq</span>
+<span class="cmd-flag">GROQ_API_KEY</span>=<span class="cmd-string">gsk_...</span>
+
+<span class="cmd-comment"># Ollama (local, no key needed)</span>
+<span class="cmd-flag">OLLAMA_BASE_URL</span>=<span class="cmd-string">http://localhost:11434</span>
+
+<span class="cmd-comment"># Z.AI</span>
+<span class="cmd-flag">ZAI_API_KEY</span>=<span class="cmd-string">...</span></pre>
+	</div>
+</section>

--- a/website/src/routes/docs/examples/+page.svelte
+++ b/website/src/routes/docs/examples/+page.svelte
@@ -1,0 +1,123 @@
+<svelte:head>
+	<title>Examples — cora docs</title>
+	<meta name="description" content="Practical examples for using cora - quick review, CI, pre-commit hooks, SARIF, and more." />
+</svelte:head>
+
+<h1 class="text-3xl md:text-4xl font-bold mb-2">Examples</h1>
+<p class="text-[var(--color-text-muted)] mb-10">Practical examples to get you started with cora.</p>
+
+<!-- Quick Review -->
+<section class="mb-10">
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">1.</span> Quick Review
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Review your staged changes before committing.</p>
+	<div class="terminal-block">
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">CORA_API_KEY</span>=<span class="cmd-string">sk-xxx</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span>
+	</div>
+</section>
+
+<!-- Branch Comparison -->
+<section class="mb-10">
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">2.</span> Branch Comparison
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Compare your current branch against main.</p>
+	<div class="terminal-block">
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--branch</span> <span class="cmd-string">main</span>
+	</div>
+</section>
+
+<!-- Full Project Scan -->
+<section class="mb-10">
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">3.</span> Full Project Scan
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Scan your entire project for issues.</p>
+	<div class="terminal-block">
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">cora scan</span>
+	</div>
+</section>
+
+<!-- Incremental Scan -->
+<section class="mb-10">
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">4.</span> Incremental Scan
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Only scan files that changed since the last scan.</p>
+	<div class="terminal-block">
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">cora scan</span> <span class="cmd-flag">--incremental</span>
+	</div>
+</section>
+
+<!-- Streaming -->
+<section class="mb-10">
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">5.</span> Streaming Output
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Stream results as they come in from the LLM.</p>
+	<div class="terminal-block">
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span> <span class="cmd-flag">--stream</span>
+	</div>
+</section>
+
+<!-- GitHub Actions -->
+<section class="mb-10">
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">6.</span> GitHub Actions CI
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Add cora to your CI pipeline.</p>
+	<div class="terminal-block">
+<pre class="whitespace-pre text-sm"><span class="cmd-comment"># .github/workflows/cora-review.yml</span>
+<span class="cmd-highlight">name:</span> <span class="cmd-string">Code Review</span>
+
+<span class="cmd-highlight">on:</span>
+  <span class="cmd-flag">pull_request:</span>
+    <span class="cmd-flag">branches:</span> [<span class="cmd-string">main</span>]
+
+<span class="cmd-highlight">jobs:</span>
+  <span class="cmd-flag">review:</span>
+    <span class="cmd-flag">runs-on:</span> <span class="cmd-string">ubuntu-latest</span>
+    <span class="cmd-flag">steps:</span>
+      <span class="text-[var(--color-text)]">- uses:</span> <span class="cmd-string">actions/checkout@v4</span>
+
+      <span class="text-[var(--color-text)]">- name:</span> <span class="cmd-string">Install cora</span>
+        <span class="cmd-flag">run:</span> <span class="cmd-string">cargo install cora</span>
+
+      <span class="text-[var(--color-text)]">- name:</span> <span class="cmd-string">Run AI code review</span>
+        <span class="cmd-flag">env:</span>
+          {@html '<span class="cmd-flag">CORA_API_KEY:</span> <span class="cmd-string">${{ secrets.CORA_API_KEY }}</span>'}
+          <span class="cmd-flag">CORA_PROVIDER:</span> <span class="cmd-string">openai</span>
+        <span class="cmd-flag">run:</span> <span class="cmd-string">cora review --branch main --fail-on error</span></pre>
+	</div>
+</section>
+
+<!-- Pre-commit Hook -->
+<section class="mb-10">
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">7.</span> Pre-commit Hook
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Install once, then every commit gets reviewed automatically.</p>
+	<div class="terminal-block">
+		<span class="cmd-comment"># Install the hook</span><br/>
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">cora hook</span> <span class="cmd-string">install</span><br/><br/>
+		<span class="cmd-comment"># Now just commit normally — cora reviews automatically</span><br/>
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">git</span> <span class="cmd-string">commit</span> <span class="cmd-flag">-m</span> <span class="cmd-string">"fix: handle edge case in parser"</span><br/>
+		<span class="text-[var(--color-text-muted)]">🪝 cora pre-commit hook running...</span><br/>
+		<span class="text-[var(--color-success)]">✓ No issues found — commit allowed</span>
+	</div>
+</section>
+
+<!-- SARIF Upload -->
+<section>
+	<h2 class="text-xl font-semibold mb-3 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">8.</span> SARIF Upload
+	</h2>
+	<p class="text-[var(--color-text-muted)] text-sm mb-3">Generate SARIF output and upload to GitHub Code Scanning.</p>
+	<div class="terminal-block">
+		<span class="cmd-comment"># Generate SARIF report and upload</span><br/>
+		<span class="cmd-comment">$</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span> <span class="cmd-flag">--output</span> <span class="cmd-string">sarif</span> <span class="text-[var(--color-text-muted)]">></span> <span class="cmd-string">results.sarif</span> <span class="text-[var(--color-text-muted)]">&&</span> \<br/>
+		&nbsp;&nbsp;<span class="cmd-highlight">cora upload-sarif</span> <span class="cmd-string">results.sarif</span><br/><br/>
+		<span class="text-[var(--color-success)]">✓ Uploaded 3 findings to GitHub Code Scanning</span>
+	</div>
+</section>

--- a/website/src/routes/docs/providers/+page.svelte
+++ b/website/src/routes/docs/providers/+page.svelte
@@ -1,0 +1,114 @@
+<svelte:head>
+	<title>Providers — cora docs</title>
+	<meta name="description" content="Supported AI providers for cora - OpenAI, Anthropic, Groq, Ollama, Z.AI." />
+</svelte:head>
+
+<h1 class="text-3xl md:text-4xl font-bold mb-2">Providers</h1>
+<p class="text-[var(--color-text-muted)] mb-10">cora supports multiple AI providers. Use your own API key — no subscriptions to us.</p>
+
+<!-- Supported Providers -->
+<section class="mb-12">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">🧠</span> Supported Providers
+	</h2>
+	<div class="rounded-xl border border-[var(--color-border)] overflow-x-auto">
+		<table class="compare-table">
+			<thead>
+				<tr class="bg-[var(--color-surface)]">
+					<th>Provider</th>
+					<th>Default Model</th>
+					<th>Env Var</th>
+					<th>Custom Base URL</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td class="font-medium highlight-col">OpenAI</td>
+					<td><code>gpt-4o</code></td>
+					<td><code class="cmd-flag">OPENAI_API_KEY</code></td>
+					<td><code class="cmd-flag">OPENAI_BASE_URL</code></td>
+				</tr>
+				<tr>
+					<td class="font-medium highlight-col">Anthropic</td>
+					<td><code>claude-sonnet-4-20250514</code></td>
+					<td><code class="cmd-flag">ANTHROPIC_API_KEY</code></td>
+					<td><code class="cmd-flag">ANTHROPIC_BASE_URL</code></td>
+				</tr>
+				<tr>
+					<td class="font-medium highlight-col">Groq</td>
+					<td><code>llama-3.3-70b-versatile</code></td>
+					<td><code class="cmd-flag">GROQ_API_KEY</code></td>
+					<td><code class="cmd-flag">GROQ_BASE_URL</code></td>
+				</tr>
+				<tr>
+					<td class="font-medium highlight-col">Ollama</td>
+					<td><code>llama3.1</code></td>
+					<td><span class="text-[var(--color-text-dim)]">— (local)</span></td>
+					<td><code class="cmd-flag">OLLAMA_BASE_URL</code> <span class="text-[var(--color-text-dim)] text-xs">(default: http://localhost:11434)</span></td>
+				</tr>
+				<tr>
+					<td class="font-medium highlight-col">Z.AI</td>
+					<td><code>glm-5.1</code></td>
+					<td><code class="cmd-flag">ZAI_API_KEY</code></td>
+					<td><code class="cmd-flag">ZAI_BASE_URL</code></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</section>
+
+<!-- Auto Detection -->
+<section class="mb-12">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">🔍</span> Auto-Detection
+	</h2>
+	<p class="text-[var(--color-text-muted)] mb-6">
+		cora automatically detects which provider to use by checking environment variables in this order:
+	</p>
+
+	<div class="space-y-2 mb-6">
+		{#each [
+			'OPENAI_API_KEY → uses OpenAI',
+			'ANTHROPIC_API_KEY → uses Anthropic',
+			'GROQ_API_KEY → uses Groq',
+			'ZAI_API_KEY → uses Z.AI',
+			'OLLAMA_BASE_URL → uses Ollama (localhost)'
+		] as item, i}
+			<div class="flex items-center gap-3 px-4 py-2.5 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)]">
+				<span class="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--color-surface-2)] text-[var(--color-text-muted)] flex items-center justify-center text-xs font-bold">
+					{i + 1}
+				</span>
+				<code class="text-sm">{item}</code>
+			</div>
+		{/each}
+	</div>
+
+	<p class="text-sm text-[var(--color-text-muted)]">
+		Override auto-detection with <code class="cmd-highlight">CORA_PROVIDER</code> env var or <code class="cmd-flag">--provider</code> flag.
+	</p>
+</section>
+
+<!-- Examples -->
+<section>
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<span class="text-[var(--color-accent)]">💡</span> Usage Examples
+	</h2>
+	<div class="space-y-4">
+		<div class="terminal-block">
+			<span class="cmd-comment"># Use OpenAI (auto-detected from OPENAI_API_KEY)</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">OPENAI_API_KEY</span>=<span class="cmd-string">sk-...</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span>
+		</div>
+		<div class="terminal-block">
+			<span class="cmd-comment"># Use Anthropic with explicit provider</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">CORA_PROVIDER</span>=<span class="cmd-string">anthropic</span> <span class="cmd-highlight">CORA_API_KEY</span>=<span class="cmd-string">sk-ant-...</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span>
+		</div>
+		<div class="terminal-block">
+			<span class="cmd-comment"># Use Ollama locally (no API key needed)</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">CORA_PROVIDER</span>=<span class="cmd-string">ollama</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span>
+		</div>
+		<div class="terminal-block">
+			<span class="cmd-comment"># Use a custom model</span><br/>
+			<span class="cmd-comment">$</span> <span class="cmd-highlight">CORA_MODEL</span>=<span class="cmd-string">gpt-4o-mini</span> <span class="cmd-highlight">cora review</span> <span class="cmd-flag">--staged</span>
+		</div>
+	</div>
+</section>

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/website/svelte.config.js
+++ b/website/svelte.config.js
@@ -1,0 +1,21 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	preprocess: vitePreprocess(),
+	kit: {
+		adapter: adapter({
+			pages: 'build',
+			assets: 'build',
+			fallback: '404.html',
+			precompress: false,
+			strict: true
+		}),
+		prerender: {
+			handleHttpError: 'warn'
+		}
+	}
+};
+
+export default config;

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler"
+	}
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,0 +1,7 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [tailwindcss(), sveltekit()]
+});


### PR DESCRIPTION
## Summary

- **CI**: 5 parallel jobs (check/fmt/clippy/test/build), `Swatinem/rust-cache@v2`
- **Release**: 4-platform matrix (linux x86_64/arm64, macos arm64, windows x86_64), crates.io publish via Infisical OIDC, template release notes, Windows zip packaging
- **Website**: SvelteKit + adapter-static, dark amber theme, landing page + 4 docs pages
- **Deploy**: CF Pages via Infisical OIDC → cora.ajianaz.dev

## Pattern Reference
Follows uteke CI/CD pattern (Infisical OIDC, rust-cache@v2, adapter-static, CF Pages wrangler)