### PR TITLE
fix(ci): add --allow-dirty to cargo publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           domain: "https://infisical.ajianaz.dev"
 
       - name: Publish to crates.io
-        run: cargo publish --token ${{ env.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --token ${{ env.CARGO_REGISTRY_TOKEN }} --allow-dirty
 
   release:
     name: Create GitHub Release


### PR DESCRIPTION
Tag checkout causes Cargo.lock to appear uncommitted. Adding `--allow-dirty` to bypass (CI env is clean, this is a known crates.io + git tag issue).