### PR TITLE
fix: resolve 104 clippy::pedantic warnings (175→71)

### DIFF
--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -99,7 +99,7 @@ pub fn execute_config_show() -> Result<()> {
 /// Execute `cora config set [--global] <key> <value>` — write a key-value pair
 /// to a YAML config file.
 ///
-/// Supported keys: model, provider, base_url, format, severity
+/// Supported keys: model, provider, `base_url`, format, severity
 pub fn execute_config_set(key: &str, value: &str, global: bool) -> Result<()> {
     // Validate the key
     match key {

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -119,7 +119,8 @@ pub async fn execute_review(
                 let duration_ms = llm_start.elapsed().as_millis() as u64;
                 let tokens = resp
                     .tokens_used
-                    .as_ref().map_or_else(TokenInfo::zero, TokenInfo::from_usage);
+                    .as_ref()
+                    .map_or_else(TokenInfo::zero, TokenInfo::from_usage);
                 progress.llm_response(&tokens, duration_ms);
             }
             resp
@@ -162,7 +163,8 @@ pub async fn execute_review(
     if progress.is_enabled() {
         let tokens = response
             .tokens_used
-            .as_ref().map_or_else(TokenInfo::zero, TokenInfo::from_usage);
+            .as_ref()
+            .map_or_else(TokenInfo::zero, TokenInfo::from_usage);
         progress.complete(
             filtered_response.issues.len(),
             exit_code == EXIT_BLOCKED,

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -119,9 +119,7 @@ pub async fn execute_review(
                 let duration_ms = llm_start.elapsed().as_millis() as u64;
                 let tokens = resp
                     .tokens_used
-                    .as_ref()
-                    .map(TokenInfo::from_usage)
-                    .unwrap_or_else(TokenInfo::zero);
+                    .as_ref().map_or_else(TokenInfo::zero, TokenInfo::from_usage);
                 progress.llm_response(&tokens, duration_ms);
             }
             resp
@@ -164,9 +162,7 @@ pub async fn execute_review(
     if progress.is_enabled() {
         let tokens = response
             .tokens_used
-            .as_ref()
-            .map(TokenInfo::from_usage)
-            .unwrap_or_else(TokenInfo::zero);
+            .as_ref().map_or_else(TokenInfo::zero, TokenInfo::from_usage);
         progress.complete(
             filtered_response.issues.len(),
             exit_code == EXIT_BLOCKED,
@@ -182,10 +178,10 @@ fn get_diff(opts: &ReviewOptions, _config: &Config) -> Result<String> {
     if let Some(ref diff_file) = opts.diff_file {
         let path = std::path::Path::new(diff_file);
         if !path.exists() {
-            anyhow::bail!("diff file not found: {}", diff_file);
+            anyhow::bail!("diff file not found: {diff_file}");
         }
         return std::fs::read_to_string(path)
-            .with_context(|| format!("failed to read diff file: {}", diff_file));
+            .with_context(|| format!("failed to read diff file: {diff_file}"));
     }
     if let Some(ref commit_ref) = opts.commit {
         return git::get_commit_diff(commit_ref);

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -93,7 +93,7 @@ pub async fn execute_scan(
         return Ok(0);
     }
 
-    println!("🔍 {} files to review…", files.len().to_string().cyan(),);
+    println!("🔍 {} files to review…", files.len().to_string().cyan());
 
     // 2. Calculate total lines
     let total_lines: usize = files.iter().map(|f| f.lines).sum();
@@ -114,7 +114,7 @@ pub async fn execute_scan(
             String::new()
         };
 
-        println!("  Reviewing{}…", batch_label);
+        println!("  Reviewing{batch_label}…");
 
         let (issues, _summary, tokens) = crate::engine::llm::scan_files(
             llm_config,
@@ -155,7 +155,7 @@ pub async fn execute_scan(
 
     let formatter = formatter_for(format);
     let output = formatter.format_scan(&response)?;
-    println!("{}", output);
+    println!("{output}");
 
     // 6. Save scan cache for incremental mode
     if opts.incremental {
@@ -194,7 +194,7 @@ fn file_content_hash(path: &std::path::Path) -> Option<String> {
 /// Stored as JSON in ~/.cora/scan-cache.json.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct ScanCache {
-    /// Key: canonical root path, Value: { file_path: hash }
+    /// Key: canonical root path, Value: { `file_path`: hash }
     projects: std::collections::HashMap<String, std::collections::HashMap<String, String>>,
 }
 

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -69,9 +69,7 @@ pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
     );
 
     // Build the upload request
-    let url = format!(
-        "https://api.github.com/repos/{owner}/{repo}/code-scanning/sarifs"
-    );
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/code-scanning/sarifs");
 
     let client = reqwest::Client::new();
     let response = client
@@ -142,8 +140,9 @@ pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
 
 /// Read SARIF content from a file or stdin.
 fn read_sarif(file: Option<&str>) -> Result<String> {
-    if let Some(path) = file { std::fs::read_to_string(path)
-    .with_context(|| format!("Failed to read SARIF file: {path}")) } else {
+    if let Some(path) = file {
+        std::fs::read_to_string(path).with_context(|| format!("Failed to read SARIF file: {path}"))
+    } else {
         eprintln!(
             "{} Reading SARIF from stdin (Ctrl+D to finish)...",
             "ℹ".blue()
@@ -161,9 +160,7 @@ fn resolve_repo(cli_repo: Option<&str>) -> Result<(String, String)> {
     if let Some(repo) = cli_repo {
         let parts: Vec<&str> = repo.split('/').collect();
         if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
-            bail!(
-                "Invalid repository format '{repo}'. Expected 'owner/repo'."
-            );
+            bail!("Invalid repository format '{repo}'. Expected 'owner/repo'.");
         }
         return Ok((parts[0].to_string(), parts[1].to_string()));
     }
@@ -194,7 +191,9 @@ fn resolve_ref(cli_ref: Option<&str>) -> Result<String> {
     }
 
     // Try to get from git
-    if let Ok(branch) = crate::git::get_current_branch() { Ok(branch) } else {
+    if let Ok(branch) = crate::git::get_current_branch() {
+        Ok(branch)
+    } else {
         // Try to get the current HEAD commit SHA as fallback
         let output = std::process::Command::new("git")
             .args(["rev-parse", "HEAD"])

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -70,8 +70,7 @@ pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
 
     // Build the upload request
     let url = format!(
-        "https://api.github.com/repos/{}/{}/code-scanning/sarifs",
-        owner, repo
+        "https://api.github.com/repos/{owner}/{repo}/code-scanning/sarifs"
     );
 
     let client = reqwest::Client::new();
@@ -79,7 +78,7 @@ pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
         .post(&url)
         .header("Accept", "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28")
-        .header("Authorization", format!("Bearer {}", token))
+        .header("Authorization", format!("Bearer {token}"))
         .json(&json!({ "commit_sha": ref_name, "sarif": &sarif_content }))
         .send()
         .await
@@ -97,7 +96,7 @@ pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
         // Parse the response for additional info
         if let Ok(resp_json) = serde_json::from_str::<serde_json::Value>(&body) {
             if let Some(id) = resp_json.get("id").and_then(|v| v.as_str()) {
-                println!("   Analysis ID: {}", id);
+                println!("   Analysis ID: {id}");
             }
         }
 
@@ -110,7 +109,7 @@ pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
                 v.get("message")
                     .or_else(|| v.get("errors")?.get(0)?.get("message"))
                     .and_then(|m| m.as_str())
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
             })
             .unwrap_or_else(|| body.clone());
 
@@ -143,20 +142,17 @@ pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
 
 /// Read SARIF content from a file or stdin.
 fn read_sarif(file: Option<&str>) -> Result<String> {
-    match file {
-        Some(path) => std::fs::read_to_string(path)
-            .with_context(|| format!("Failed to read SARIF file: {}", path)),
-        None => {
-            eprintln!(
-                "{} Reading SARIF from stdin (Ctrl+D to finish)...",
-                "ℹ".blue()
-            );
-            let mut content = String::new();
-            std::io::stdin()
-                .read_to_string(&mut content)
-                .context("Failed to read from stdin")?;
-            Ok(content)
-        }
+    if let Some(path) = file { std::fs::read_to_string(path)
+    .with_context(|| format!("Failed to read SARIF file: {path}")) } else {
+        eprintln!(
+            "{} Reading SARIF from stdin (Ctrl+D to finish)...",
+            "ℹ".blue()
+        );
+        let mut content = String::new();
+        std::io::stdin()
+            .read_to_string(&mut content)
+            .context("Failed to read from stdin")?;
+        Ok(content)
     }
 }
 
@@ -166,8 +162,7 @@ fn resolve_repo(cli_repo: Option<&str>) -> Result<(String, String)> {
         let parts: Vec<&str> = repo.split('/').collect();
         if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
             bail!(
-                "Invalid repository format '{}'. Expected 'owner/repo'.",
-                repo
+                "Invalid repository format '{repo}'. Expected 'owner/repo'."
             );
         }
         return Ok((parts[0].to_string(), parts[1].to_string()));
@@ -199,24 +194,21 @@ fn resolve_ref(cli_ref: Option<&str>) -> Result<String> {
     }
 
     // Try to get from git
-    match crate::git::get_current_branch() {
-        Ok(branch) => Ok(branch),
-        Err(_) => {
-            // Try to get the current HEAD commit SHA as fallback
-            let output = std::process::Command::new("git")
-                .args(["rev-parse", "HEAD"])
-                .output();
+    if let Ok(branch) = crate::git::get_current_branch() { Ok(branch) } else {
+        // Try to get the current HEAD commit SHA as fallback
+        let output = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output();
 
-            match output {
-                Ok(out) if out.status.success() => {
-                    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                    Ok(sha)
-                }
-                _ => {
-                    bail!(
-                        "Could not detect current git ref. Pass --ref-name or run inside a git repo."
-                    );
-                }
+        match output {
+            Ok(out) if out.status.success() => {
+                let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                Ok(sha)
+            }
+            _ => {
+                bail!(
+                    "Could not detect current git ref. Pass --ref-name or run inside a git repo."
+                );
             }
         }
     }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -72,7 +72,7 @@ fn load_global_config() -> Result<Option<CoraFile>> {
 
 /// Migrate old `~/.cora/config.toml` to the new format if it exists.
 /// - Non-secret keys → `~/.cora/config.yaml`
-/// - api_key → `~/.cora/auth.toml`
+/// - `api_key` → `~/.cora/auth.toml`
 /// - Delete the old file after successful migration.
 /// - Creates `.migrated` marker to prevent re-running.
 fn migrate_old_config() {
@@ -114,12 +114,12 @@ fn migrate_old_config() {
         .get("auth")
         .and_then(|a| a.get("api_key"))
         .and_then(|k| k.as_str())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
         .or_else(|| {
             table
                 .get("api_key")
                 .and_then(|k| k.as_str())
-                .map(|s| s.to_string())
+                .map(std::string::ToString::to_string)
         });
 
     // Extract non-secret config fields into a CoraFile
@@ -147,7 +147,7 @@ fn migrate_old_config() {
         if let Some(v) = output.get("format").and_then(|v| v.as_str()) {
             os.format = Some(v.to_string());
         }
-        if let Some(v) = output.get("color").and_then(|v| v.as_bool()) {
+        if let Some(v) = output.get("color").and_then(toml::Value::as_bool) {
             os.color = Some(v);
         }
         if os.format.is_some() || os.color.is_some() {
@@ -163,7 +163,7 @@ fn migrate_old_config() {
         if let Some(v) = hook.get("min_severity").and_then(|v| v.as_str()) {
             hs.min_severity = Some(v.to_string());
         }
-        if let Some(v) = hook.get("max_diff_size").and_then(|v| v.as_integer()) {
+        if let Some(v) = hook.get("max_diff_size").and_then(toml::Value::as_integer) {
             hs.max_diff_size = Some(v as usize);
         }
         if hs.mode.is_some() || hs.min_severity.is_some() || hs.max_diff_size.is_some() {
@@ -283,10 +283,10 @@ pub fn load_config(
 }
 
 /// Build an `LLMConfig` from the resolved `Config`, fetching the API key
-/// from: CLI flag → env CORA_API_KEY → ~/.cora/auth.toml.
+/// from: CLI flag → env `CORA_API_KEY` → ~/.cora/auth.toml.
 ///
-/// If none of those are set, auto-detect from known provider env vars (OPENAI_API_KEY, etc.)
-/// and configure provider/model/base_url from the matching preset.
+/// If none of those are set, auto-detect from known provider env vars (`OPENAI_API_KEY`, etc.)
+/// and configure `provider/model/base_url` from the matching preset.
 pub fn build_llm_config(config: &Config, cli_api_key: Option<&str>) -> Result<LLMConfig> {
     // Resolve the API key and optional auto-detected preset in one pass.
     let (api_key, auto_preset) = if let Some(key) = cli_api_key {
@@ -403,12 +403,12 @@ pub fn load_api_key_from_auth_file() -> Result<Option<String>> {
         .get("auth")
         .and_then(|a| a.get("api_key"))
         .and_then(|k| k.as_str())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
         .or_else(|| {
             value
                 .get("api_key")
                 .and_then(|k| k.as_str())
-                .map(|s| s.to_string())
+                .map(std::string::ToString::to_string)
         });
 
     Ok(key)

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -18,7 +18,7 @@ pub struct Config {
     pub hook: HookConfig,
     /// Output configuration.
     pub output: OutputConfig,
-    /// Response format for LLM API calls ("none" or "json_object").
+    /// Response format for LLM API calls ("none" or "`json_object`").
     pub response_format: String,
     /// Optional custom system prompt that replaces the default for review.
     pub review_system_prompt_override: Option<String>,
@@ -115,7 +115,7 @@ impl Default for Config {
 }
 
 impl HookConfig {
-    /// Parse the min_severity string into a Severity enum.
+    /// Parse the `min_severity` string into a Severity enum.
     pub fn min_severity_level(&self) -> Severity {
         Severity::from_str_lossy(&self.min_severity)
     }
@@ -200,7 +200,7 @@ pub struct ScanSection {
     pub system_prompt_file: Option<String>,
 }
 
-/// LLM-specific configuration section (temperature, max_tokens, timeout, cache_ttl).
+/// LLM-specific configuration section (temperature, `max_tokens`, timeout, `cache_ttl`).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LlmSection {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn parse_cora_file_full() {
-        let yaml = r#"
+        let yaml = r"
 provider:
   provider: anthropic
   model: claude-3-haiku
@@ -498,7 +498,7 @@ hook:
 output:
   format: json
   color: false
-"#;
+";
         let cora = CoraFile::from_str(yaml).unwrap();
         assert_eq!(
             cora.provider.as_ref().unwrap().provider.as_deref(),
@@ -589,10 +589,10 @@ output:
 
     #[test]
     fn parse_review_section_with_response_format() {
-        let yaml = r#"
+        let yaml = r"
 review:
   response_format: json_object
-"#;
+";
         let cora = CoraFile::from_str(yaml).unwrap();
         assert_eq!(
             cora.review.as_ref().unwrap().response_format.as_deref(),
@@ -602,12 +602,12 @@ review:
 
     #[test]
     fn parse_review_section_with_system_prompt() {
-        let yaml = r#"
+        let yaml = r"
 review:
   system_prompt: |
     You are a security-focused reviewer.
   system_prompt_file: .cora/prompts/review.md
-"#;
+";
         let cora = CoraFile::from_str(yaml).unwrap();
         assert_eq!(
             cora.review.as_ref().unwrap().system_prompt.as_deref(),
@@ -674,11 +674,11 @@ review:
 
     #[test]
     fn parse_scan_section_with_system_prompt() {
-        let yaml = r#"
+        let yaml = r"
 scan:
   system_prompt: |
     You are a performance-focused scanner.
-"#;
+";
         let cora = CoraFile::from_str(yaml).unwrap();
         assert_eq!(
             cora.scan.as_ref().unwrap().system_prompt.as_deref(),
@@ -707,7 +707,7 @@ scan:
 
     #[test]
     fn parse_cora_file_with_review_and_scan() {
-        let yaml = r#"
+        let yaml = r"
 review:
   response_format: json_object
   system_prompt: |
@@ -716,7 +716,7 @@ scan:
   system_prompt: |
     Performance only.
   system_prompt_file: scan.md
-"#;
+";
         let cora = CoraFile::from_str(yaml).unwrap();
         let review = cora.review.unwrap();
         assert_eq!(review.response_format.as_deref(), Some("json_object"));
@@ -754,13 +754,13 @@ scan:
 
     #[test]
     fn parse_llm_section() {
-        let yaml = r#"
+        let yaml = r"
 llm:
   temperature: 0.5
   max_tokens: 8192
   timeout: 60
   cache_ttl: 720
-"#;
+";
         let cora = CoraFile::from_str(yaml).unwrap();
         let llm = cora.llm.unwrap();
         assert_eq!(llm.temperature, Some(0.5));
@@ -771,10 +771,10 @@ llm:
 
     #[test]
     fn parse_llm_section_partial() {
-        let yaml = r#"
+        let yaml = r"
 llm:
   temperature: 0.3
-"#;
+";
         let cora = CoraFile::from_str(yaml).unwrap();
         let llm = cora.llm.unwrap();
         assert_eq!(llm.temperature, Some(0.3));
@@ -858,12 +858,12 @@ llm:
 
     #[test]
     fn cora_file_malformed_yaml_returns_error() {
-        let yaml = r#"
+        let yaml = r"
 provider:
   provider: openai
   model: gpt-4
   this is not valid yaml: [
-"#;
+";
         let result = CoraFile::from_str(yaml);
         assert!(result.is_err(), "malformed YAML should return an error");
         let err = result.unwrap_err().to_string();

--- a/src/engine/cache.rs
+++ b/src/engine/cache.rs
@@ -20,7 +20,7 @@ fn cache_key(diff: &str, model: &str, temperature: f32) -> String {
     hasher.update(model.as_bytes());
     hasher.update(temperature.to_le_bytes());
     let result = hasher.finalize();
-    result.iter().map(|b| format!("{:02x}", b)).collect()
+    result.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Get cached review response if available and not expired.
@@ -35,7 +35,7 @@ pub fn get_cached_review(
 ) -> Option<ReviewResponse> {
     let hash = cache_key(diff, model, temperature);
     let dir = cache_dir().ok()?;
-    let path = dir.join(format!("{}.json", hash));
+    let path = dir.join(format!("{hash}.json"));
 
     if !path.is_file() {
         debug!("cache miss: file not found");
@@ -82,7 +82,7 @@ pub fn save_cached_review(
         .with_context(|| format!("failed to create cache dir {}", dir.display()))?;
 
     let hash = cache_key(diff, model, temperature);
-    let path = dir.join(format!("{}.json", hash));
+    let path = dir.join(format!("{hash}.json"));
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -247,7 +247,7 @@ mod tests {
         // Manually set up a cache entry in the temp dir
         let diff = "test diff content";
         let hash = cache_key(diff, "model", 0.0);
-        let path = dir.join(format!("{}.json", hash));
+        let path = dir.join(format!("{hash}.json"));
 
         let response = make_response();
         let now = SystemTime::now()

--- a/src/engine/llm.rs
+++ b/src/engine/llm.rs
@@ -7,9 +7,9 @@ use tracing::debug;
 
 use crate::engine::types::{LLMConfig, ReviewIssue, ReviewResponse, TokenUsage};
 
-/// Shared reqwest::Client with connection pooling. Reused across all LLM requests.
+/// Shared `reqwest::Client` with connection pooling. Reused across all LLM requests.
 /// Created lazily on first use to avoid blocking initialization.
-/// Per-request timeout is set via .timeout() on the RequestBuilder.
+/// Per-request timeout is set via .`timeout()` on the `RequestBuilder`.
 ///
 /// Supports `REQUESTS_CA_BUNDLE` env var for custom CA certificates
 /// (corporate proxies with self-signed certs).
@@ -42,7 +42,7 @@ static SHARED_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     })
 });
 
-/// Return the shared reqwest::Client for LLM API requests.
+/// Return the shared `reqwest::Client` for LLM API requests.
 pub fn shared_client() -> reqwest::Client {
     SHARED_CLIENT.clone()
 }
@@ -220,7 +220,7 @@ async fn chat_completion(
         .context("failed to read LLM response body")?;
 
     if !status.is_success() {
-        anyhow::bail!("LLM API returned status {status}: {body}",);
+        anyhow::bail!("LLM API returned status {status}: {body}");
     }
 
     if let Some(sp) = spinner {
@@ -515,7 +515,7 @@ pub async fn scan_files(
             "Additional rules:\n{}\n\n",
             rules
                 .iter()
-                .map(|r| format!("- {}", r))
+                .map(|r| format!("- {r}"))
                 .collect::<Vec<_>>()
                 .join("\n")
         ));
@@ -586,7 +586,7 @@ fn build_review_prompt(diff: &str, focus: &[String], rules: &[String]) -> String
     if !file_paths.is_empty() {
         prompt.push_str("Valid files in this diff:\n");
         for path in &file_paths {
-            prompt.push_str(&format!("- \"{}\"\n", path));
+            prompt.push_str(&format!("- \"{path}\"\n"));
         }
         prompt.push('\n');
     }
@@ -696,11 +696,11 @@ fn repair_json_string(json_str: &str) -> String {
     // Replace lone backslashes inside JSON string values that aren't valid JSON escapes.
     // Valid JSON escapes: \" \\ \/ \b \f \n \r \t \uXXXX
     let repaired = repair_invalid_escapes(json_str);
-    if repaired != json_str {
+    if repaired == json_str {
+        json_str.to_string()
+    } else {
         debug!("applied backslash repair to LLM JSON output");
         repaired
-    } else {
-        json_str.to_string()
     }
 }
 

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -9,12 +9,9 @@ use crate::engine::types::{LLMConfig, ReviewIssue, ReviewResponse};
 /// Returns the file content, or None if the file doesn't exist, can't be read,
 /// or is outside the project root (path traversal guard).
 fn load_system_prompt_file(path: &str) -> Option<String> {
-    let canonical = match std::fs::canonicalize(path) {
-        Ok(p) => p,
-        Err(_) => {
-            tracing::debug!(path = path, "system_prompt_file does not exist");
-            return None;
-        }
+    let canonical = if let Ok(p) = std::fs::canonicalize(path) { p } else {
+        tracing::debug!(path = path, "system_prompt_file does not exist");
+        return None;
     };
     let project_root = std::env::current_dir().ok()?;
     let project_root = std::fs::canonicalize(&project_root).ok()?;
@@ -184,7 +181,7 @@ async fn review_diff_inner(
     Ok(response)
 }
 
-/// Filter out issues whose issue_type matches any ignored rule pattern.
+/// Filter out issues whose `issue_type` matches any ignored rule pattern.
 fn apply_ignore_rules(mut issues: Vec<ReviewIssue>, ignore_rules: &[String]) -> Vec<ReviewIssue> {
     if ignore_rules.is_empty() {
         return issues;
@@ -194,9 +191,7 @@ fn apply_ignore_rules(mut issues: Vec<ReviewIssue>, ignore_rules: &[String]) -> 
         !ignore_rules.iter().any(|pattern| {
             let pattern_lower = pattern.to_lowercase();
             let issue_type_lower = issue
-                .issue_type
-                .as_ref()
-                .map(|t| t.to_string())
+                .issue_type.clone()
                 .unwrap_or_default()
                 .to_lowercase();
             issue_type_lower.contains(&pattern_lower)

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -9,7 +9,9 @@ use crate::engine::types::{LLMConfig, ReviewIssue, ReviewResponse};
 /// Returns the file content, or None if the file doesn't exist, can't be read,
 /// or is outside the project root (path traversal guard).
 fn load_system_prompt_file(path: &str) -> Option<String> {
-    let canonical = if let Ok(p) = std::fs::canonicalize(path) { p } else {
+    let canonical = if let Ok(p) = std::fs::canonicalize(path) {
+        p
+    } else {
         tracing::debug!(path = path, "system_prompt_file does not exist");
         return None;
     };
@@ -190,10 +192,7 @@ fn apply_ignore_rules(mut issues: Vec<ReviewIssue>, ignore_rules: &[String]) -> 
     issues.retain(|issue| {
         !ignore_rules.iter().any(|pattern| {
             let pattern_lower = pattern.to_lowercase();
-            let issue_type_lower = issue
-                .issue_type.clone()
-                .unwrap_or_default()
-                .to_lowercase();
+            let issue_type_lower = issue.issue_type.clone().unwrap_or_default().to_lowercase();
             issue_type_lower.contains(&pattern_lower)
                 || issue.title.to_lowercase().contains(&pattern_lower)
         })

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -43,7 +43,7 @@ pub fn walk_project(
 
     // Build extension set
     let mut extensions: BTreeSet<String> =
-        DEFAULT_EXTENSIONS.iter().map(|s| s.to_string()).collect();
+        DEFAULT_EXTENSIONS.iter().map(std::string::ToString::to_string).collect();
     for ext in extra_extensions {
         extensions.insert(ext.trim_start_matches('.').to_lowercase());
     }

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -42,8 +42,10 @@ pub fn walk_project(
     );
 
     // Build extension set
-    let mut extensions: BTreeSet<String> =
-        DEFAULT_EXTENSIONS.iter().map(std::string::ToString::to_string).collect();
+    let mut extensions: BTreeSet<String> = DEFAULT_EXTENSIONS
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
     for ext in extra_extensions {
         extensions.insert(ext.trim_start_matches('.').to_lowercase());
     }

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Severity {
 /// Issue type categories.
 ///
 /// Kept for API completeness — used for deserialization and future typed
-/// issue-type matching. Currently the LLM returns issue_type as a string,
+/// issue-type matching. Currently the LLM returns `issue_type` as a string,
 /// but this enum provides a structured alternative.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -111,7 +111,7 @@ pub struct ReviewIssue {
     pub line: Option<u32>,
     pub severity: Severity,
     /// Issue type/category — stored as string since LLM output varies.
-    /// Common values: security, performance, bug, best_practice, style, suggestion
+    /// Common values: security, performance, bug, `best_practice`, style, suggestion
     #[serde(rename = "type", alias = "issue_type")]
     pub issue_type: Option<String>,
     pub title: String,

--- a/src/formatters/compact.rs
+++ b/src/formatters/compact.rs
@@ -61,7 +61,7 @@ impl Formatter for CompactFormatter {
     }
 }
 
-/// Format a single issue as one line: [SEVERITY] file:line: title
+/// Format a single issue as one line: [SEVERITY] <file:line>: title
 fn format_issue_compact(issue: &ReviewIssue) -> String {
     let sev = match issue.severity {
         Severity::Critical => "CRITICAL".red().bold().to_string(),

--- a/src/formatters/pretty.rs
+++ b/src/formatters/pretty.rs
@@ -55,10 +55,10 @@ impl Formatter for PrettyFormatter {
             "Found {} issue{}: {} {} {} {} {}\n\n",
             response.issues.len(),
             if response.issues.len() == 1 { "" } else { "s" },
-            format!("{} critical", crit).red(),
-            format!("{} major", maj).yellow(),
-            format!("{} minor", min).blue(),
-            format!("{} info", inf).white(),
+            format!("{crit} critical").red(),
+            format!("{maj} major").yellow(),
+            format!("{min} minor").blue(),
+            format!("{inf} info").white(),
             if response.should_block {
                 format!("\n{}", "⚠ BLOCKED".red().bold())
             } else {
@@ -141,10 +141,10 @@ impl Formatter for PrettyFormatter {
             "Found {} issue{}: {} {} {} {} {}\n\n",
             response.issues.len(),
             if response.issues.len() == 1 { "" } else { "s" },
-            format!("{} critical", crit).red(),
-            format!("{} major", maj).yellow(),
-            format!("{} minor", min).blue(),
-            format!("{} info", inf).white(),
+            format!("{crit} critical").red(),
+            format!("{maj} major").yellow(),
+            format!("{min} minor").blue(),
+            format!("{inf} info").white(),
             if response.should_block {
                 format!("\n{}", "⚠ BLOCKED".red().bold())
             } else {
@@ -193,7 +193,7 @@ fn format_issue_pretty(issue: &ReviewIssue, num: usize) -> String {
 
     out.push_str(&format!("{icon} [{sev_colored}] "));
     if let Some(ref itype) = issue.issue_type {
-        out.push_str(&format!("{}: ", itype));
+        out.push_str(&format!("{itype}: "));
     }
 
     // File:line location
@@ -222,7 +222,7 @@ fn format_issue_pretty(issue: &ReviewIssue, num: usize) -> String {
     if let Some(ref fix) = issue.suggested_fix {
         if !fix.trim().is_empty() {
             out.push_str(&format!("  {}\n", "💡 Suggested fix:".green().bold()));
-            out.push_str(&format!("    {}\n", fix));
+            out.push_str(&format!("    {fix}\n"));
         }
     }
 

--- a/src/formatters/sarif.rs
+++ b/src/formatters/sarif.rs
@@ -7,7 +7,7 @@ use crate::formatters::Formatter;
 /// SARIF formatter for GitHub Code Scanning integration.
 ///
 /// Output conforms to the SARIF v2.1.0 specification:
-/// https://docs.oasis-open.org/sarif/sarif/v2.1.0/
+/// <https://docs.oasis-open.org/sarif/sarif/v2.1.0>/
 pub struct SarifFormatter;
 
 impl Formatter for SarifFormatter {
@@ -30,9 +30,7 @@ fn build_sarif(issues: &[ReviewIssue]) -> Value {
     let mut rule_map = serde_json::Map::new();
     for issue in issues {
         let rule_id = issue
-            .issue_type
-            .as_ref()
-            .map(|t| t.to_string())
+            .issue_type.clone()
             .unwrap_or_else(|| "unknown".to_string());
         if !rule_map.contains_key(&rule_id) {
             rule_map.insert(
@@ -58,7 +56,7 @@ fn build_sarif(issues: &[ReviewIssue]) -> Value {
         .iter()
         .map(|issue| {
             let mut result = json!({
-                "ruleId": issue.issue_type.as_ref().map(|t| t.to_string()).unwrap_or_else(|| "unknown".to_string()),
+                "ruleId": issue.issue_type.clone().unwrap_or_else(|| "unknown".to_string()),
                 "level": severity_to_sarif_level(&issue.severity),
                 "message": {
                     "text": issue.body.clone()
@@ -106,15 +104,15 @@ fn build_sarif(issues: &[ReviewIssue]) -> Value {
         .collect();
 
     // Build invocations array with watermark
-    let invocations = if !issues.is_empty() {
+    let invocations = if issues.is_empty() {
+        json!([])
+    } else {
         json!([{
             "executionSuccessful": true,
             "properties": {
                 "cora.watermark": format!("Reviewed by Cora v{}", env!("CARGO_PKG_VERSION"))
             }
         }])
-    } else {
-        json!([])
     };
 
     json!({
@@ -258,7 +256,7 @@ mod tests {
         let wm = &invocations[0]["properties"]["cora.watermark"];
         let wm_str = wm.as_str().unwrap();
         assert!(wm_str.contains("Cora"));
-        assert!(wm_str.contains("v"));
+        assert!(wm_str.contains('v'));
     }
 
     #[test]

--- a/src/formatters/sarif.rs
+++ b/src/formatters/sarif.rs
@@ -30,7 +30,8 @@ fn build_sarif(issues: &[ReviewIssue]) -> Value {
     let mut rule_map = serde_json::Map::new();
     for issue in issues {
         let rule_id = issue
-            .issue_type.clone()
+            .issue_type
+            .clone()
             .unwrap_or_else(|| "unknown".to_string());
         if !rule_map.contains_key(&rule_id) {
             rule_map.insert(

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -23,8 +23,7 @@ fn validate_ref(ref_str: &str) -> Result<()> {
         // that start with ".." or contain "/.." or ".." at the end.
         if ref_str.starts_with("..") || ref_str.contains("/..") || ref_str.ends_with("..") {
             anyhow::bail!(
-                "invalid ref '{}': contains path traversal sequence '..'",
-                ref_str
+                "invalid ref '{ref_str}': contains path traversal sequence '..'"
             );
         }
     }
@@ -35,9 +34,7 @@ fn validate_ref(ref_str: &str) -> Result<()> {
             .filter(|c| DANGEROUS_REF_CHARS.contains(c))
             .collect();
         anyhow::bail!(
-            "invalid ref '{}': contains unsafe characters: '{}'",
-            ref_str,
-            found
+            "invalid ref '{ref_str}': contains unsafe characters: '{found}'"
         );
     }
 
@@ -77,7 +74,7 @@ pub fn get_unstaged_diff() -> Result<String> {
 /// Get the diff between the current branch and `base_branch`.
 pub fn get_branch_diff(base_branch: &str) -> Result<String> {
     validate_ref(base_branch)?;
-    let arg = format!("{}...HEAD", base_branch);
+    let arg = format!("{base_branch}...HEAD");
     git_cmd(&["diff", &arg])
 }
 
@@ -122,7 +119,7 @@ pub fn get_current_branch() -> Result<String> {
     Ok(name)
 }
 
-/// Try to get repository info: (owner, repo_name, branch).
+/// Try to get repository info: (owner, `repo_name`, branch).
 /// Owner is derived from the remote URL if possible.
 pub fn get_repo_info() -> Result<(String, String, String)> {
     let repo = open_repo()?;
@@ -131,14 +128,14 @@ pub fn get_repo_info() -> Result<(String, String, String)> {
     let remote_url = repo
         .find_remote("origin")
         .ok()
-        .and_then(|r| r.url().map(|s| s.to_string()))
+        .and_then(|r| r.url().map(std::string::ToString::to_string))
         .unwrap_or_default();
 
     let (owner, repo_name) = parse_remote_url(&remote_url);
     Ok((owner, repo_name, branch))
 }
 
-/// Parse a remote URL into (owner, repo_name).
+/// Parse a remote URL into (owner, `repo_name`).
 fn parse_remote_url(url: &str) -> (String, String) {
     // Handle git@host:owner/repo.git, https://host/owner/repo.git, etc.
     let clean = url

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -22,9 +22,7 @@ fn validate_ref(ref_str: &str) -> Result<()> {
         // Since git refs shouldn't contain path components with "..", we reject refs
         // that start with ".." or contain "/.." or ".." at the end.
         if ref_str.starts_with("..") || ref_str.contains("/..") || ref_str.ends_with("..") {
-            anyhow::bail!(
-                "invalid ref '{ref_str}': contains path traversal sequence '..'"
-            );
+            anyhow::bail!("invalid ref '{ref_str}': contains path traversal sequence '..'");
         }
     }
 
@@ -33,9 +31,7 @@ fn validate_ref(ref_str: &str) -> Result<()> {
             .chars()
             .filter(|c| DANGEROUS_REF_CHARS.contains(c))
             .collect();
-        anyhow::bail!(
-            "invalid ref '{ref_str}': contains unsafe characters: '{found}'"
-        );
+        anyhow::bail!("invalid ref '{ref_str}': contains unsafe characters: '{found}'");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ struct GlobalOptions {
     #[clap(long, global = true, env = "CORA_BASE_URL")]
     pub base_url: Option<String>,
 
-    /// API key (or set CORA_API_KEY env var, or use `cora auth login`)
+    /// API key (or set `CORA_API_KEY` env var, or use `cora auth login`)
     #[clap(long, global = true, env = "CORA_API_KEY")]
     pub api_key: Option<String>,
 
@@ -137,7 +137,7 @@ enum Command {
         #[clap(long, env = "GITHUB_REF")]
         ref_name: Option<String>,
 
-        /// GitHub token for upload (default: GITHUB_TOKEN env var)
+        /// GitHub token for upload (default: `GITHUB_TOKEN` env var)
         #[clap(long, env = "GITHUB_TOKEN")]
         token: Option<String>,
     },
@@ -182,7 +182,7 @@ enum Command {
         #[clap(long, env = "GITHUB_REF")]
         ref_name: Option<String>,
 
-        /// GitHub token (default: GITHUB_TOKEN env var)
+        /// GitHub token (default: `GITHUB_TOKEN` env var)
         #[clap(long, env = "GITHUB_TOKEN")]
         token: Option<String>,
     },
@@ -244,7 +244,7 @@ enum AuthAction {
 enum ConfigAction {
     /// Show the current resolved configuration
     Show,
-    /// Set a configuration value (keys: model, provider, base_url, format, severity)
+    /// Set a configuration value (keys: model, provider, `base_url`, format, severity)
     Set {
         /// Configuration key to set
         key: String,
@@ -317,11 +317,11 @@ async fn main() -> Result<()> {
                     progress,
                     quiet,
                     severity,
-                    no_cache,
                     upload,
                     repo,
                     ref_name,
                     token,
+                    no_cache,
                 },
             )
             .await?
@@ -585,8 +585,6 @@ fn resolve_format(
     cli_format: Option<&str>,
     config: &crate::config::schema::Config,
 ) -> Result<OutputFormat> {
-    let fmt_str = cli_format
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| config.output.format.clone());
+    let fmt_str = cli_format.map_or_else(|| config.output.format.clone(), std::string::ToString::to_string);
     OutputFormat::from_str_loose(&fmt_str)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -585,6 +585,9 @@ fn resolve_format(
     cli_format: Option<&str>,
     config: &crate::config::schema::Config,
 ) -> Result<OutputFormat> {
-    let fmt_str = cli_format.map_or_else(|| config.output.format.clone(), std::string::ToString::to_string);
+    let fmt_str = cli_format.map_or_else(
+        || config.output.format.clone(),
+        std::string::ToString::to_string,
+    );
     OutputFormat::from_str_loose(&fmt_str)
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -116,7 +116,7 @@ impl ProgressReporter {
             return;
         }
         if let Ok(json) = serde_json::to_string(event) {
-            let _ = writeln!(std::io::stderr(), "{}", json);
+            let _ = writeln!(std::io::stderr(), "{json}");
         }
     }
 
@@ -124,12 +124,12 @@ impl ProgressReporter {
     pub fn started(&self, mode: &str, base: Option<&str>) {
         self.emit(&ProgressEvent::Started {
             mode: mode.to_string(),
-            base: base.map(|s| s.to_string()),
+            base: base.map(std::string::ToString::to_string),
             timestamp: Self::now_iso(),
         });
     }
 
-    /// Emit a "parsing_diff" event.
+    /// Emit a "`parsing_diff`" event.
     pub fn parsing_diff(&self, files_changed: usize, lines_changed: usize) {
         self.emit(&ProgressEvent::ParsingDiff {
             files_changed,
@@ -138,7 +138,7 @@ impl ProgressReporter {
         });
     }
 
-    /// Emit a "calling_llm" event.
+    /// Emit a "`calling_llm`" event.
     pub fn calling_llm(&self, provider: &str, model: &str) {
         self.emit(&ProgressEvent::CallingLlm {
             provider: provider.to_string(),
@@ -147,7 +147,7 @@ impl ProgressReporter {
         });
     }
 
-    /// Emit a "llm_response" event.
+    /// Emit a "`llm_response`" event.
     pub fn llm_response(&self, tokens: &TokenInfo, duration_ms: u64) {
         self.emit(&ProgressEvent::LlmResponse {
             tokens: tokens.clone(),
@@ -176,7 +176,7 @@ impl ProgressReporter {
     }
 }
 
-/// Extract diff statistics: (files_changed, lines_changed).
+/// Extract diff statistics: (`files_changed`, `lines_changed`).
 pub fn diff_stats(diff: &str) -> (usize, usize) {
     let mut files_changed = 0;
     let mut lines_changed = 0;

--- a/tests/config_loading.rs
+++ b/tests/config_loading.rs
@@ -11,7 +11,7 @@ fn cora_cmd() -> Command {
 /// Helper: write content to a temp file and return its path.
 fn write_temp_yaml(content: &str) -> NamedTempFile {
     let mut file = tempfile::Builder::new().suffix(".yaml").tempfile().unwrap();
-    write!(file, "{}", content).unwrap();
+    write!(file, "{content}").unwrap();
     file.flush().unwrap();
     file
 }
@@ -47,7 +47,7 @@ fn init_creates_valid_yaml() {
 
 #[test]
 fn config_file_with_custom_provider() {
-    let yaml = r#"
+    let yaml = r"
 provider:
   provider: anthropic
   model: claude-3-haiku
@@ -56,7 +56,7 @@ focus:
   - security
 output:
   format: json
-"#;
+";
     let file = write_temp_yaml(yaml);
 
     // Parse and verify using serde_yaml_ng directly
@@ -71,7 +71,7 @@ output:
 
 #[test]
 fn config_file_roundtrip_yaml() {
-    let yaml = r#"
+    let yaml = r"
 provider:
   provider: ollama
   model: llama3
@@ -83,7 +83,7 @@ ignore:
   files:
     - vendor/**
     - generated/**
-"#;
+";
     let file = write_temp_yaml(yaml);
     let content = std::fs::read_to_string(file.path()).unwrap();
 
@@ -112,10 +112,10 @@ fn config_file_empty_yaml_is_valid() {
 
 #[test]
 fn config_file_minimal_sections() {
-    let yaml = r#"
+    let yaml = r"
 focus:
   - security
-"#;
+";
     let file = write_temp_yaml(yaml);
     let content = std::fs::read_to_string(file.path()).unwrap();
     let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
@@ -126,11 +126,11 @@ focus:
 #[test]
 fn cli_uses_config_file_via_flag() {
     // Create a temp config and verify the CLI at least accepts the flag
-    let yaml = r#"
+    let yaml = r"
 provider:
   provider: test-provider
 model: test-model
-"#;
+";
     let file = write_temp_yaml(yaml);
 
     // We can't run a full review without an API key, but we can verify


### PR DESCRIPTION
## What
Auto-fix 104 of 175 clippy::pedantic warnings using `cargo clippy --fix`.

## Remaining (71)
Will be addressed in follow-up PRs:
- `format_push_string` (28) — needs manual `write!` conversion
- `assigning_clones` (11) — needs manual `clone_from()`
- `too_many_lines` (4) — function split or allow
- `float_cmp` (4) — test assertions, allow
- `cast_*` (4) — intentional casts, allow
- `manual_let_else` (4) — pattern conversion
- misc (16)

## Verification
- ✅ 224 tests pass
- ✅ `cargo clippy --all-targets -- -D warnings` clean
- ✅ `cargo fmt --all -- --check` clean

Partially closes #84