### PR TITLE
fix: resolve remaining clippy pedantic warnings (71→0)

### DIFF
--- a/src/commands/providers.rs
+++ b/src/commands/providers.rs
@@ -1,10 +1,9 @@
-use anyhow::Result;
 use colored::Colorize;
 
 use crate::config::providers::{PRESETS, detected_presets};
 
 /// Execute the `cora providers` subcommand.
-pub fn execute_providers() -> Result<()> {
+pub fn execute_providers() {
     let detected = detected_presets();
 
     println!("{}", "Available LLM Providers".bold().underline());
@@ -69,6 +68,4 @@ pub fn execute_providers() -> Result<()> {
             "   Using first detected. Set CORA_PROVIDER or use --provider to choose.".dimmed()
         );
     }
-
-    Ok(())
 }

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -13,6 +13,7 @@ pub const EXIT_OK: i32 = 0;
 pub const EXIT_BLOCKED: i32 = 2;
 
 /// Review command options.
+#[allow(clippy::struct_excessive_bools)]
 pub struct ReviewOptions {
     /// Review staged changes.
     pub staged: bool,
@@ -50,6 +51,7 @@ pub struct ReviewResult {
 ///
 /// Gets the diff, validates its size, calls the LLM engine, formats output,
 /// and returns the appropriate exit code along with the formatted output.
+#[allow(clippy::cast_possible_truncation)]
 pub async fn execute_review(
     config: &Config,
     llm_config: &crate::engine::LLMConfig,
@@ -116,6 +118,7 @@ pub async fn execute_review(
     {
         Ok(resp) => {
             if progress.is_enabled() {
+                // SAFETY: elapsed ms fits u64 for any reasonable review duration
                 let duration_ms = llm_start.elapsed().as_millis() as u64;
                 let tokens = resp
                     .tokens_used

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -28,6 +28,7 @@ pub struct ScanOptions {
 ///
 /// Walks the project directory, filters files, batches them, calls the LLM,
 /// and formats the output.
+#[allow(clippy::too_many_lines)]
 pub async fn execute_scan(
     config: &Config,
     llm_config: &crate::engine::LLMConfig,
@@ -67,9 +68,8 @@ pub async fn execute_scan(
         let root_abs = root.canonicalize().unwrap_or_else(|_| root.clone());
         files.retain(|f| {
             let abs_path = root_abs.join(&f.path);
-            let hash = match file_content_hash(&abs_path) {
-                Some(h) => h,
-                None => return true, // can't read file, rescan it
+            let Some(hash) = file_content_hash(&abs_path) else {
+                return true; // can't read file, rescan it
             };
             match cache.get(&root_abs, &f.path) {
                 Some(cached_hash) if cached_hash == hash => {
@@ -163,9 +163,8 @@ pub async fn execute_scan(
         let mut cache = ScanCache::load().unwrap_or_default();
         for f in &files {
             let abs_path = root_abs.join(&f.path);
-            let hash = match file_content_hash(&abs_path) {
-                Some(h) => h,
-                None => continue, // can't read file, skip cache entry
+            let Some(hash) = file_content_hash(&abs_path) else {
+                continue; // can't read file, skip cache entry
             };
             cache.set(&root_abs, &f.path, &hash);
         }
@@ -182,6 +181,7 @@ pub async fn execute_scan(
 
 /// Compute a short SHA256 hash of a file's content for incremental scanning.
 /// Returns None if the file cannot be read (caller should rescan it).
+#[allow(clippy::format_collect)]
 fn file_content_hash(path: &std::path::Path) -> Option<String> {
     use sha2::Digest;
     let bytes = std::fs::read(path).ok()?;

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -20,6 +20,7 @@ pub struct UploadOptions {
 ///
 /// Reads the SARIF content from the specified file or stdin, then POSTs it
 /// to the GitHub Code Scanning API.
+#[allow(clippy::items_after_statements, clippy::cast_precision_loss)]
 pub async fn execute_upload(opts: &UploadOptions) -> Result<i32> {
     let token = opts
         .token

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -75,10 +75,14 @@ fn load_global_config() -> Result<Option<CoraFile>> {
 /// - `api_key` → `~/.cora/auth.toml`
 /// - Delete the old file after successful migration.
 /// - Creates `.migrated` marker to prevent re-running.
+#[allow(
+    clippy::too_many_lines,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 fn migrate_old_config() {
-    let dir = match cora_dir() {
-        Ok(d) => d,
-        Err(_) => return,
+    let Ok(dir) = cora_dir() else {
+        return;
     };
     let old_path = dir.join(OLD_AUTH_FILENAME);
     if !old_path.is_file() {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -219,38 +219,39 @@ impl CoraFile {
     }
 
     /// Merge this file config into a `Config`, overwriting only fields that are present.
+    #[allow(clippy::assigning_clones)]
     pub fn merge_into(&self, config: &mut Config) {
         if let Some(p) = &self.provider {
             if let Some(v) = &p.provider {
-                config.provider.provider = v.clone();
+                config.provider.provider.clone_from(v);
             }
             if let Some(v) = &p.model {
-                config.provider.model = v.clone();
+                config.provider.model.clone_from(v);
             }
             if let Some(v) = &p.base_url {
-                config.provider.base_url = v.clone();
+                config.provider.base_url.clone_from(v);
             }
         }
         if let Some(v) = &self.focus {
-            config.focus = v.clone();
+            config.focus.clone_from(v);
         }
         if let Some(v) = &self.rules {
-            config.rules = v.clone();
+            config.rules.clone_from(v);
         }
         if let Some(ig) = &self.ignore {
             if let Some(v) = &ig.files {
-                config.ignore.files = v.clone();
+                config.ignore.files.clone_from(v);
             }
             if let Some(v) = &ig.rules {
-                config.ignore.rules = v.clone();
+                config.ignore.rules.clone_from(v);
             }
         }
         if let Some(h) = &self.hook {
             if let Some(v) = &h.mode {
-                config.hook.mode = v.clone();
+                config.hook.mode.clone_from(v);
             }
             if let Some(v) = &h.min_severity {
-                config.hook.min_severity = v.clone();
+                config.hook.min_severity.clone_from(v);
             }
             if let Some(v) = h.max_diff_size {
                 config.hook.max_diff_size = v;
@@ -258,7 +259,7 @@ impl CoraFile {
         }
         if let Some(o) = &self.output {
             if let Some(v) = &o.format {
-                config.output.format = v.clone();
+                config.output.format.clone_from(v);
             }
             if let Some(v) = o.color {
                 config.output.color = v;
@@ -266,7 +267,7 @@ impl CoraFile {
         }
         if let Some(r) = &self.review {
             if let Some(v) = &r.response_format {
-                config.response_format = v.clone();
+                config.response_format.clone_from(v);
             }
             if let Some(v) = &r.system_prompt {
                 config.review_system_prompt_override = Some(v.clone());
@@ -301,6 +302,7 @@ impl CoraFile {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/engine/cache.rs
+++ b/src/engine/cache.rs
@@ -14,6 +14,7 @@ fn cache_dir() -> Result<PathBuf> {
 
 /// Compute SHA-256 hex digest of the diff content + config parameters.
 /// Includes model and temperature so config changes invalidate the cache.
+#[allow(clippy::format_collect)]
 fn cache_key(diff: &str, model: &str, temperature: f32) -> String {
     let mut hasher = Sha256::new();
     hasher.update(diff.as_bytes());

--- a/src/engine/llm.rs
+++ b/src/engine/llm.rs
@@ -82,6 +82,7 @@ struct ChatChoice {
 /// (deserialization) even though only `total_tokens` is currently accessed.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
+#[allow(clippy::struct_field_names)]
 struct Usage {
     prompt_tokens: u32,
     completion_tokens: u32,
@@ -366,6 +367,7 @@ pub async fn review_diff_stream(
 ///
 /// Sends `"stream": true` in the request body, reads SSE chunks, prints
 /// delta content to stdout in real-time, and returns the full accumulated text.
+#[allow(clippy::too_many_lines)]
 async fn chat_completion_stream(
     config: &LLMConfig,
     system_prompt: &str,
@@ -494,6 +496,7 @@ async fn chat_completion_stream(
 }
 
 /// Scan a batch of file contents using the LLM. Returns issues found.
+#[allow(clippy::format_push_string)]
 pub async fn scan_files(
     llm_config: &LLMConfig,
     files_content: &str,
@@ -578,6 +581,7 @@ pub(crate) fn extract_file_paths_from_diff(diff: &str) -> Vec<String> {
 }
 
 /// Build the user prompt for diff review.
+#[allow(clippy::format_push_string)]
 fn build_review_prompt(diff: &str, focus: &[String], rules: &[String]) -> String {
     let mut prompt = String::new();
 
@@ -611,7 +615,7 @@ fn build_review_prompt(diff: &str, focus: &[String], rules: &[String]) -> String
 }
 
 /// Parse the LLM response into review issues.
-/// Handles: raw JSON array, JSON wrapped in ```json fences, array|||summary format.
+/// Handles: raw JSON array, JSON wrapped in markdown fences, array and summary format.
 pub(crate) fn parse_review_response(
     raw: &str,
 ) -> Result<(Vec<ReviewIssue>, String, Option<TokenUsage>)> {

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -9,9 +9,7 @@ use crate::engine::types::{LLMConfig, ReviewIssue, ReviewResponse};
 /// Returns the file content, or None if the file doesn't exist, can't be read,
 /// or is outside the project root (path traversal guard).
 fn load_system_prompt_file(path: &str) -> Option<String> {
-    let canonical = if let Ok(p) = std::fs::canonicalize(path) {
-        p
-    } else {
+    let Ok(canonical) = std::fs::canonicalize(path) else {
         tracing::debug!(path = path, "system_prompt_file does not exist");
         return None;
     };

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -30,6 +30,7 @@ const DEFAULT_EXTENSIONS: &[&str] = &[
 /// Uses `include` and `exclude` glob patterns to filter results.
 /// The `ignore` crate handles .gitignore (including nested), .git/info/exclude,
 /// and hidden-file filtering automatically.
+#[allow(clippy::unnecessary_wraps, clippy::format_push_string)]
 pub fn walk_project(
     root: &Path,
     include_patterns: &[String],
@@ -184,6 +185,7 @@ pub fn batch_files(files: &[FileEntry], max_chars: usize, max_files: usize) -> V
 }
 
 /// Format a batch of files for the LLM prompt.
+#[allow(clippy::format_push_string)]
 pub fn format_batch_for_prompt(files: &[FileEntry]) -> String {
     let mut output = String::new();
 

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -23,7 +23,7 @@ impl Severity {
     }
 
     /// Get the label text for this severity.
-    pub fn label(&self) -> &'static str {
+    pub fn label(self) -> &'static str {
         match self {
             Severity::Critical => "CRITICAL",
             Severity::Major => "MAJOR",
@@ -33,7 +33,7 @@ impl Severity {
     }
 
     /// Get the icon for this severity.
-    pub fn icon(&self) -> &'static str {
+    pub fn icon(self) -> &'static str {
         match self {
             Severity::Critical => "🔴",
             Severity::Major => "🟠",
@@ -97,8 +97,7 @@ impl IssueType {
                 IssueType::BestPractice
             }
             "style" | "formatting" => IssueType::Style,
-            "suggestion" | "info" => IssueType::Suggestion,
-            _ => IssueType::Suggestion, // fallback
+            _ => IssueType::Suggestion, // fallback (includes suggestion, info)
         }
     }
 }
@@ -121,6 +120,7 @@ pub struct ReviewIssue {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/formatters/compact.rs
+++ b/src/formatters/compact.rs
@@ -7,6 +7,7 @@ use crate::formatters::Formatter;
 /// Compact formatter: one line per issue. Ideal for git hooks.
 pub struct CompactFormatter;
 
+#[allow(clippy::format_push_string)]
 impl Formatter for CompactFormatter {
     fn format_review(&self, response: &ReviewResponse) -> Result<String> {
         let mut output = String::new();

--- a/src/formatters/pretty.rs
+++ b/src/formatters/pretty.rs
@@ -7,6 +7,7 @@ use crate::formatters::Formatter;
 /// Pretty formatter with colored terminal output and severity icons.
 pub struct PrettyFormatter;
 
+#[allow(clippy::format_push_string)]
 impl Formatter for PrettyFormatter {
     fn format_review(&self, response: &ReviewResponse) -> Result<String> {
         let mut output = String::new();
@@ -179,6 +180,7 @@ impl Formatter for PrettyFormatter {
 }
 
 /// Format a single issue with colors and icons.
+#[allow(clippy::format_push_string)]
 fn format_issue_pretty(issue: &ReviewIssue, num: usize) -> String {
     let mut out = String::new();
 

--- a/src/formatters/sarif.rs
+++ b/src/formatters/sarif.rs
@@ -137,8 +137,7 @@ fn build_sarif(issues: &[ReviewIssue]) -> Value {
 /// Map our severity to SARIF failure level.
 fn severity_to_sarif_level(severity: &Severity) -> &str {
     match severity {
-        Severity::Critical => "error",
-        Severity::Major => "error",
+        Severity::Critical | Severity::Major => "error",
         Severity::Minor => "warning",
         Severity::Info => "note",
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,7 @@ enum ConfigAction {
     },
 }
 
+#[allow(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -398,7 +399,7 @@ async fn main() -> Result<()> {
             }
         },
         Command::Providers => {
-            providers::execute_providers()?;
+            providers::execute_providers();
             0
         }
         Command::Completion { shell } => {
@@ -411,6 +412,7 @@ async fn main() -> Result<()> {
 }
 
 /// Struct to hold review options from CLI.
+#[allow(clippy::struct_excessive_bools)]
 struct ReviewOpts {
     staged: bool,
     unpushed: bool,
@@ -517,6 +519,7 @@ async fn cmd_review(globals: &GlobalOptions, opts: ReviewOpts) -> Result<i32> {
 }
 
 /// Upload a SARIF string to GitHub Code Scanning.
+#[allow(clippy::ref_option)]
 async fn upload_sarif_content(
     sarif_content: &str,
     repo: &Option<String>,


### PR DESCRIPTION
Completes #84 — zero clippy::pedantic warnings remaining.

**Summary:** All 71 remaining pedantic warnings resolved:
- **Fixed:** clone_from, let...else, self by value, match arm merge
- **Allowed with reason:** too_many_lines (4), struct_excessive_bools (2), format_push_string (28), format_collect (2), float_cmp (4 tests), unnecessary_wraps, items_after_statements, ref_option, doc_backticks, casts (2), struct_field_names

**Checks:** 224 tests ✅, clippy pedantic 0 warnings ✅, fmt clean ✅