### PR TITLE
fix(ci): add id-token write permission for Infisical OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
     name: Publish to crates.io
     needs: []
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Publish job failed: 'Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable'

Root cause: missing `permissions: id-token: write` on publish-crates job. OIDC token exchange requires this permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This PR contains no user-facing changes. It updates internal CI/CD workflow configuration to enhance security permissions for the release process. No new features, bug fixes, or changes visible to end-users have been introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajianaz/cora-cli/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->