### PR TITLE
fix: OG tags use cora.ajianaz.dev

### DIFF
--- a/website/src/app.html
+++ b/website/src/app.html
@@ -14,8 +14,8 @@
 		<meta property="og:title" content="cora — AI Code Review CLI" />
 		<meta property="og:description" content="CLI-first AI code review. BYOK, zero config, pre-commit hooks. Open source, MIT license." />
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://cora.ajianaz.com" />
-		<meta property="og:image" content="https://cora.ajianaz.com/og.png" />
+		<meta property="og:url" content="https://cora.ajianaz.dev" />
+		<meta property="og:image" content="https://cora.ajianaz.dev/og.png" />
 
 		<!-- Fonts -->
 		<link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
Fix og:url and og:image from cora.ajianaz.com to cora.ajianaz.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain references in social sharing metadata from `.com` to `.dev` for improved link consistency across social platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->