### PR TITLE
release: v0.1.4

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -15,7 +15,7 @@ no managed API, no cloud service. Runs locally against diffs, scans, or branches
 ```bash
 cargo build              # Build (debug)
 cargo build --release    # Build (release)
-cargo test               # Run all 151 tests
+cargo test               # Run all 157 tests
 cargo clippy             # Lint
 cargo fmt                # Format check (use -- --check for CI)
 ```
@@ -75,8 +75,8 @@ src/
 ## Testing
 
 ```bash
-cargo test               # 151 tests total
-                         #   129 unit tests
+cargo test               # 157 tests total
+                         #   135 unit tests
                          #   16 CLI integration tests
                          #    6 config tests
 cargo test --no-verify   # Skip pre-commit hooks (avoids timeout in hooks)
@@ -120,3 +120,12 @@ API keys live in a separate `auth.toml` file (`~/.cora/auth.toml`), not in
 - **Auth/config separation**: API keys are deliberately stored in `auth.toml`
   rather than the main config to allow `.cora.yaml` to be safely committed to
   repositories without exposing secrets.
+- **LLM JSON repair**: `engine/llm.rs` includes `repair_invalid_escapes()` — a state
+  machine that fixes invalid JSON escape sequences produced by some LLMs (e.g.
+  `\s`, `\d` → `\\s`, `\\d`). Applied before `serde_json::from_str` in all parse paths.
+  `review_diff()` also retries once on parse failure.
+- **Release workflow v-prefix**: `release.yml` strips `v` from git tag to match
+  CHANGELOG `[X.Y.Z]` format. `TAG` (with v) for display/URLs, `VERSION` (without)
+  for changelog sed matching and asset naming.
+- **Infisical secrets**: All workflows use `secrets.INFISICAL_IDENTITY_ID` — never
+  hardcode identity IDs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-01
+
+### Added
+
+- LLM JSON repair engine (`repair_invalid_escapes`) — auto-fixes invalid escape sequences in LLM output (e.g. `\s`, `\d`) before JSON parse
+- Retry mechanism in `review_diff` — if first LLM parse fails, automatically retries once
+- Branding footer on "No issues found" PR comment — consistent with issues-found variant
+
+### Fixed
+
+- **Silent false-negative** — cora JSON parse failure previously posted "No issues found" without actual review (LLM invalid escapes)
+- Hardcoded Infisical `identity-id` in `release.yml` and `deploy-website.yml` — migrated to `secrets.INFISICAL_IDENTITY_ID`
+- Release workflow changelog extraction — `v` prefix mismatch (tag `v0.1.3` vs CHANGELOG `[0.1.3]`) now properly stripped
+- `printf` double-escape in release workflow — `\\n` corrected to `\n`
+- Stale `v0.1.2` binary download filenames in README
+- Clippy `unnecessary_map_or` lint — `.map_or(false, |s| s.success())` replaced with `.is_ok_and(|s| s.success())`
+
+### Changed
+
+- All 3 workflows use `secrets.INFISICAL_IDENTITY_ID` (consistent with `ci.yml` pattern)
+- Release workflow validates semver format before sed injection
+- Branch cleanup — removed 14 stale branches
+
 ## [0.1.3] - 2026-06-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "cora-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Download the latest release from [GitHub Releases](https://github.com/ajianaz/co
 
 ```bash
 # Determine your platform tag from the releases page, e.g.:
-#   cora-aarch64-unknown-linux-gnu-v0.1.3.tar.gz
-#   cora-x86_64-unknown-linux-gnu-v0.1.3.tar.gz
-#   cora-aarch64-apple-darwin-v0.1.3.tar.gz
-#   cora-x86_64-pc-windows-msvc-v0.1.3.zip
+#   cora-aarch64-unknown-linux-gnu-v0.1.4.tar.gz
+#   cora-x86_64-unknown-linux-gnu-v0.1.4.tar.gz
+#   cora-aarch64-apple-darwin-v0.1.4.tar.gz
+#   cora-x86_64-pc-windows-msvc-v0.1.4.zip
 
 # Example: Linux aarch64
 VERSION=$(curl -s https://api.github.com/repos/ajianaz/cora-cli/releases/latest | grep tag_name | cut -d'"' -f4)


### PR DESCRIPTION
## v0.1.4 Release

Pre-release checklist:
- [x] Version: `0.1.4` in `Cargo.toml`
- [x] CHANGELOG `[0.1.4]` section filled
- [x] `cargo test` — 157/157 passed
- [x] `cargo clippy -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] README binary refs updated to v0.1.4
- [x] Release workflow v-prefix fix verified (dry run)
- [x] AGENT.md updated (test count, design decisions)

Auto-release: tag `v0.1.4` after merge → release notes from CHANGELOG
