### PR TITLE
fix(ci): address cora self-review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         uses: Infisical/secrets-action@v1.0.9
         with:
           method: "oidc"
-          identity-id: "6bd2b8d8-a9a3-4331-8b37-bf2764fc320b"
+          identity-id: ${{ secrets.INFISICAL_IDENTITY_ID }}
           project-slug: "github-actions"
           env-slug: "prod"
           domain: "https://infisical.ajianaz.dev"
@@ -96,7 +96,7 @@ jobs:
             --format sarif \
             --severity major \
             --quiet \
-            > cora-results.sarif 2>&1 || true
+            > cora-results.sarif
 
           echo "### 🔍 Cora AI Code Review" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Upload SARIF to GitHub Code Scanning
-        if: always()
+        if: always() && hashFiles('cora-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: cora-results.sarif


### PR DESCRIPTION
## Self-Review by Cora 🐕

Cora found 4 issues in its own CI workflow:

1. **Infisical identity-id hardcoded** → moved to `INFISICAL_IDENTITY_ID` secret
2. **`2>&1` mixing stderr into SARIF** → removed (only stdout)
3. **`|| true` masking failures** → removed (fail loudly)
4. **SARIF upload on empty file** → guarded with `hashFiles`

### Required setup
Add GitHub repo secret `INFISICAL_IDENTITY_ID` with value `6bd2b8d8-a9a3-4331-8b37-bf2764fc320b`