### PR TITLE
chore: rename crate to cora-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "cora"
+name = "cora-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cora"
+name = "cora-cli"
 version = "0.1.0"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"


### PR DESCRIPTION
crates.io 'cora' already taken (v0.0.0 placeholder). Rename package to 'cora-cli', binary command stays 'cora' via [[bin]].

```cargo publish --dry-run``` ✅ — 65 files, 418.6KiB, zero errors.