### PR TITLE
fix(ci): normalize release binary naming + sync action

### DIFF
--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -1,5 +1,5 @@
 name: 'Cora AI Code Review'
-description: 'Run cora AI code review on a PR diff — uploads SARIF to Code Scanning and posts a PR comment.'
+description: 'Run cora AI code review on a PR diff — posts a PR comment. SARIF upload is optional.'
 
 inputs:
   base-branch:
@@ -10,6 +10,14 @@ inputs:
     description: 'Minimum severity to report (info, minor, major, critical)'
     required: false
     default: 'major'
+  cora-version:
+    description: 'cora-cli version tag (default: latest release)'
+    required: false
+    default: 'latest'
+  upload-sarif:
+    description: 'Upload SARIF to GitHub Code Scanning (default: false)'
+    required: false
+    default: 'false'
   infisical-identity-id:
     description: 'Infisical OIDC identity ID (from secret INFISICAL_IDENTITY_ID)'
     required: true
@@ -41,11 +49,31 @@ runs:
         env-slug: ${{ inputs.infisical-env }}
         domain: ${{ inputs.infisical-domain }}
 
-    - name: Run cora review
+    - name: Install cora-cli
       shell: bash
       run: |
-        cargo build --release
-        ./target/release/cora review \
+        ARCH=$(uname -m)
+        if [ "$ARCH" = "x86_64" ]; then
+          ASSET="cora-x86_64-unknown-linux-gnu"
+        elif [ "$ARCH" = "aarch64" ]; then
+          ASSET="cora-aarch64-unknown-linux-gnu"
+        else
+          echo "Unsupported architecture: $ARCH"
+          exit 1
+        fi
+        curl -sL "https://github.com/ajianaz/cora-cli/releases/download/${{ inputs.cora-version }}/${ASSET}-${{ inputs.cora-version }}.tar.gz" | tar xz -C /usr/local/bin cora
+        chmod +x /usr/local/bin/cora
+        cora --version
+
+    - name: Run cora review
+      id: review
+      shell: bash
+      env:
+        CORA_API_KEY: ${{ env.CORA_API_KEY }}
+        CORA_BASE_URL: ${{ env.CORA_BASE_URL }}
+        CORA_MODEL: ${{ env.CORA_MODEL }}
+      run: |
+        cora review \
           --base ${{ inputs.base-branch }} \
           --format sarif \
           --severity ${{ inputs.severity }} \
@@ -54,7 +82,8 @@ runs:
         echo "Cora review complete ($(wc -c < cora-results.sarif) bytes)"
 
     - name: Upload SARIF to GitHub Code Scanning
-      if: always() && hashFiles('cora-results.sarif') != ''
+      if: inputs.upload-sarif == 'true'
+      continue-on-error: true
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: cora-results.sarif
@@ -162,7 +191,7 @@ runs:
           " 2>/dev/null || echo "0")
 
           if [ "$ERRORS" -gt 0 ]; then
-            echo "::error::Cora found $ERRORS blocking issue(s). Review the Code Scanning results."
+            echo "::error::Cora found $ERRORS blocking issue(s)."
             exit 1
           fi
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           mkdir -p release
-          cp target/${{ matrix.target }}/release/cora release/${{ matrix.artifact }}
+          cp target/${{ matrix.target }}/release/cora release/cora
           cd release
-          tar czf ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }} ${{ matrix.artifact }}
+          tar czf ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }} cora
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -151,10 +151,10 @@ jobs:
 
           | Platform | File |
           |----------|------|
-          | Linux (x86_64) | `cora-VERSION-x86_64-unknown-linux-gnu.tar.gz` |
-          | Linux (ARM64) | `cora-VERSION-aarch64-unknown-linux-gnu.tar.gz` |
-          | macOS (Apple Silicon) | `cora-VERSION-aarch64-apple-darwin.tar.gz` |
-          | Windows (x86_64) | `cora-VERSION-x86_64-pc-windows-msvc.zip` |
+          | Linux (x86_64) | `cora-x86_64-unknown-linux-gnu-VERSION.tar.gz` |
+          | Linux (ARM64) | `cora-aarch64-unknown-linux-gnu-VERSION.tar.gz` |
+          | macOS (Apple Silicon) | `cora-aarch64-apple-darwin-VERSION.tar.gz` |
+          | Windows (x86_64) | `cora-x86_64-pc-windows-msvc-VERSION.zip` |
 
           ### 🚀 Quick Start
 
@@ -162,8 +162,10 @@ jobs:
           # Install via cargo
           cargo install cora
 
-          # Or download binary
-          curl -fsSL https://github.com/ajianaz/cora-cli/releases/latest/download/cora-x86_64-unknown-linux-gnu-v0.1.1.tar.gz | tar xz
+          # Or download binary (extracts as 'cora')
+          curl -fsSL https://github.com/ajianaz/cora-cli/releases/latest/download/cora-x86_64-unknown-linux-gnu-VERSION.tar.gz | tar xz
+          chmod +x cora
+          sudo mv cora /usr/local/bin/
 
           # Init project
           cora init


### PR DESCRIPTION
## Changes

### Release workflow
- Binary inside tar now named `cora` (was `cora-x86_64-unknown-linux-gnu`)
- Consumers can do `tar xz ... | cora` directly
- Updated release notes template (quick start, file naming)

### cora-review action
- Synced with consumer repos (bond, gofin, uteke)
- Download from releases instead of build from source
- `cora-version` default: `latest` (auto-update)
- `upload-sarif` default: `false` (opt-in)

## Impact
All consumer repos (bond, gofin-full, uteke) updated to expect `cora` inside tar and default to `latest` version.

**Note:** This PR must be released before consumer PRs can pass CI — the current release (v0.1.1) still has target-triple naming.