### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"


### PR DESCRIPTION
Patch bump 0.1.0 → 0.1.1 for crates.io re-publish with updated README icon.