### PR TITLE
chore: bump version to v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"


### PR DESCRIPTION
Patch bump for release. Binary naming fix + action sync.