### PR TITLE
feat: sticky header nav + spacing fixes + 4 docs pages

### DIFF
--- a/website/src/app.css
+++ b/website/src/app.css
@@ -724,3 +724,32 @@ body {
   height: 24px;
   color: var(--accent);
 }
+
+/* ---- Site Header ---- */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: oklch(0.13 0.01 270 / 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid oklch(0.27 0.01 270 / 0.5);
+}
+
+.site-header-link {
+  font-size: 14px;
+  color: var(--muted-foreground);
+  text-decoration: none;
+  transition: color 0.2s ease;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+}
+
+.site-header-link:hover {
+  color: var(--foreground);
+}
+
+.site-header-link.active {
+  color: var(--accent);
+}

--- a/website/src/app.html
+++ b/website/src/app.html
@@ -14,8 +14,8 @@
 		<meta property="og:title" content="cora — AI Code Review CLI" />
 		<meta property="og:description" content="CLI-first AI code review. BYOK, zero config, pre-commit hooks. Open source, MIT license." />
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://cora.nousresearch.com" />
-		<meta property="og:image" content="https://cora.nousresearch.com/og.png" />
+		<meta property="og:url" content="https://cora.ajianaz.com" />
+		<meta property="og:image" content="https://cora.ajianaz.com/og.png" />
 
 		<!-- Fonts -->
 		<link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,7 +1,34 @@
 <script lang="ts">
 	import '../app.css';
+	import { page } from '$app/stores';
 
 	let { children } = $props();
+
+	const isDocs = $derived($page.url.pathname.startsWith('/docs'));
 </script>
 
-{@render children()}
+<div style="background: var(--background); min-height: 100vh;">
+	<!-- Header -->
+	<header class="site-header">
+		<div class="max-w-6xl mx-auto px-6 flex items-center justify-between" style="height: 3.5rem;">
+			<a href="/" class="site-header-link" style="font-weight: 600; color: var(--foreground);">
+				cora
+			</a>
+
+			<nav class="hidden sm:flex items-center gap-6">
+				<a href="/docs" class="site-header-link" class:active={isDocs}>Docs</a>
+				<a href="https://github.com/ajianaz/cora-cli" target="_blank" rel="noopener" class="site-header-link">
+					GitHub
+				</a>
+			</nav>
+
+			<div class="hidden sm:block">
+				<a href="/docs/getting-started" class="btn-primary" style="font-size: 13px; padding: 0.375rem 0.875rem;">Get Started</a>
+			</div>
+		</div>
+	</header>
+
+	<main>
+		{@render children()}
+	</main>
+</div>

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -78,7 +78,7 @@
 <div style="background: var(--background);">
 
 	<!-- ====== S1 — HERO (TALL) ====== -->
-	<section class="relative flex items-center justify-center" style="min-height: 100vh; padding: 6rem 1.5rem 4rem;">
+	<section class="relative flex items-center justify-center" style="min-height: calc(100vh - 3.5rem); padding: 6rem 1.5rem 4rem;">
 		<!-- Subtle radial gradient glow -->
 		<div class="absolute inset-0 pointer-events-none" style="background: radial-gradient(ellipse 50% 40% at 50% 40%, oklch(0.65 0.22 270 / 0.04), transparent);"></div>
 
@@ -92,7 +92,7 @@
 			</div>
 
 			<!-- Headline -->
-			<h1 class="mt-8 mb-0 animate-fade-in-up delay-100" style="font-size: clamp(3rem, 6vw, 4.5rem); font-weight: 700; letter-spacing: -0.035em; color: var(--foreground); line-height: 1.05;">
+			<h1 class="mt-6 mb-0 animate-fade-in-up delay-100" style="font-size: clamp(3rem, 6vw, 4.5rem); font-weight: 700; letter-spacing: -0.035em; color: var(--foreground); line-height: 1.1;">
 				Review code.<br />
 				<span style="background: linear-gradient(135deg, oklch(0.65 0.22 270), oklch(0.7 0.15 240)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">Ship faster.</span>
 			</h1>
@@ -133,7 +133,7 @@
 					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
 					Get Started
 				</a>
-				<a href="https://github.com/nousresearch/cora-cli" target="_blank" rel="noopener" class="btn-ghost">
+				<a href="https://github.com/ajianaz/cora-cli" target="_blank" rel="noopener" class="btn-ghost">
 					<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
 					View on GitHub
 				</a>
@@ -151,20 +151,20 @@
 		<p class="text-center mb-8 scroll-reveal" style="font-size: 12px; font-weight: 500; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.08em;">
 			Trusted by developers who ship fast
 		</p>
-		<div class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl mx-auto">
-			<div class="glass-card text-center scroll-reveal" style="padding-top: 2rem; padding-bottom: 2rem;">
-				<div style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">5</div>
-				<div style="font-size: 14px; color: var(--muted-foreground); margin-top: 0.5rem;">AI Providers</div>
-			</div>
-			<div class="glass-card text-center scroll-reveal" style="padding-top: 2rem; padding-bottom: 2rem; transition-delay: 100ms;">
-				<div style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">&lt; 3s</div>
-				<div style="font-size: 14px; color: var(--muted-foreground); margin-top: 0.5rem;">Review Time</div>
-			</div>
-			<div class="glass-card text-center scroll-reveal" style="padding-top: 2rem; padding-bottom: 2rem; transition-delay: 200ms;">
-				<div style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">Zero</div>
-				<div style="font-size: 14px; color: var(--muted-foreground); margin-top: 0.5rem;">Config Required</div>
-			</div>
+	<div class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl mx-auto">
+		<div class="glass-card text-center scroll-reveal py-8">
+			<div style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">5</div>
+			<div style="font-size: 14px; color: var(--muted-foreground); margin-top: 0.5rem;">AI Providers</div>
 		</div>
+		<div class="glass-card text-center scroll-reveal py-8" style="transition-delay: 100ms;">
+			<div style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">&lt; 3s</div>
+			<div style="font-size: 14px; color: var(--muted-foreground); margin-top: 0.5rem;">Review Time</div>
+		</div>
+		<div class="glass-card text-center scroll-reveal py-8" style="transition-delay: 200ms;">
+			<div style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">Zero</div>
+			<div style="font-size: 14px; color: var(--muted-foreground); margin-top: 0.5rem;">Config Required</div>
+		</div>
+	</div>
 	</section>
 
 	<!-- ====== S3 — LIVE TERMINAL DEMO (TALL) ====== -->
@@ -172,11 +172,11 @@
 		<h2 class="text-center scroll-reveal" style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">
 			See it in action
 		</h2>
-		<p class="text-center mt-3 scroll-reveal" style="color: var(--muted-foreground); max-width: 32rem; margin-left: auto; margin-right: auto; font-size: 14px;">
-			Run cora against staged changes. Results in seconds, not minutes.
-		</p>
+	<p class="text-center mt-4 scroll-reveal" style="color: var(--muted-foreground); max-width: 32rem; margin-left: auto; margin-right: auto; font-size: 14px;">
+		Run cora against staged changes. Results in seconds, not minutes.
+	</p>
 
-		<div class="max-w-2xl mx-auto mt-10 scroll-reveal">
+	<div class="max-w-2xl mx-auto mt-8 scroll-reveal">
 			<div class="terminal">
 				<div class="terminal-header">
 					<span class="terminal-dot terminal-dot-red"></span>
@@ -201,14 +201,14 @@
 		<h2 class="text-center scroll-reveal" style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">
 			How it works
 		</h2>
-		<p class="text-center mt-3 scroll-reveal" style="color: var(--muted-foreground); max-width: 32rem; margin-left: auto; margin-right: auto; font-size: 14px;">
-			Three steps from code to confidence.
-		</p>
+	<p class="text-center mt-4 scroll-reveal" style="color: var(--muted-foreground); max-width: 32rem; margin-left: auto; margin-right: auto; font-size: 14px;">
+		Three steps from code to confidence.
+	</p>
 
 		<div class="flex flex-col md:flex-row items-stretch mt-10" style="gap: 1.5rem;">
 			<!-- Step 1 -->
 			<div class="glass-card flex-1 text-center scroll-reveal">
-				<div style="font-size: 24px; font-weight: 700; color: var(--accent); letter-spacing: -0.02em; font-family: var(--font-mono); opacity: 0.4;">01</div>
+				<div style="font-size: 24px; font-weight: 700; color: var(--accent); letter-spacing: -0.02em; font-family: var(--font-mono); opacity: 0.5;">01</div>
 				<div class="flex justify-center mt-4">
 					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
 				</div>
@@ -223,7 +223,7 @@
 
 			<!-- Step 2 -->
 			<div class="glass-card flex-1 text-center scroll-reveal" style="transition-delay: 100ms;">
-				<div style="font-size: 24px; font-weight: 700; color: var(--accent); letter-spacing: -0.02em; font-family: var(--font-mono); opacity: 0.4;">02</div>
+				<div style="font-size: 24px; font-weight: 700; color: var(--accent); letter-spacing: -0.02em; font-family: var(--font-mono); opacity: 0.5;">02</div>
 				<div class="flex justify-center mt-4">
 					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
 				</div>
@@ -238,7 +238,7 @@
 
 			<!-- Step 3 -->
 			<div class="glass-card flex-1 text-center scroll-reveal" style="transition-delay: 200ms;">
-				<div style="font-size: 24px; font-weight: 700; color: var(--accent); letter-spacing: -0.02em; font-family: var(--font-mono); opacity: 0.4;">03</div>
+				<div style="font-size: 24px; font-weight: 700; color: var(--accent); letter-spacing: -0.02em; font-family: var(--font-mono); opacity: 0.5;">03</div>
 				<div class="flex justify-center mt-4">
 					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
 				</div>
@@ -253,18 +253,18 @@
 		<h2 class="text-center scroll-reveal" style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">
 			Built for developers who value control
 		</h2>
-		<p class="text-center mt-3 scroll-reveal" style="color: var(--muted-foreground); font-size: 14px;">
-			Everything you need, nothing you don't.
-		</p>
+	<p class="text-center mt-4 scroll-reveal" style="color: var(--muted-foreground); font-size: 14px;">
+		Everything you need, nothing you don't.
+	</p>
 
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-10">
+	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-10">
 			<!-- Feature 1: AI Code Review -->
 			<div class="glass-card scroll-reveal">
 				<div class="feature-icon">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><path d="M11 8v6"/><path d="M8 11h6"/></svg>
 				</div>
-				<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">AI Code Review</h3>
-				<p class="mt-1" style="font-size: 14px; color: var(--accent);">Diff, branch, or full scan</p>
+			<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">AI Code Review</h3>
+			<p class="mt-3" style="font-size: 14px; color: var(--accent);">Diff, branch, or full scan</p>
 				<p class="mt-3" style="font-size: 14px; color: var(--muted-foreground); line-height: 1.5;">Three review modes: staged diff, branch comparison, or full project scan. LLM-powered analysis catches bugs, security issues, and style violations.</p>
 			</div>
 
@@ -273,8 +273,8 @@
 				<div class="feature-icon">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 11-7.778 7.778 5.5 5.5 0 017.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
 				</div>
-				<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Bring Your Own Key</h3>
-				<p class="mt-1" style="font-size: 14px; color: var(--accent);">No subscriptions, no lock-in</p>
+			<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Bring Your Own Key</h3>
+			<p class="mt-3" style="font-size: 14px; color: var(--accent);">No subscriptions, no lock-in</p>
 				<p class="mt-3" style="font-size: 14px; color: var(--muted-foreground); line-height: 1.5;">Uses YOUR OpenAI, Anthropic, Groq, Ollama, or Z.AI API key. No data stored on our servers. You control the model, you control the cost.</p>
 			</div>
 
@@ -283,8 +283,8 @@
 				<div class="feature-icon">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22V8"/><path d="M5 12H2a10 10 0 0020 0h-3"/><circle cx="12" cy="5" r="3"/></svg>
 				</div>
-				<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Pre-commit Hooks</h3>
-				<p class="mt-1" style="font-size: 14px; color: var(--accent);">Review before you push</p>
+			<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Pre-commit Hooks</h3>
+			<p class="mt-3" style="font-size: 14px; color: var(--accent);">Review before you push</p>
 				<p class="mt-3" style="font-size: 14px; color: var(--muted-foreground); line-height: 1.5;">Install once. Every commit gets reviewed automatically. Block bad code from entering your branch before it ships.</p>
 			</div>
 
@@ -293,8 +293,8 @@
 				<div class="feature-icon">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
 				</div>
-				<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Incremental Scan</h3>
-				<p class="mt-1" style="font-size: 14px; color: var(--accent);">Only scan what changed</p>
+			<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Incremental Scan</h3>
+			<p class="mt-3" style="font-size: 14px; color: var(--accent);">Only scan what changed</p>
 				<p class="mt-3" style="font-size: 14px; color: var(--muted-foreground); line-height: 1.5;">SHA256 content hash cache. First scan indexes your codebase. Subsequent scans only review new or modified files.</p>
 			</div>
 
@@ -303,8 +303,8 @@
 				<div class="feature-icon">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
 				</div>
-				<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">SARIF Output</h3>
-				<p class="mt-1" style="font-size: 14px; color: var(--accent);">GitHub Code Scanning</p>
+			<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">SARIF Output</h3>
+			<p class="mt-3" style="font-size: 14px; color: var(--accent);">GitHub Code Scanning</p>
 				<p class="mt-3" style="font-size: 14px; color: var(--muted-foreground); line-height: 1.5;">Upload review findings directly to GitHub's Security tab. Track issues across PRs. Works with any CI/CD pipeline.</p>
 			</div>
 
@@ -313,8 +313,8 @@
 				<div class="feature-icon">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/><circle cx="12" cy="16" r="1"/></svg>
 				</div>
-				<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Fully Private</h3>
-				<p class="mt-1" style="font-size: 14px; color: var(--accent);">Your code stays yours</p>
+			<h3 class="mt-4" style="font-size: 18px; font-weight: 600; color: var(--foreground);">Fully Private</h3>
+			<p class="mt-3" style="font-size: 14px; color: var(--accent);">Your code stays yours</p>
 				<p class="mt-3" style="font-size: 14px; color: var(--muted-foreground); line-height: 1.5;">Runs entirely on your machine. No cloud, no telemetry, no data leaving your network. Perfect for Gitea and air-gapped environments.</p>
 			</div>
 		</div>
@@ -325,9 +325,9 @@
 		<h2 class="text-center scroll-reveal" style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">
 			Why developers choose cora
 		</h2>
-		<p class="text-center mt-3 scroll-reveal" style="color: var(--muted-foreground); font-size: 14px;">
-			Side-by-side with popular code review tools.
-		</p>
+	<p class="text-center mt-4 scroll-reveal" style="color: var(--muted-foreground); font-size: 14px;">
+		Side-by-side with popular code review tools.
+	</p>
 
 		<div class="glass-card scroll-reveal mt-10" style="padding: 0; max-width: 56rem; margin-left: auto; margin-right: auto; overflow: hidden;">
 			<div style="overflow-x: auto;">
@@ -409,9 +409,9 @@
 		<h2 class="text-center scroll-reveal" style="font-size: 32px; font-weight: 700; color: var(--foreground); letter-spacing: -0.025em; line-height: 1.2;">
 			Start in 30 seconds
 		</h2>
-		<p class="text-center mt-3 scroll-reveal" style="color: var(--muted-foreground); font-size: 14px;">
-			No account required. No subscription. No cloud.
-		</p>
+	<p class="text-center mt-4 scroll-reveal" style="color: var(--muted-foreground); font-size: 14px;">
+		No account required. No subscription. No cloud.
+	</p>
 
 		<div class="flex flex-col mt-10" style="max-width: 40rem; margin-left: auto; margin-right: auto; gap: 1.5rem;">
 			<!-- Step 1 -->
@@ -420,16 +420,16 @@
 				<div>
 					<h3 style="font-size: 18px; font-weight: 600; color: var(--foreground); letter-spacing: -0.01em; line-height: 1.35;">Install</h3>
 					<p class="mt-1 mb-4" style="font-size: 14px; color: var(--muted-foreground);">Single binary, no dependencies.</p>
-					<div class="terminal" style="font-size: 13px;">
-						<div class="terminal-header">
-							<span class="terminal-dot terminal-dot-red"></span>
-							<span class="terminal-dot terminal-dot-yellow"></span>
-							<span class="terminal-dot terminal-dot-green"></span>
-						</div>
-						<div class="terminal-body" style="padding: 0.75rem 1rem; font-size: 13px;">
-							<span class="syntax-cmd">$</span> <span class="syntax-highlight">cargo install</span> <span class="syntax-string">cora</span>
-						</div>
+				<div class="terminal">
+					<div class="terminal-header">
+						<span class="terminal-dot terminal-dot-red"></span>
+						<span class="terminal-dot terminal-dot-yellow"></span>
+						<span class="terminal-dot terminal-dot-green"></span>
 					</div>
+					<div class="terminal-body" style="padding: 0.75rem 1rem;">
+						<span class="syntax-cmd">$</span> <span class="syntax-highlight">cargo install</span> <span class="syntax-string">cora</span>
+					</div>
+				</div>
 				</div>
 			</div>
 
@@ -439,16 +439,16 @@
 				<div>
 					<h3 style="font-size: 18px; font-weight: 600; color: var(--foreground); letter-spacing: -0.01em; line-height: 1.35;">Initialize</h3>
 					<p class="mt-1 mb-4" style="font-size: 14px; color: var(--muted-foreground);">Creates <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">.cora.yaml</code> config file.</p>
-					<div class="terminal" style="font-size: 13px;">
-						<div class="terminal-header">
-							<span class="terminal-dot terminal-dot-red"></span>
-							<span class="terminal-dot terminal-dot-yellow"></span>
-							<span class="terminal-dot terminal-dot-green"></span>
-						</div>
-						<div class="terminal-body" style="padding: 0.75rem 1rem; font-size: 13px;">
-							<span class="syntax-cmd">$</span> <span class="syntax-highlight">cora init</span>
-						</div>
+				<div class="terminal">
+					<div class="terminal-header">
+						<span class="terminal-dot terminal-dot-red"></span>
+						<span class="terminal-dot terminal-dot-yellow"></span>
+						<span class="terminal-dot terminal-dot-green"></span>
 					</div>
+					<div class="terminal-body" style="padding: 0.75rem 1rem;">
+						<span class="syntax-cmd">$</span> <span class="syntax-highlight">cora init</span>
+					</div>
+				</div>
 				</div>
 			</div>
 
@@ -458,13 +458,13 @@
 				<div>
 					<h3 style="font-size: 18px; font-weight: 600; color: var(--foreground); letter-spacing: -0.01em; line-height: 1.35;">Review</h3>
 					<p class="mt-1 mb-4" style="font-size: 14px; color: var(--muted-foreground);">Review your staged changes.</p>
-					<div class="terminal" style="font-size: 13px;">
-						<div class="terminal-header">
+				<div class="terminal">
+					<div class="terminal-header">
 							<span class="terminal-dot terminal-dot-red"></span>
 							<span class="terminal-dot terminal-dot-yellow"></span>
 							<span class="terminal-dot terminal-dot-green"></span>
 						</div>
-						<div class="terminal-body" style="padding: 0.75rem 1rem; font-size: 13px;">
+						<div class="terminal-body" style="padding: 0.75rem 1rem;">
 							<span class="syntax-cmd">$</span> <span class="syntax-flag">CORA_API_KEY</span>=<span class="syntax-string">key</span> <span class="syntax-highlight">cora review</span> <span class="syntax-flag">--staged</span>
 						</div>
 					</div>
@@ -494,7 +494,7 @@
 					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
 					Get Started
 				</a>
-				<a href="https://github.com/nousresearch/cora-cli" target="_blank" rel="noopener" class="btn-ghost">
+				<a href="https://github.com/ajianaz/cora-cli" target="_blank" rel="noopener" class="btn-ghost">
 					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
 					Star on GitHub
 				</a>
@@ -502,14 +502,14 @@
 		</div>
 
 		<!-- Footer -->
-		<footer style="border-top: 1px solid var(--border); margin-top: 6rem; padding: 2rem 1.5rem;">
+		<footer style="border-top: 1px solid var(--border); margin-top: 4rem; padding: 2rem 1.5rem;">
 			<div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
 				<div>
 					<span style="font-size: 14px; font-weight: 600; color: var(--foreground);">cora</span>
 					<span style="font-size: 12px; color: var(--muted-foreground); margin-left: 0.75rem;">MIT License</span>
 				</div>
 				<div class="flex items-center gap-6">
-					<a href="https://github.com/nousresearch/cora-cli" target="_blank" rel="noopener" style="font-size: 14px; color: var(--muted-foreground); text-decoration: none; transition: color 0.2s ease;">GitHub</a>
+					<a href="https://github.com/ajianaz/cora-cli" target="_blank" rel="noopener" style="font-size: 14px; color: var(--muted-foreground); text-decoration: none; transition: color 0.2s ease;">GitHub</a>
 					<a href="/docs" style="font-size: 14px; color: var(--muted-foreground); text-decoration: none; transition: color 0.2s ease;">Docs</a>
 				</div>
 			</div>

--- a/website/src/routes/docs/+layout.svelte
+++ b/website/src/routes/docs/+layout.svelte
@@ -4,10 +4,14 @@
 	let { children } = $props();
 
 	const navLinks = [
-		{ href: '/docs/cli-reference', label: 'CLI Reference' },
+		{ href: '/docs/getting-started', label: 'Getting Started' },
+		{ href: '/docs/installation', label: 'Installation' },
+		{ href: '/docs/usage', label: 'Usage' },
 		{ href: '/docs/configuration', label: 'Configuration' },
 		{ href: '/docs/providers', label: 'Providers' },
-		{ href: '/docs/examples', label: 'Examples' }
+		{ href: '/docs/self-hosted', label: 'Self-Hosted' },
+		{ href: '/docs/examples', label: 'Examples' },
+		{ href: '/docs/cli-reference', label: 'CLI Reference' },
 	];
 </script>
 

--- a/website/src/routes/docs/getting-started/+page.svelte
+++ b/website/src/routes/docs/getting-started/+page.svelte
@@ -1,0 +1,154 @@
+<svelte:head>
+	<title>Getting Started — cora docs</title>
+</svelte:head>
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	onMount(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						entry.target.classList.add('revealed');
+						observer.unobserve(entry.target);
+					}
+				});
+			},
+			{ threshold: 0.1 }
+		);
+		document.querySelectorAll('.scroll-reveal').forEach((el) => observer.observe(el));
+	});
+</script>
+
+<h1 style="font-size: 28px; font-weight: 700; color: var(--foreground); letter-spacing: -0.02em; line-height: 1.2; margin-bottom: 1.5rem;">
+	Getting Started
+</h1>
+
+<div class="docs-section scroll-reveal">
+	<h2>Quick Start</h2>
+	<p>Get up and running with cora in four simple steps.</p>
+
+	<div class="docs-card">
+		<div class="docs-card-number primary">1</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<strong style="color: var(--foreground);">Install cora</strong> — Single binary via Cargo:
+			<code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">cargo install cora</code>
+		</div>
+	</div>
+
+	<div class="docs-card">
+		<div class="docs-card-number primary">2</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<strong style="color: var(--foreground);">Configure</strong> — Initialize your project:
+			<code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">cora init</code> creates <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">.cora.yaml</code>
+		</div>
+	</div>
+
+	<div class="docs-card">
+		<div class="docs-card-number primary">3</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<strong style="color: var(--foreground);">Add API key</strong> — Run <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">cora auth login</code> or set <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">CORA_API_KEY</code> environment variable
+		</div>
+	</div>
+
+	<div class="docs-card">
+		<div class="docs-card-number primary">4</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<strong style="color: var(--foreground);">Review</strong> — Analyze your staged changes:
+			<code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">cora review --staged</code>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Understanding the Output</h2>
+	<p>cora outputs a structured, color-coded summary of findings for each file reviewed.</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--staged</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);">Analyzing 3 files...</span></div>
+			<div><span style="color: var(--success);">&#10003;</span> src/auth/login.ts <span style="color: var(--muted-foreground);">— 2 issues found</span></div>
+			<div>  <span style="color: var(--warning);">&#9888;</span> <span style="color: var(--muted-foreground);">Line 42:</span> Potential SQL injection</div>
+			<div>  <span style="color: var(--warning);">&#9888;</span> <span style="color: var(--muted-foreground);">Line 87:</span> Hardcoded secret</div>
+			<div><span style="color: var(--success);">&#10003;</span> src/utils/parser.ts <span style="color: var(--muted-foreground);">— clean</span></div>
+			<div><span style="color: var(--success);">&#10003;</span> src/api/routes.ts <span style="color: var(--muted-foreground);">— 1 issue found</span></div>
+			<div>  <span style="color: var(--destructive);">&#10007;</span> <span style="color: var(--muted-foreground);">Line 23:</span> Missing error handling</div>
+			<div></div>
+			<div>3 issues found in 3 files</div>
+		</div>
+	</div>
+
+	<p>Each line in the output contains:</p>
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent); font-family: var(--font-mono);">file path</span>
+			<span>The relative path to the file being reviewed</span>
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent); font-family: var(--font-mono);">line number</span>
+			<span>Specific line where the issue was found</span>
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent); font-family: var(--font-mono);">severity</span>
+			<span>Suggestion (&#9888;), Warning (&#9888;), or Error (&#10007;)</span>
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent); font-family: var(--font-mono);">description</span>
+			<span>Brief explanation of the issue</span>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Customizing Your Review</h2>
+	<p>The <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">.cora.yaml</code> file controls how cora reviews your code.</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># .cora.yaml</span></div>
+			<div><span style="color: var(--accent);">provider</span>: <span style="color: var(--success);">openai</span></div>
+			<div><span style="color: var(--accent);">model</span>: <span style="color: var(--success);">gpt-4o</span></div>
+			<div></div>
+			<div><span style="color: var(--accent);">custom_prompt</span>: <span style="color: var(--success);">|</span></div>
+			<div><span style="color: var(--success);">  Focus on security vulnerabilities and</span></div>
+			<div><span style="color: var(--success);">  performance issues. Ignore style linting.</span></div>
+		</div>
+	</div>
+
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-family: var(--font-mono);">provider</span> — Which LLM provider to use (openai, anthropic, groq, ollama, zai)
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-family: var(--font-mono);">model</span> — Specific model name (e.g., gpt-4o, claude-sonnet-4-20250514)
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-family: var(--font-mono);">custom_prompt</span> — Override the default review prompt to focus on specific concerns
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Next Steps</h2>
+	<p>Now that you have cora running, explore these topics to get the most out of it:</p>
+	<div style="display: flex; flex-direction: column; gap: 0.5rem;">
+		<a href="/docs/installation" style="font-size: 14px; color: var(--accent); text-decoration: none;">Installation — install options and shell completions</a>
+		<a href="/docs/usage" style="font-size: 14px; color: var(--accent); text-decoration: none;">Usage — review modes, output formats, and configuration</a>
+		<a href="/docs/configuration" style="font-size: 14px; color: var(--accent); text-decoration: none;">Configuration — full .cora.yaml reference</a>
+		<a href="/docs/providers" style="font-size: 14px; color: var(--accent); text-decoration: none;">Providers — setting up OpenAI, Anthropic, Groq, Ollama, and Z.AI</a>
+		<a href="/docs/self-hosted" style="font-size: 14px; color: var(--accent); text-decoration: none;">Self-Hosted — running cora with local LLMs and air-gapped environments</a>
+	</div>
+</div>

--- a/website/src/routes/docs/installation/+page.svelte
+++ b/website/src/routes/docs/installation/+page.svelte
@@ -1,0 +1,165 @@
+<svelte:head>
+	<title>Installation — cora docs</title>
+</svelte:head>
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	onMount(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						entry.target.classList.add('revealed');
+						observer.unobserve(entry.target);
+					}
+				});
+			},
+			{ threshold: 0.1 }
+		);
+		document.querySelectorAll('.scroll-reveal').forEach((el) => observer.observe(el));
+	});
+</script>
+
+<h1 style="font-size: 28px; font-weight: 700; color: var(--foreground); letter-spacing: -0.02em; line-height: 1.2; margin-bottom: 1.5rem;">
+	Installation
+</h1>
+
+<div class="docs-section scroll-reveal">
+	<h2>Prerequisites</h2>
+	<p>cora is a Rust binary. You have two installation paths:</p>
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-weight: 600;">Via Cargo (recommended)</span> — Requires Rust 1.70 or later with Cargo installed
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-weight: 600;">Binary download</span> — No Rust required; just download and place in your PATH
+		</div>
+	</div>
+	<p>cora works on Linux (x86_64 and arm64), macOS (arm64), and Windows.</p>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Install via Cargo</h2>
+	<p>The recommended way to install cora is through Cargo:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cargo install</span> <span style="color: var(--success);">cora</span></div>
+		</div>
+	</div>
+
+	<p>This compiles cora from source and installs it to Cargo's binary directory (typically <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">~/.cargo/bin/</code>).</p>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Download Binary</h2>
+	<p>Pre-built binaries are available from the <a href="https://github.com/ajianaz/cora-cli/releases" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: none;">GitHub Releases</a> page.</p>
+
+	<div style="font-size: 14px; color: var(--muted-foreground); margin-bottom: 1rem;">
+		<p>Supported platforms:</p>
+		<div style="display: flex; flex-direction: column; gap: 0.25rem; margin-top: 0.5rem;">
+			<div>Linux x86_64 (glibc)</div>
+			<div>Linux arm64 (aarch64)</div>
+			<div>macOS arm64 (Apple Silicon)</div>
+			<div>Windows x86_64</div>
+		</div>
+	</div>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># Download and extract</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">curl</span> -sL https://github.com/ajianaz/cora-cli/releases/latest/download/cora-linux-x86_64.tar.gz | <span style="color: var(--accent);">tar</span> xz</div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">mv</span> cora ~/.local/bin/cora</div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Build from Source</h2>
+	<p>If you prefer to build from the latest source:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">git clone</span> <span style="color: var(--success);">https://github.com/ajianaz/cora-cli.git</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cd</span> cora-cli</div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cargo build</span> <span style="color: oklch(0.75 0.15 240);">--release</span></div>
+			<div><span style="color: var(--muted-foreground);"># Binary at target/release/cora</span></div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Shell Completions</h2>
+	<p>cora provides shell completions for bash, zsh, and fish:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># Bash</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora completion</span> <span style="color: var(--success);">bash</span> > ~/.cora/completion.bash</div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">echo</span> <span style="color: var(--success);">'source ~/.cora/completion.bash'</span> >> ~/.bashrc</div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Zsh</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora completion</span> <span style="color: var(--success);">zsh</span> > ~/.cora/completion.zsh</div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">echo</span> <span style="color: var(--success);">'source ~/.cora/completion.zsh'</span> >> ~/.zshrc</div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Fish</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora completion</span> <span style="color: var(--success);">fish</span> > ~/.config/fish/completions/cora.fish</div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Verify Installation</h2>
+	<p>Confirm cora is installed correctly:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora</span> <span style="color: oklch(0.75 0.15 240);">--version</span></div>
+			<div><span style="color: var(--success);">cora 0.x.x</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora auth</span> <span style="color: var(--success);">status</span></div>
+			<div><span style="color: var(--success);">Provider: openai</span></div>
+			<div><span style="color: var(--success);">API key: configured</span></div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Updating</h2>
+	<p>To update cora to the latest version:</p>
+
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-weight: 600;">Via Cargo:</span> <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">cargo install cora --force</code>
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-weight: 600;">Via Binary:</span> Download the latest release from GitHub and replace the existing binary
+		</div>
+	</div>
+</div>

--- a/website/src/routes/docs/self-hosted/+page.svelte
+++ b/website/src/routes/docs/self-hosted/+page.svelte
@@ -1,0 +1,217 @@
+<svelte:head>
+	<title>Self-Hosted — cora docs</title>
+</svelte:head>
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	onMount(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						entry.target.classList.add('revealed');
+						observer.unobserve(entry.target);
+					}
+				});
+			},
+			{ threshold: 0.1 }
+		);
+		document.querySelectorAll('.scroll-reveal').forEach((el) => observer.observe(el));
+	});
+</script>
+
+<h1 style="font-size: 28px; font-weight: 700; color: var(--foreground); letter-spacing: -0.02em; line-height: 1.2; margin-bottom: 1.5rem;">
+	Self-Hosted
+</h1>
+
+<div class="docs-section scroll-reveal">
+	<h2>Why Self-Hosted?</h2>
+	<p>cora is designed to run entirely on your infrastructure. Self-hosting gives you:</p>
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">Privacy</span> — Your code never leaves your network
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">Compliance</span> — Meet regulatory requirements for code review in sensitive environments
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">Air-gapped</span> — Works in fully offline environments with local LLMs
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">No vendor lock-in</span> — Switch providers or models at any time
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Using Ollama (Local LLM)</h2>
+	<p>Ollama lets you run LLMs locally. cora works with any Ollama model that supports chat completions.</p>
+
+	<div class="docs-card" style="margin-top: 1rem; margin-bottom: 0.5rem;">
+		<div class="docs-card-number primary">1</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<strong style="color: var(--foreground);">Install Ollama</strong> — Follow the instructions at <a href="https://ollama.ai" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: none;">ollama.ai</a>
+		</div>
+	</div>
+
+	<div class="docs-card" style="margin-bottom: 0.5rem;">
+		<div class="docs-card-number primary">2</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<strong style="color: var(--foreground);">Pull a model</strong> — For code review, use <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">ollama pull codellama</code>
+		</div>
+	</div>
+
+	<div class="docs-card" style="margin-bottom: 0.5rem;">
+		<div class="docs-card-number primary">3</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<strong style="color: var(--foreground);">Configure cora</strong> — Point cora to your local Ollama instance
+		</div>
+	</div>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># Start Ollama</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">ollama serve</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Pull a code-focused model</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">ollama pull</span> <span style="color: var(--success);">codellama</span></div>
+		</div>
+	</div>
+
+	<p style="margin-top: 1rem;">Configure cora to use Ollama via environment variables:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: oklch(0.75 0.15 240);">CORA_PROVIDER</span>=<span style="color: var(--success);">ollama</span> <span style="color: oklch(0.75 0.15 240);">CORA_BASE_URL</span>=<span style="color: var(--success);">http://localhost:11434/v1</span> <span style="color: oklch(0.75 0.15 240);">CORA_MODEL</span>=<span style="color: var(--success);">codellama</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--staged</span></div>
+		</div>
+	</div>
+
+	<p style="margin-top: 1rem;">Or persist the configuration in <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">.cora.yaml</code>:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># .cora.yaml</span></div>
+			<div><span style="color: var(--accent);">provider</span>: <span style="color: var(--success);">ollama</span></div>
+			<div><span style="color: var(--accent);">base_url</span>: <span style="color: var(--success);">http://localhost:11434/v1</span></div>
+			<div><span style="color: var(--accent);">model</span>: <span style="color: var(--success);">codellama</span></div>
+		</div>
+	</div>
+
+	<p style="margin-top: 1rem;">To authenticate with Ollama (no API key needed for local use):</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora auth login</span> <span style="color: oklch(0.75 0.15 240);">--provider</span> <span style="color: var(--success);">ollama</span> <span style="color: oklch(0.75 0.15 240);">--base-url</span> <span style="color: var(--success);">http://localhost:11434/v1</span></div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Using with Gitea</h2>
+	<p>cora works seamlessly with Gitea repositories. Since cora reads your local git state directly, no Gitea integration or plugin is needed:</p>
+
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			cora reads <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">git diff</code> output — it works with any git remote (GitHub, Gitea, GitLab, Bitbucket)
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			No API tokens, webhooks, or server-side configuration required
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Works with Gitea's CI/CD pipelines — just add <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">cora review --branch main</code> as a pipeline step
+		</div>
+	</div>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># Clone your Gitea repo and review</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">git clone</span> <span style="color: var(--success);">gitea.example.com/org/repo.git</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cd</span> repo</div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora init</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--staged</span></div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Network Isolation</h2>
+	<p>For fully offline or air-gapped environments:</p>
+
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Download the cora binary and transfer it to the isolated machine
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Run Ollama on the same machine with a locally-pulled model
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Configure cora to use <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">http://localhost:11434/v1</code> as the base URL
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			No outbound network connections are made — everything stays on the local machine
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>No Telemetry</h2>
+	<p>cora is designed with privacy as a core principle:</p>
+
+	<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">Zero data collection</span> — cora does not send any data to any server
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">No analytics</span> — No usage tracking, no metrics, no phone home
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">Local execution</span> — Everything runs on your machine
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			<span style="color: var(--foreground); font-weight: 500;">The only network traffic</span> — API calls to your configured LLM provider (which you control)
+		</div>
+	</div>
+
+	<p style="margin-top: 1rem;">You can verify this by inspecting the source code at <a href="https://github.com/ajianaz/cora-cli" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: none;">github.com/ajianaz/cora-cli</a>. The codebase is open source under the MIT license.</p>
+</div>

--- a/website/src/routes/docs/usage/+page.svelte
+++ b/website/src/routes/docs/usage/+page.svelte
@@ -1,0 +1,309 @@
+<svelte:head>
+	<title>Usage — cora docs</title>
+</svelte:head>
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	onMount(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						entry.target.classList.add('revealed');
+						observer.unobserve(entry.target);
+					}
+				});
+			},
+			{ threshold: 0.1 }
+		);
+		document.querySelectorAll('.scroll-reveal').forEach((el) => observer.observe(el));
+	});
+</script>
+
+<h1 style="font-size: 28px; font-weight: 700; color: var(--foreground); letter-spacing: -0.02em; line-height: 1.2; margin-bottom: 1.5rem;">
+	Usage
+</h1>
+
+<div class="docs-section scroll-reveal">
+	<h2>Review Modes</h2>
+	<p>cora supports four review modes, each suited to a different workflow:</p>
+
+	<div style="overflow-x: auto;">
+		<table class="compare-table">
+			<thead>
+				<tr>
+					<th>Mode</th>
+					<th>Flag</th>
+					<th>Scope</th>
+					<th>Best For</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td style="font-weight: 500;">Staged</td>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--staged</code></td>
+					<td>Files in git staging area</td>
+					<td>Pre-commit review</td>
+				</tr>
+				<tr>
+					<td style="font-weight: 500;">Branch</td>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--branch</code></td>
+					<td>Diff against base branch</td>
+					<td>PR review workflow</td>
+				</tr>
+				<tr>
+					<td style="font-weight: 500;">Full</td>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--full</code></td>
+					<td>Entire repository</td>
+					<td>Comprehensive audit</td>
+				</tr>
+				<tr>
+					<td style="font-weight: 500;">Incremental</td>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--incremental</code></td>
+					<td>Only new/changed files</td>
+					<td>Large codebases</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># Review staged changes</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--staged</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Review against main branch</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--branch</span> <span style="color: var(--success);">main</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Full project scan</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--full</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Incremental (only changed files)</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--incremental</span></div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Output Formats</h2>
+	<p>cora can output results in three formats:</p>
+
+	<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-weight: 600; font-family: var(--font-mono);">--format pretty</span> — Human-readable terminal output (default)
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-weight: 600; font-family: var(--font-mono);">--format json</span> — Machine-readable JSON for CI/CD pipelines
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground);">
+			<span style="color: var(--accent); font-weight: 600; font-family: var(--font-mono);">--format sarif</span> — SARIF format for GitHub Code Scanning
+		</div>
+	</div>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># JSON output example</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--staged</span> <span style="color: oklch(0.75 0.15 240);">--format</span> <span style="color: var(--success);">json</span></div>
+			<div></div>
+			<div>{'{'}</div>
+			<div>  <span style="color: var(--accent);">"files"</span>: [</div>
+			<div>    {'{'}</div>
+			<div>      <span style="color: var(--accent);">"path"</span>: <span style="color: var(--success);">"src/auth/login.ts"</span>,</div>
+			<div>      <span style="color: var(--accent);">"issues"</span>: [</div>
+			<div>        {'{'}</div>
+			<div>          <span style="color: var(--accent);">"line"</span>: <span style="color: oklch(0.75 0.15 240);">42</span>,</div>
+			<div>          <span style="color: var(--accent);">"severity"</span>: <span style="color: var(--success);">"warning"</span>,</div>
+			<div>          <span style="color: var(--accent);">"message"</span>: <span style="color: var(--success);">"Potential SQL injection"</span></div>
+			<div>{'}'}</div>
+			<div>      ]</div>
+			<div>    {'}'}</div>
+			<div>  ],</div>
+			<div>  <span style="color: var(--accent);">"summary"</span>: {'{'}</div>
+			<div>    <span style="color: var(--accent);">"total_files"</span>: <span style="color: oklch(0.75 0.15 240);">3</span>,</div>
+			<div>    <span style="color: var(--accent);">"total_issues"</span>: <span style="color: oklch(0.75 0.15 240);">3</span></div>
+			<div>{'}'}</div>
+			<div>{'}'}</div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Configuration File</h2>
+	<p>The <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">.cora.yaml</code> file provides persistent configuration. Place it in your project root or use <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">~/.cora/config.yaml</code> for global settings.</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># .cora.yaml — full example</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># LLM provider: openai, anthropic, groq, ollama, zai</span></div>
+			<div><span style="color: var(--accent);">provider</span>: <span style="color: var(--success);">openai</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Model name</span></div>
+			<div><span style="color: var(--accent);">model</span>: <span style="color: var(--success);">gpt-4o</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Custom base URL (for proxies or self-hosted endpoints)</span></div>
+			<div><span style="color: var(--muted-foreground);"># base_url: https://api.example.com/v1</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Custom review prompt</span></div>
+			<div><span style="color: var(--muted-foreground);"># custom_prompt: |</span></div>
+			<div><span style="color: var(--muted-foreground);">#   Focus on security and performance only.</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># File patterns to include</span></div>
+			<div><span style="color: var(--muted-foreground);"># include:</span></div>
+			<div><span style="color: var(--muted-foreground);">#   - "src/**"</span></div>
+			<div><span style="color: var(--muted-foreground);">#   - "lib/**"</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># File patterns to exclude</span></div>
+			<div><span style="color: var(--muted-foreground);"># exclude:</span></div>
+			<div><span style="color: var(--muted-foreground);">#   - "**/*.test.ts"</span></div>
+			<div><span style="color: var(--muted-foreground);">#   - "**/node_modules/**"</span></div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Environment Variables</h2>
+	<p>Environment variables override configuration file settings:</p>
+
+	<div style="overflow-x: auto;">
+		<table class="compare-table">
+			<thead>
+				<tr>
+					<th>Variable</th>
+					<th>Description</th>
+					<th>Required</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">CORA_API_KEY</code></td>
+					<td>API key for the configured provider</td>
+					<td>Yes (unless using cora auth)</td>
+				</tr>
+				<tr>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">CORA_PROVIDER</code></td>
+					<td>Override the LLM provider</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">CORA_MODEL</code></td>
+					<td>Override the model name</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">CORA_BASE_URL</code></td>
+					<td>Override the API base URL</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td><code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">CORA_CONFIG</code></td>
+					<td>Path to alternative config file</td>
+					<td>No</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Working with Monorepos</h2>
+	<p>cora works well in monorepo setups. Use include patterns to limit review scope to specific packages:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--destructive);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warning);"></span>
+			<span style="width: 8px; height: 8px; border-radius: 50%; background: var(--success);"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span style="color: var(--muted-foreground);"># Review only the backend package</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--staged</span> <span style="color: oklch(0.75 0.15 240);">--include</span> <span style="color: var(--success);">"packages/backend/**"</span></div>
+			<div></div>
+			<div><span style="color: var(--muted-foreground);"># Exclude test and generated files</span></div>
+			<div><span style="color: var(--muted-foreground);">$</span> <span style="color: var(--accent);">cora review</span> <span style="color: oklch(0.75 0.15 240);">--staged</span> <span style="color: oklch(0.75 0.15 240);">--exclude</span> <span style="color: var(--success);">"**/*.test.ts"</span> <span style="color: oklch(0.75 0.15 240);">--exclude</span> <span style="color: var(--success);">"**/generated/**"</span></div>
+		</div>
+	</div>
+
+	<p>Alternatively, set include/exclude patterns in <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">.cora.yaml</code> for persistent configuration.</p>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Exit Codes</h2>
+	<p>cora uses standard exit codes for scripting and CI integration:</p>
+
+	<div style="overflow-x: auto;">
+		<table class="compare-table">
+			<thead>
+				<tr>
+					<th>Code</th>
+					<th>Meaning</th>
+					<th>CI Behavior</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code style="color: var(--success); font-family: var(--font-mono); font-size: 13px;">0</code></td>
+					<td>No issues found</td>
+					<td>Pass</td>
+				</tr>
+				<tr>
+					<td><code style="color: var(--warning); font-family: var(--font-mono); font-size: 13px;">1</code></td>
+					<td>Issues found</td>
+					<td>Fail (warning/error)</td>
+				</tr>
+				<tr>
+					<td><code style="color: var(--destructive); font-family: var(--font-mono); font-size: 13px;">2</code></td>
+					<td>Review blocked</td>
+					<td>Fail (auth/config error)</td>
+				</tr>
+				<tr>
+					<td><code style="color: var(--destructive); font-family: var(--font-mono); font-size: 13px;">3</code></td>
+					<td>Authentication error</td>
+					<td>Fail (missing API key)</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal" style="margin-top: 3rem;">
+	<h2>Tips</h2>
+	<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Use <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--staged</code> as a pre-commit hook for the fastest feedback loop
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Combine <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--format json</code> with <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--branch main</code> in CI pipelines
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Use <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">--incremental</code> for large codebases — only changed files are analyzed
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Set <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">custom_prompt</code> to match your team's coding standards
+		</div>
+		<div style="font-size: 14px; color: var(--muted-foreground); display: flex; gap: 0.5rem;">
+			<span style="color: var(--accent);">&#8226;</span>
+			Use <code style="color: var(--accent); font-family: var(--font-mono); font-size: 13px;">cora auth login</code> to store API keys securely instead of environment variables
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Changes

### Header
- Sticky glass nav: logo (cora), Docs + GitHub links, Get Started CTA
- backdrop-blur, z-index 50, 56px height

### Spacing
- Hero: `calc(100vh - 3.5rem)` to account for header
- Footer: mt-4rem
- Terminal font-size overrides removed

### New Docs Pages (4)
- Getting Started — quick start tutorial for personal use
- Installation — cargo, binary, source, completions, verify
- Usage — review modes, formats, config, env vars, exit codes
- Self-Hosted — Ollama, Gitea, offline, no telemetry

### Sidebar
- 8 nav links in proper order

Build clean. Deploy will auto-trigger.