### PR TITLE
chore(ci): bump actions & add Node 24 readiness

### DIFF
--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -53,7 +53,7 @@ runs:
           done
           if [ -z "$VERSION" ]; then
             echo "::warning::Failed to resolve latest cora-cli version from GitHub API, using fallback"
-            VERSION="v0.1.7"
+            VERSION="v0.2.0"
           fi
         else
           VERSION="$INPUT_VERSION"

--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -116,10 +116,16 @@ runs:
           --format sarif \
           --severity "$INPUT_SEVERITY" \
           --quiet \
-          > cora-results.sarif 2>cora-stderr.log || true
-        echo "Cora review complete ($(wc -c < cora-results.sarif) bytes)"
+          > cora-results.sarif 2>cora-stderr.log; EXIT_CODE=$?
+        SARIF_BYTES=$(wc -c < cora-results.sarif)
+        echo "Cora review complete ($SARIF_BYTES bytes, exit=$EXIT_CODE)"
         if [ -s cora-stderr.log ]; then
           echo "::warning::Cora stderr: $(cat cora-stderr.log)"
+        fi
+        # Fail if cora exited non-zero AND produced empty result (LLM API failure)
+        if [ "$EXIT_CODE" -ne 0 ] && [ "$SARIF_BYTES" -lt 10 ]; then
+          echo "::error::Cora review failed (exit=$EXIT_CODE, $SARIF_BYTES bytes). LLM API may be unavailable."
+          exit 1
         fi
 
     - name: Upload SARIF to GitHub Code Scanning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-release:
@@ -78,7 +79,7 @@ jobs:
           7z a ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }} ${{ matrix.artifact }}.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}
           path: release/${{ matrix.artifact }}-${{ steps.version.outputs.VERSION }}.${{ matrix.ext }}


### PR DESCRIPTION
## Summary

Sync CI action versions with uteke (latest):

| Change | Before | After |
|--------|--------|-------|
| `actions/upload-artifact` | `@v4` | `@v7` |
| `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` | missing | `true` (ci.yml + release.yml) |
| cora-review fallback version | `v0.1.7` | `v0.2.0` |

**Why:** GitHub will force Node.js 24 migration by June 16, 2026. `upload-artifact@v4` is deprecated and incompatible with Node 24.

> ⚠️ Cora flagged `upload-artifact@v7` as "does not exist" — this is a **false positive** (LLM knowledge cutoff). Latest release is [v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1).

**Note:** Infisical OIDC adoption is deferred — needs Infisical trust relationship setup for `codecoradev/cora-cli` org first.

Co-Authored-By: codecoradev <noreply@github.com>