### PR TITLE
fix: resolve clippy warnings and fmt issues

### DIFF
--- a/src/commands/providers.rs
+++ b/src/commands/providers.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use colored::Colorize;
 
-use crate::config::providers::{detected_presets, PRESETS};
+use crate::config::providers::{PRESETS, detected_presets};
 
 /// Execute the `cora providers` subcommand.
 pub fn execute_providers() -> Result<()> {
@@ -21,29 +21,13 @@ pub fn execute_providers() -> Result<()> {
         println!("  {} {}", status, preset.name.bold());
 
         if is_detected {
-            println!(
-                "    {}  {} (detected)",
-                "key:".dimmed(),
-                preset.env_key
-            );
+            println!("    {}  {} (detected)", "key:".dimmed(), preset.env_key);
         } else {
-            println!(
-                "    {}  set {} to enable",
-                "key:".dimmed(),
-                preset.env_key
-            );
+            println!("    {}  set {} to enable", "key:".dimmed(), preset.env_key);
         }
 
-        println!(
-            "    {}  {}",
-            "model:".dimmed(),
-            preset.default_model
-        );
-        println!(
-            "    {}  {}",
-            "base:".dimmed(),
-            preset.default_base_url
-        );
+        println!("    {}  {}", "model:".dimmed(), preset.default_model);
+        println!("    {}  {}", "base:".dimmed(), preset.default_base_url);
         println!(
             "    {}  {} = <custom url>",
             "url override:".dimmed(),
@@ -60,7 +44,8 @@ pub fn execute_providers() -> Result<()> {
         );
         println!(
             "{}",
-            "   Or set CORA_API_KEY with --provider to use any OpenAI-compatible endpoint.".dimmed()
+            "   Or set CORA_API_KEY with --provider to use any OpenAI-compatible endpoint."
+                .dimmed()
         );
     } else if detected.len() == 1 {
         println!(

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -66,10 +66,16 @@ pub async fn execute_review(
         );
     }
 
-    debug!(diff_len = diff.len(), stream = opts.stream, "running review");
+    debug!(
+        diff_len = diff.len(),
+        stream = opts.stream,
+        "running review"
+    );
 
     // 3. Call the LLM engine
-    let response = crate::engine::review::review_diff_with_stream(config, llm_config, &diff, opts.stream).await?;
+    let response =
+        crate::engine::review::review_diff_with_stream(config, llm_config, &diff, opts.stream)
+            .await?;
 
     // 4. Format output
     let formatter = formatter_for(format);

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -195,7 +195,7 @@ impl ScanCache {
             return Ok(Self::default());
         }
         let content = std::fs::read_to_string(&path)?;
-        serde_json::from_str(&content).context("failed to parse scan cache").map_err(Into::into)
+        serde_json::from_str(&content).context("failed to parse scan cache")
     }
 
     fn save(&self) -> Result<()> {

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use tracing::debug;
 
-use crate::config::providers::{detected_presets, PRESETS};
+use crate::config::providers::{PRESETS, detected_presets};
 use crate::config::schema::{Config, CoraFile};
 use crate::engine::LLMConfig;
 

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -1,8 +1,8 @@
 /// Known provider presets with their expected env vars and defaults.
 pub struct ProviderPreset {
     pub name: &'static str,
-    pub env_key: &'static str,      // env var for API key
-    pub env_url: &'static str,      // env var for custom base URL
+    pub env_key: &'static str, // env var for API key
+    pub env_url: &'static str, // env var for custom base URL
     pub default_model: &'static str,
     pub default_base_url: &'static str,
 }
@@ -53,7 +53,7 @@ pub fn preset_has_key(preset: &ProviderPreset) -> bool {
     if preset.name == "ollama" {
         return std::env::var("OLLAMA_HOST").is_ok()
             || std::env::var("OLLAMA_API_KEY").is_ok()
-            || std::env::var("CORA_PROVIDER").map_or(false, |v| v == "ollama");
+            || std::env::var("CORA_PROVIDER").is_ok_and(|v| v == "ollama");
     }
     std::env::var(preset.env_key).is_ok()
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -202,7 +202,10 @@ mod tests {
     #[test]
     fn config_default_focus() {
         let cfg = Config::default();
-        assert_eq!(cfg.focus, vec!["security", "performance", "bugs", "best_practice"]);
+        assert_eq!(
+            cfg.focus,
+            vec!["security", "performance", "bugs", "best_practice"]
+        );
     }
 
     #[test]
@@ -382,10 +385,16 @@ output:
   color: false
 "#;
         let cora = CoraFile::from_str(yaml).unwrap();
-        assert_eq!(cora.provider.as_ref().unwrap().provider.as_deref(), Some("anthropic"));
+        assert_eq!(
+            cora.provider.as_ref().unwrap().provider.as_deref(),
+            Some("anthropic")
+        );
         assert_eq!(cora.focus.as_ref().unwrap().len(), 2);
         assert_eq!(cora.rules.as_ref().unwrap().len(), 1);
-        assert_eq!(cora.output.as_ref().unwrap().format.as_deref(), Some("json"));
+        assert_eq!(
+            cora.output.as_ref().unwrap().format.as_deref(),
+            Some("json")
+        );
         assert_eq!(cora.output.as_ref().unwrap().color, Some(false));
     }
 
@@ -426,7 +435,10 @@ output:
         };
         let yaml = serde_yaml::to_string(&cora).unwrap();
         let back: CoraFile = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(back.provider.as_ref().unwrap().provider.as_deref(), Some("ollama"));
+        assert_eq!(
+            back.provider.as_ref().unwrap().provider.as_deref(),
+            Some("ollama")
+        );
         assert_eq!(back.focus.as_ref().unwrap().len(), 1);
     }
 

--- a/src/engine/llm.rs
+++ b/src/engine/llm.rs
@@ -220,12 +220,7 @@ pub async fn review_diff_stream(
 ) -> Result<ReviewResponse> {
     let user_prompt = build_review_prompt(diff, focus, rules);
 
-    let raw = chat_completion_stream(
-        llm_config,
-        REVIEW_SYSTEM_PROMPT,
-        &user_prompt,
-    )
-    .await?;
+    let raw = chat_completion_stream(llm_config, REVIEW_SYSTEM_PROMPT, &user_prompt).await?;
 
     let (issues, summary, tokens_used) = parse_review_response(&raw)?;
 
@@ -248,8 +243,8 @@ async fn chat_completion_stream(
     system_prompt: &str,
     user_message: &str,
 ) -> Result<String> {
-    use std::io::Write;
     use futures_util::StreamExt;
+    use std::io::Write;
 
     let client = reqwest::Client::new();
     let url = format!("{}/chat/completions", config.base_url.trim_end_matches('/'));
@@ -420,7 +415,9 @@ fn build_review_prompt(diff: &str, focus: &[String], rules: &[String]) -> String
 
 /// Parse the LLM response into review issues.
 /// Handles: raw JSON array, JSON wrapped in ```json fences, array|||summary format.
-pub(crate) fn parse_review_response(raw: &str) -> Result<(Vec<ReviewIssue>, String, Option<TokenUsage>)> {
+pub(crate) fn parse_review_response(
+    raw: &str,
+) -> Result<(Vec<ReviewIssue>, String, Option<TokenUsage>)> {
     let (json_str, summary) = extract_json_and_summary(raw);
 
     // Strip markdown code fences if present

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -38,7 +38,11 @@ async fn review_diff_inner(
     diff: &str,
     stream: bool,
 ) -> Result<ReviewResponse> {
-    debug!(diff_len = diff.len(), stream = stream, "starting diff review");
+    debug!(
+        diff_len = diff.len(),
+        stream = stream,
+        "starting diff review"
+    );
 
     if diff.trim().is_empty() {
         return Ok(ReviewResponse {

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -206,7 +206,10 @@ mod tests {
 
     #[test]
     fn issue_type_performance() {
-        assert_eq!(IssueType::from_str_lossy("performance"), IssueType::Performance);
+        assert_eq!(
+            IssueType::from_str_lossy("performance"),
+            IssueType::Performance
+        );
     }
 
     #[test]
@@ -226,10 +229,22 @@ mod tests {
 
     #[test]
     fn issue_type_best_practice_variants() {
-        assert_eq!(IssueType::from_str_lossy("best_practice"), IssueType::BestPractice);
-        assert_eq!(IssueType::from_str_lossy("best-practice"), IssueType::BestPractice);
-        assert_eq!(IssueType::from_str_lossy("bestpractice"), IssueType::BestPractice);
-        assert_eq!(IssueType::from_str_lossy("best practice"), IssueType::BestPractice);
+        assert_eq!(
+            IssueType::from_str_lossy("best_practice"),
+            IssueType::BestPractice
+        );
+        assert_eq!(
+            IssueType::from_str_lossy("best-practice"),
+            IssueType::BestPractice
+        );
+        assert_eq!(
+            IssueType::from_str_lossy("bestpractice"),
+            IssueType::BestPractice
+        );
+        assert_eq!(
+            IssueType::from_str_lossy("best practice"),
+            IssueType::BestPractice
+        );
     }
 
     #[test]
@@ -244,7 +259,10 @@ mod tests {
 
     #[test]
     fn issue_type_suggestion() {
-        assert_eq!(IssueType::from_str_lossy("suggestion"), IssueType::Suggestion);
+        assert_eq!(
+            IssueType::from_str_lossy("suggestion"),
+            IssueType::Suggestion
+        );
     }
 
     #[test]
@@ -299,9 +317,6 @@ mod tests {
         assert_eq!(EXIT_ERROR, 1);
         assert_eq!(EXIT_BLOCKED, 2);
         assert_eq!(EXIT_AUTH_ERROR, 3);
-        assert!(EXIT_OK < EXIT_ERROR);
-        assert!(EXIT_ERROR < EXIT_BLOCKED);
-        assert!(EXIT_BLOCKED < EXIT_AUTH_ERROR);
     }
 
     // ─── Constants ───

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -54,29 +54,50 @@ mod tests {
 
     #[test]
     fn output_format_pretty() {
-        assert_eq!(OutputFormat::from_str_loose("pretty").unwrap(), OutputFormat::Pretty);
+        assert_eq!(
+            OutputFormat::from_str_loose("pretty").unwrap(),
+            OutputFormat::Pretty
+        );
     }
 
     #[test]
     fn output_format_json() {
-        assert_eq!(OutputFormat::from_str_loose("json").unwrap(), OutputFormat::Json);
+        assert_eq!(
+            OutputFormat::from_str_loose("json").unwrap(),
+            OutputFormat::Json
+        );
     }
 
     #[test]
     fn output_format_compact() {
-        assert_eq!(OutputFormat::from_str_loose("compact").unwrap(), OutputFormat::Compact);
+        assert_eq!(
+            OutputFormat::from_str_loose("compact").unwrap(),
+            OutputFormat::Compact
+        );
     }
 
     #[test]
     fn output_format_sarif() {
-        assert_eq!(OutputFormat::from_str_loose("sarif").unwrap(), OutputFormat::Sarif);
+        assert_eq!(
+            OutputFormat::from_str_loose("sarif").unwrap(),
+            OutputFormat::Sarif
+        );
     }
 
     #[test]
     fn output_format_case_insensitive() {
-        assert_eq!(OutputFormat::from_str_loose("JSON").unwrap(), OutputFormat::Json);
-        assert_eq!(OutputFormat::from_str_loose("Pretty").unwrap(), OutputFormat::Pretty);
-        assert_eq!(OutputFormat::from_str_loose("SARIF").unwrap(), OutputFormat::Sarif);
+        assert_eq!(
+            OutputFormat::from_str_loose("JSON").unwrap(),
+            OutputFormat::Json
+        );
+        assert_eq!(
+            OutputFormat::from_str_loose("Pretty").unwrap(),
+            OutputFormat::Pretty
+        );
+        assert_eq!(
+            OutputFormat::from_str_loose("SARIF").unwrap(),
+            OutputFormat::Sarif
+        );
     }
 
     #[test]

--- a/src/formatters/sarif.rs
+++ b/src/formatters/sarif.rs
@@ -196,7 +196,12 @@ mod tests {
         let fmt = SarifFormatter;
         let output = fmt.format_review(&sample_response()).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-        assert_eq!(parsed["runs"][0]["tool"]["driver"]["name"].as_str().unwrap(), "Cora");
+        assert_eq!(
+            parsed["runs"][0]["tool"]["driver"]["name"]
+                .as_str()
+                .unwrap(),
+            "Cora"
+        );
     }
 
     #[test]

--- a/tests/cli_basic.rs
+++ b/tests/cli_basic.rs
@@ -1,7 +1,7 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
 use std::io::Write;
+use std::process::Command;
 
 // Binary name matches the [[bin]] in Cargo.toml
 fn cora_cmd() -> Command {

--- a/tests/config_loading.rs
+++ b/tests/config_loading.rs
@@ -10,10 +10,7 @@ fn cora_cmd() -> Command {
 
 /// Helper: write content to a temp file and return its path.
 fn write_temp_yaml(content: &str) -> NamedTempFile {
-    let mut file = tempfile::Builder::new()
-        .suffix(".yaml")
-        .tempfile()
-        .unwrap();
+    let mut file = tempfile::Builder::new().suffix(".yaml").tempfile().unwrap();
     write!(file, "{}", content).unwrap();
     file.flush().unwrap();
     file
@@ -36,11 +33,14 @@ fn init_creates_valid_yaml() {
 
     // Verify the created file is valid YAML
     let content = std::fs::read_to_string(&config_path).unwrap();
-    let parsed: serde_yaml::Value = serde_yaml::from_str(&content)
-        .expect("init should create valid YAML");
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(&content).expect("init should create valid YAML");
 
     // Verify it has expected top-level keys
-    assert!(parsed.get("provider").is_some(), "should have provider section");
+    assert!(
+        parsed.get("provider").is_some(),
+        "should have provider section"
+    );
     assert!(parsed.get("focus").is_some(), "should have focus section");
     assert!(parsed.get("output").is_some(), "should have output section");
 }
@@ -63,14 +63,8 @@ output:
     let content = std::fs::read_to_string(file.path()).unwrap();
     let parsed: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
 
-    assert_eq!(
-        parsed["provider"]["provider"].as_str(),
-        Some("anthropic")
-    );
-    assert_eq!(
-        parsed["provider"]["model"].as_str(),
-        Some("claude-3-haiku")
-    );
+    assert_eq!(parsed["provider"]["provider"].as_str(), Some("anthropic"));
+    assert_eq!(parsed["provider"]["model"].as_str(), Some("claude-3-haiku"));
     assert_eq!(parsed["focus"].as_sequence().unwrap().len(), 1);
     assert_eq!(parsed["output"]["format"].as_str(), Some("json"));
 }
@@ -142,7 +136,12 @@ model: test-model
     // We can't run a full review without an API key, but we can verify
     // the --config flag is accepted
     cora_cmd()
-        .args(["--config", &file.path().to_string_lossy(), "review", "--help"])
+        .args([
+            "--config",
+            &file.path().to_string_lossy(),
+            "review",
+            "--help",
+        ])
         .assert()
         .success();
 }


### PR DESCRIPTION
Fix CI failures from PR #25:

- Remove useless `anyhow::Error` conversion in `scan.rs`
- Use `is_ok_and` instead of `map_or` in `providers.rs` (clippy suggestion)
- Remove constant-value assertions in `types.rs` (clippy: assertions_on_constants)
- Run `cargo fmt` to fix import ordering in `providers.rs`