### PR TITLE
fix: enable Cora Review on PRs to main branch

### DIFF
--- a/.github/workflows/cora-review.yml
+++ b/.github/workflows/cora-review.yml
@@ -2,7 +2,7 @@ name: Cora AI Code Review
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
     types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:


### PR DESCRIPTION
## Why

`main` has branch protection requiring `Cora Review` check, but `cora-review.yml` only triggers on PRs to `develop`. This causes PR #155 (develop → main sync) to be blocked with no way to satisfy the required check.

## Change

- `cora-review.yml`: added `main` to `pull_request.branches` list