### PR TITLE
fix: skip SARIF upload when no findings

### DIFF
--- a/.github/actions/cora-review-simple/action.yml
+++ b/.github/actions/cora-review-simple/action.yml
@@ -93,8 +93,29 @@ runs:
           > cora-results.sarif 2>/dev/null
         echo "Cora review complete ($(wc -c < cora-results.sarif) bytes)"
 
-    - name: Upload SARIF to GitHub Code Scanning
+    - name: Check SARIF for findings
+      id: sarif-check
       if: inputs.upload-sarif == 'true'
+      shell: bash
+      run: |
+        RESULTS=$(python3 -c "
+        import json, sys
+        try:
+            data = json.load(open('cora-results.sarif'))
+            results = data.get('runs', [{}])[0].get('results', [])
+            print(len(results))
+        except:
+            print(0)
+        " 2>/dev/null || echo "0")
+        echo "results=$RESULTS" >> "$GITHUB_OUTPUT"
+        if [ "$RESULTS" -gt 0 ]; then
+          echo "SARIF contains $RESULTS finding(s) — will upload."
+        else
+          echo "SARIF has no findings — skipping upload."
+        fi
+
+    - name: Upload SARIF to GitHub Code Scanning
+      if: inputs.upload-sarif == 'true' && steps.sarif-check.outputs.results > 0
       continue-on-error: true
       uses: github/codeql-action/upload-sarif@v4
       with:

--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -128,8 +128,29 @@ runs:
           exit 1
         fi
 
-    - name: Upload SARIF to GitHub Code Scanning
+    - name: Check SARIF for findings
+      id: sarif-check
       if: inputs.upload-sarif == 'true'
+      shell: bash
+      run: |
+        RESULTS=$(python3 -c "
+        import json, sys
+        try:
+            data = json.load(open('cora-results.sarif'))
+            results = data.get('runs', [{}])[0].get('results', [])
+            print(len(results))
+        except:
+            print(0)
+        " 2>/dev/null || echo "0")
+        echo "results=$RESULTS" >> "$GITHUB_OUTPUT"
+        if [ "$RESULTS" -gt 0 ]; then
+          echo "SARIF contains $RESULTS finding(s) — will upload."
+        else
+          echo "SARIF has no findings — skipping upload."
+        fi
+
+    - name: Upload SARIF to GitHub Code Scanning
+      if: inputs.upload-sarif == 'true' && steps.sarif-check.outputs.results > 0
       continue-on-error: true
       uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
       with:


### PR DESCRIPTION
## Summary

CodeCora check shows ❌ fail on clean PRs because SARIF is always uploaded to GitHub Code Scanning — even when cora found **zero issues**.

### Fix

Add a `sarif-check` step before upload that parses SARIF and counts findings. The `upload-sarif` step now only runs when `findings > 0`:

```yaml
- name: Check SARIF for findings
  id: sarif-check
  run: |
    RESULTS=$(python3 -c "parse sarif, count results")
    echo "results=$RESULTS" >> "$GITHUB_OUTPUT"

- name: Upload SARIF to GitHub Code Scanning
  if: inputs.upload-sarif == 'true' && steps.sarif-check.outputs.results > 0
  uses: github/codeql-action/upload-sarif@v4
```

### Behavior Change

| Scenario | Before | After |
|---|---|---|
| PR with issues | SARIF uploaded ✅, CodeCora ❌ (expected) | SARIF uploaded ✅, CodeCora ❌ (expected) |
| Clean PR (no issues) | SARIF uploaded ✅, CodeCora ❌ (false fail) | SARIF **skipped**, no CodeCora check |
| LLM API failure | SARIF empty, CodeCora ❌ (false fail) | SARIF **skipped**, no CodeCora check |

### Files Modified
- `.github/actions/cora-review/action.yml` — add sarif-check + conditional upload
- `.github/actions/cora-review-simple/action.yml` — same fix

Co-Authored-By: codecoradev <noreply@github.com>