### PR TITLE
fix: QA minor findings — touch targets, terminal width, table mobile

### DIFF
--- a/website/src/app.css
+++ b/website/src/app.css
@@ -389,8 +389,8 @@ body {
   font-family: var(--font-sans);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
-  min-height: 32px;
-  min-width: 32px;
+  min-height: 44px;
+  min-width: 44px;
   justify-content: center;
 }
 
@@ -440,6 +440,14 @@ body {
 .compare-table thead .cora-col {
   background: oklch(0.65 0.22 270 / 0.1);
   color: var(--accent);
+}
+
+@media (max-width: 640px) {
+  .compare-table th,
+  .compare-table td {
+    padding: 0.5rem 0.75rem;
+    font-size: 13px;
+  }
 }
 
 /* ---- Syntax Highlighting ---- */

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -103,7 +103,7 @@
 			</p>
 
 			<!-- Install Terminal -->
-			<div class="max-w-md w-full mx-auto mt-10 animate-fade-in-up delay-300">
+			<div class="max-w-lg w-full mx-auto mt-10 animate-fade-in-up delay-300">
 				<div class="terminal" style="position: relative;">
 					<div class="terminal-header">
 						<span class="terminal-dot terminal-dot-red"></span>
@@ -509,8 +509,8 @@
 					<span style="font-size: 12px; color: var(--muted-foreground); margin-left: 0.75rem;">MIT License</span>
 				</div>
 				<div class="flex items-center gap-6">
-					<a href="https://github.com/ajianaz/cora-cli" target="_blank" rel="noopener" style="font-size: 14px; color: var(--muted-foreground); text-decoration: none; transition: color 0.2s ease;">GitHub</a>
-					<a href="/docs" style="font-size: 14px; color: var(--muted-foreground); text-decoration: none; transition: color 0.2s ease;">Docs</a>
+					<a href="https://github.com/ajianaz/cora-cli" target="_blank" rel="noopener" style="font-size: 14px; color: var(--muted-foreground); text-decoration: none; transition: color 0.2s ease; min-height: 44px; display: inline-flex; align-items: center;">GitHub</a>
+					<a href="/docs" style="font-size: 14px; color: var(--muted-foreground); text-decoration: none; transition: color 0.2s ease; min-height: 44px; display: inline-flex; align-items: center;">Docs</a>
 				</div>
 			</div>
 		</footer>


### PR DESCRIPTION
Fix 4 minor QA findings:
1. Footer links min-height 44px (was 21px)
2. Copy button 32px → 44px
3. Hero terminal max-w-md → max-w-lg
4. Table mobile: 13px font + reduced padding @640px