### PR TITLE
feat: tiered auth login, configurable CI, updated docs

### DIFF
--- a/.github/actions/cora-review/action.yml
+++ b/.github/actions/cora-review/action.yml
@@ -109,14 +109,24 @@ runs:
         INPUT_BASE: ${{ inputs.base-branch }}
         INPUT_SEVERITY: ${{ inputs.severity }}
       run: |
-        # Set higher diff limit for CI (default 50K is too small for large PRs)
-        printf 'hook:\n  max_diff_size: 200000\n' > .cora-ci.yaml
-        CORA_CONFIG=".cora-ci.yaml" cora review \
-          --base "$INPUT_BASE" \
-          --format sarif \
-          --severity "$INPUT_SEVERITY" \
-          --quiet \
-          > cora-results.sarif 2>cora-stderr.log; EXIT_CODE=$?
+        # Use project .cora.yaml if it exists; otherwise create a CI-friendly fallback
+        if [ ! -f .cora.yaml ]; then
+          printf 'hook:\n  max_diff_size: 5242880\n' > .cora-ci.yaml
+          CORA_CONFIG=".cora-ci.yaml" cora review \
+            --base "$INPUT_BASE" \
+            --format sarif \
+            --severity "$INPUT_SEVERITY" \
+            --quiet \
+            > cora-results.sarif 2>cora-stderr.log; EXIT_CODE=$?
+        else
+          echo "Using project .cora.yaml for configuration"
+          cora review \
+            --base "$INPUT_BASE" \
+            --format sarif \
+            --severity "$INPUT_SEVERITY" \
+            --quiet \
+            > cora-results.sarif 2>cora-stderr.log; EXIT_CODE=$?
+        fi
         SARIF_BYTES=$(wc -c < cora-results.sarif)
         echo "Cora review complete ($SARIF_BYTES bytes, exit=$EXIT_CODE)"
         if [ -s cora-stderr.log ]; then

--- a/README.md
+++ b/README.md
@@ -87,37 +87,42 @@ cargo install --path .
 
 ## 🚀 Quick Start
 
-### 1. Set Your API Key
+### 1. Install
 
 ```bash
-export OPENAI_API_KEY="sk-..."
-# or
-export ANTHROPIC_API_KEY="sk-ant-..."
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 ```
 
-### 2. Initialize Config (Optional)
+### 2. Set Up Authentication
+
+```bash
+cora auth login
+```
+
+Pick your provider, enter your API key — done. Cora stores it securely in `~/.cora/auth.toml` (never committed to git).
+
+> **No API key yet?** Set any provider env var instead: `export OPENAI_API_KEY="..."`
+
+### 3. Review Your Code
+
+```bash
+# Review staged changes
+cora review
+
+# Review vs a branch
+cora review --base origin/main
+
+# Review the last commit
+cora review --commit HEAD
+```
+
+### 4. Optional — Project Config
 
 ```bash
 cora init
 ```
 
-### 3. Review Staged Changes
-
-```bash
-cora review --staged
-```
-
-### 4. Review the Last Commit
-
-```bash
-cora review --commit HEAD
-```
-
-### 5. Scan the Entire Project
-
-```bash
-cora scan
-```
+Creates `.cora.yaml` in your project root for custom settings (focus areas, ignore patterns, hook config). The CI action automatically reads this file.
 
 ## 📖 Commands
 
@@ -324,15 +329,67 @@ output:
 
 ### Authentication
 
-API keys can be provided via environment variable (`CORA_API_KEY`), provider-specific env vars (`OPENAI_API_KEY`, etc.), or stored in `~/.cora/auth.toml` (auto-created by `cora auth login`, permission `0600`).
+API keys can be provided via environment variables, stored in `~/.cora/auth.toml` (auto-created by `cora auth login`, permission `0600`), or passed via CLI flags.
+
+#### Interactive Login (Recommended)
 
 ```bash
-# Interactive login (stores key in ~/.cora/auth.toml)
 cora auth login
-
-# Or set via environment variable
-export CORA_API_KEY=sk-...
 ```
+
+This starts an interactive setup that:
+
+1. **Lists known providers** — OpenAI, Anthropic, Groq, Ollama, Z.AI
+2. **Lets you pick one** — known providers only need an API key
+3. **Or choose "custom"** — enter your own base URL, model, and API key for any OpenAI-compatible endpoint
+
+Example flow:
+
+```
+$ cora auth login
+
+🔑 Cora Auth Setup
+   Choose your LLM provider:
+
+  [1] openai — https://api.openai.com/v1 (model: gpt-4o-mini)
+  [2] anthropic — https://api.anthropic.com/v1 (model: claude-3-haiku-20240307)
+  [3] groq — https://api.groq.com/openai/v1 (model: llama-3.1-8b-instant)
+  [4] ollama — http://localhost:11434/v1 (model: llama3.1)
+  [5] zai — https://api.z.ai/api/coding/paas/v4 (model: glm-5.1)
+  [6] custom — use any OpenAI-compatible endpoint
+
+  Select provider [1-6]: 1
+
+  → Provider: openai
+  → Model: gpt-4o-mini
+  → Base URL: https://api.openai.com/v1
+
+  🔑 Enter your API key: sk-...
+
+✅ API key saved to ~/.cora/auth.toml
+   Provider: openai | Model: gpt-4o-mini | Base: https://api.openai.com/v1
+```
+
+#### Check Auth Status
+
+```bash
+cora auth status
+```
+
+Shows your configured provider, model, and key source.
+
+#### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CORA_API_KEY` | API key (overrides all other sources) |
+| `OPENAI_API_KEY` | OpenAI API key (auto-detected) |
+| `ANTHROPIC_API_KEY` | Anthropic API key (auto-detected) |
+| `GROQ_API_KEY` | Groq API key (auto-detected) |
+| `ZAI_API_KEY` | Z.AI API key (auto-detected) |
+| `CORA_PROVIDER` | Override provider name |
+| `CORA_MODEL` | Override model |
+| `CORA_BASE_URL` | Override API base URL |
 
 ## 🔗 CI/CD Integration
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -4,8 +4,9 @@ use anyhow::Result;
 use colored::Colorize;
 
 use crate::config::loader;
+use crate::config::providers::PRESETS;
 
-/// Execute `auth login` — prompt for API key and save it.
+/// Execute `auth login` — interactive tiered provider selection and API key setup.
 pub fn execute_auth_login() -> Result<()> {
     // Check if already logged in
     let status = loader::auth_status()?;
@@ -26,7 +27,97 @@ pub fn execute_auth_login() -> Result<()> {
         }
     }
 
-    print!("🔑 Enter your API key: ");
+    println!();
+    println!("{}", "🔑 Cora Auth Setup".bold());
+    println!("{}", "   Choose your LLM provider:".dimmed());
+    println!();
+
+    // List known providers
+    for (i, preset) in PRESETS.iter().enumerate() {
+        println!(
+            "  {} {} — {} (model: {})",
+            format!("[{}]", i + 1).cyan().bold(),
+            preset.name.bold(),
+            preset.default_base_url.dimmed(),
+            preset.default_model.dimmed(),
+        );
+    }
+    // Custom option
+    println!(
+        "  {} {} — use any OpenAI-compatible endpoint",
+        format!("[{}]", PRESETS.len() + 1).cyan().bold(),
+        "custom".bold(),
+    );
+    println!();
+
+    print!(
+        "  {} ",
+        format!("Select provider [1-{}]:", PRESETS.len() + 1).bold()
+    );
+    io::stdout().flush()?;
+
+    let mut choice = String::new();
+    io::stdin().read_line(&mut choice)?;
+    let choice_num: usize = choice
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid choice — enter a number"))?;
+
+    if choice_num == 0 || choice_num > PRESETS.len() + 1 {
+        anyhow::bail!(
+            "Invalid choice — pick a number between 1 and {}",
+            PRESETS.len() + 1
+        );
+    }
+
+    let (provider, base_url, model) = if choice_num <= PRESETS.len() {
+        // Known provider — just need API key
+        let preset = &PRESETS[choice_num - 1];
+        println!();
+        println!(
+            "  {} {} ({})",
+            "→".green(),
+            "Provider:".bold(),
+            preset.name.green()
+        );
+        println!(
+            "  {} {} ({})",
+            "→".green(),
+            "Model:".bold(),
+            preset.default_model.green()
+        );
+        println!(
+            "  {} {} ({})",
+            "→".green(),
+            "Base URL:".bold(),
+            preset.default_base_url.dimmed()
+        );
+        println!();
+        (
+            preset.name.to_string(),
+            preset.default_base_url.to_string(),
+            preset.default_model.to_string(),
+        )
+    } else {
+        // Custom provider — collect all details
+        println!();
+        println!("  {} {}", "→".green(), "Custom provider setup".bold());
+        println!();
+
+        let provider = prompt_input("  Provider name (e.g. my-llm):")?;
+        let base_url = prompt_input("  Base URL (e.g. https://api.example.com/v1):")?;
+        let model = prompt_input("  Default model (e.g. gpt-4o):")?;
+
+        if provider.is_empty() || base_url.is_empty() || model.is_empty() {
+            anyhow::bail!("Provider name, base URL, and model are required for custom providers");
+        }
+
+        (provider, base_url, model)
+    };
+
+    // Collect API key
+    println!();
+    print!("  🔑 Enter your API key: ");
     io::stdout().flush()?;
 
     let mut key = String::new();
@@ -37,35 +128,80 @@ pub fn execute_auth_login() -> Result<()> {
         anyhow::bail!("API key cannot be empty");
     }
 
+    // Save API key + provider info
     loader::save_api_key(&key)?;
-    println!("{} API key saved to ~/.cora/auth.toml", "✅".green().bold());
+    loader::save_provider_info(&provider, &base_url, &model)?;
+
+    println!();
+    println!(
+        "{} API key saved to {}",
+        "✅".green().bold(),
+        "~/.cora/auth.toml".green()
+    );
+    println!(
+        "{} Provider: {} | Model: {} | Base: {}",
+        "   ".dimmed(),
+        provider.bold(),
+        model.bold(),
+        base_url.dimmed()
+    );
     println!(
         "{}",
         "   This file is local to your machine and not committed to git.".dimmed()
+    );
+    println!();
+    println!(
+        "{} Run {} to verify, or {} to start reviewing.",
+        "Next:".bold(),
+        "cora auth status".cyan(),
+        "cora review".cyan()
     );
 
     Ok(())
 }
 
-/// Execute `auth status` — show whether an API key is configured.
+/// Prompt for a non-empty string with label.
+fn prompt_input(label: &str) -> Result<String> {
+    print!("{} ", label);
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(input.trim().to_string())
+}
+
+/// Execute `auth status` — show whether an API key is configured and which provider.
 pub fn execute_auth_status() -> Result<()> {
     let status = loader::auth_status()?;
 
     if status.has_key {
         println!("{} API key is configured.", "✅".green().bold());
         println!("   Source: {}", status.source);
+
+        // Show stored provider info if available
+        if let Some(info) = loader::load_provider_info()? {
+            println!();
+            println!("   {} {}", "Provider:".bold(), info.provider.green());
+            println!("   {} {}", "Model:".bold(), info.model.green());
+            println!("   {} {}", "Base URL:".bold(), info.base_url.dimmed());
+        } else {
+            println!(
+                "   {} No provider info stored — run {} to set up",
+                "ℹ️".yellow(),
+                "cora auth login".cyan()
+            );
+        }
     } else {
         println!("{} No API key configured.", "❌".red().bold());
         println!("   Set it via:");
+        println!("     • {} (interactive setup)", "cora auth login".cyan());
         println!("     • CORA_API_KEY environment variable");
-        println!("     • `cora auth login` command");
-        println!("     • `cora review --api-key <key>` flag");
+        println!("     • Provider-specific env vars: OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.");
     }
 
     Ok(())
 }
 
-/// Execute `auth remove` — delete the stored API key.
+/// Execute `auth remove` — delete the stored API key and provider info.
 pub fn execute_auth_remove() -> Result<()> {
     let status = loader::auth_status()?;
     if !status.has_key && std::env::var("CORA_API_KEY").is_err() {
@@ -74,7 +210,11 @@ pub fn execute_auth_remove() -> Result<()> {
     }
 
     loader::remove_api_key()?;
-    println!("{} API key removed from local config.", "✅".green().bold());
+    loader::remove_provider_info()?;
+    println!(
+        "{} API key and provider info removed from local config.",
+        "✅".green().bold()
+    );
     println!(
         "{}",
         "   If you set CORA_API_KEY in your shell, remove it there too.".dimmed()

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -478,3 +478,134 @@ pub struct AuthStatus {
     pub source: String,
     pub has_key: bool,
 }
+
+/// Stored provider information alongside the API key.
+#[derive(Debug, Clone)]
+pub struct ProviderInfo {
+    pub provider: String,
+    pub base_url: String,
+    pub model: String,
+}
+
+/// Save provider info (name, base_url, model) to `~/.cora/auth.toml`
+/// alongside the existing `api_key`.
+pub fn save_provider_info(
+    provider: &str,
+    base_url: &str,
+    model: &str,
+) -> std::result::Result<(), CoraError> {
+    let dir = cora_dir()?;
+    let path = dir.join(AUTH_FILENAME);
+
+    // Read existing auth.toml or start fresh
+    let mut table = if path.is_file() {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| CoraError::AuthError(format!("{}: {}", path.display(), e)))?;
+        content
+            .parse::<toml::Table>()
+            .unwrap_or_else(|_| toml::Table::new())
+    } else {
+        toml::Table::new()
+    };
+
+    // Set provider info fields
+    table.insert(
+        "provider".to_string(),
+        toml::Value::String(provider.to_string()),
+    );
+    table.insert(
+        "base_url".to_string(),
+        toml::Value::String(base_url.to_string()),
+    );
+    table.insert("model".to_string(), toml::Value::String(model.to_string()));
+
+    let content = table.to_string();
+    std::fs::write(&path, content)
+        .map_err(|e| CoraError::AuthError(format!("{}: {}", path.display(), e)))?;
+
+    // Restrict permissions to owner only (0o600)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(&path, perms)?;
+    }
+
+    debug!(provider = provider, "saved provider info");
+    Ok(())
+}
+
+/// Load stored provider info from `~/.cora/auth.toml`.
+/// Returns `None` if no provider info is stored.
+pub fn load_provider_info() -> std::result::Result<Option<ProviderInfo>, CoraError> {
+    let dir = cora_dir()?;
+    let path = dir.join(AUTH_FILENAME);
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| CoraError::AuthError(format!("{}: {}", path.display(), e)))?;
+
+    let table: toml::Table = content
+        .parse::<toml::Table>()
+        .map_err(|e| CoraError::AuthError(format!("invalid TOML: {}", e)))?;
+
+    let provider = table
+        .get("provider")
+        .and_then(toml::Value::as_str)
+        .unwrap_or("");
+    let base_url = table
+        .get("base_url")
+        .and_then(toml::Value::as_str)
+        .unwrap_or("");
+    let model = table
+        .get("model")
+        .and_then(toml::Value::as_str)
+        .unwrap_or("");
+
+    if provider.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(ProviderInfo {
+        provider: provider.to_string(),
+        base_url: base_url.to_string(),
+        model: model.to_string(),
+    }))
+}
+
+/// Remove stored provider info from `~/.cora/auth.toml` while keeping the api_key if present.
+pub fn remove_provider_info() -> std::result::Result<(), CoraError> {
+    let dir = cora_dir()?;
+    let path = dir.join(AUTH_FILENAME);
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| CoraError::AuthError(format!("{}: {}", path.display(), e)))?;
+
+    let mut table: toml::Table = content
+        .parse::<toml::Table>()
+        .map_err(|e| CoraError::AuthError(format!("invalid TOML: {}", e)))?;
+
+    let changed = table.remove("provider").is_some()
+        | table.remove("base_url").is_some()
+        | table.remove("model").is_some();
+
+    if changed {
+        // If only provider info was left (no api_key), just delete the file
+        if table.is_empty() {
+            std::fs::remove_file(&path)
+                .map_err(|e| CoraError::AuthError(format!("{}: {}", path.display(), e)))?;
+        } else {
+            let content = table.to_string();
+            std::fs::write(&path, content)
+                .map_err(|e| CoraError::AuthError(format!("{}: {}", path.display(), e)))?;
+        }
+        debug!("removed provider info from auth.toml");
+    }
+
+    Ok(())
+}

--- a/website/src/routes/docs/getting-started/+page.svelte
+++ b/website/src/routes/docs/getting-started/+page.svelte
@@ -28,38 +28,107 @@
 
 <div class="docs-section scroll-reveal">
 	<h2>Quick Start</h2>
-	<p>Get up and running with cora in four simple steps.</p>
+	<p>Get up and running with cora in three simple steps.</p>
 
 	<div class="docs-card">
 		<div class="docs-card-number primary">1</div>
 		<div class="text-sm text-[var(--muted-foreground)]">
-			<strong class="text-[var(--foreground)]">Install cora</strong> — Single binary via Cargo:
-			<code>cargo install cora-cli</code>
+			<strong class="text-[var(--foreground)]">Install cora</strong> — Single binary, no runtime dependencies:
+			<code>curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh</code>
 		</div>
 	</div>
 
 	<div class="docs-card">
 		<div class="docs-card-number primary">2</div>
 		<div class="text-sm text-[var(--muted-foreground)]">
-			<strong class="text-[var(--foreground)]">Configure</strong> — Initialize your project:
-			<code>cora init</code> creates <code>.cora.yaml</code>
+			<strong class="text-[var(--foreground)]">Authenticate</strong> — Run <code>cora auth login</code> to pick your provider and enter your API key.
+			Cora stores it securely in <code>~/.cora/auth.toml</code> (never committed to git).
 		</div>
 	</div>
 
 	<div class="docs-card">
 		<div class="docs-card-number primary">3</div>
 		<div class="text-sm text-[var(--muted-foreground)]">
-			<strong class="text-[var(--foreground)]">Add API key</strong> — Run <code>cora auth login</code> or set <code>CORA_API_KEY</code> environment variable
-		</div>
-	</div>
-
-	<div class="docs-card">
-		<div class="docs-card-number primary">4</div>
-		<div class="text-sm text-[var(--muted-foreground)]">
 			<strong class="text-[var(--foreground)]">Review</strong> — Analyze your staged changes:
 			<code>cora review</code>
 		</div>
 	</div>
+</div>
+
+<div class="docs-section scroll-reveal">
+	<h2>Authentication — <code>cora auth login</code></h2>
+	<p>
+		The interactive login guides you through provider selection:
+	</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span class="terminal-dot-red"></span>
+			<span class="terminal-dot-yellow"></span>
+			<span class="terminal-dot-green"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span class="syntax-cmd">$</span> <span class="syntax-highlight">cora auth login</span></div>
+			<div></div>
+			<div><span class="syntax-cmd">🔑 Cora Auth Setup</span></div>
+			<div>   Choose your LLM provider:</div>
+			<div></div>
+			<div>  <span class="syntax-flag">[1]</span> <span class="syntax-highlight">openai</span> — https://api.openai.com/v1</div>
+			<div>  <span class="syntax-flag">[2]</span> <span class="syntax-highlight">anthropic</span> — https://api.anthropic.com/v1</div>
+			<div>  <span class="syntax-flag">[3]</span> <span class="syntax-highlight">groq</span> — https://api.groq.com/openai/v1</div>
+			<div>  <span class="syntax-flag">[4]</span> <span class="syntax-highlight">ollama</span> — http://localhost:11434/v1</div>
+			<div>  <span class="syntax-flag">[5]</span> <span class="syntax-highlight">zai</span> — https://api.z.ai/api/coding/paas/v4</div>
+			<div>  <span class="syntax-flag">[6]</span> <span class="syntax-highlight">custom</span> — any OpenAI-compatible endpoint</div>
+			<div></div>
+			<div>  Select provider [1-6]: <span class="syntax-string">1</span></div>
+			<div></div>
+			<div>  → Provider: <span class="syntax-success">openai</span></div>
+			<div>  → Model: <span class="syntax-success">gpt-4o-mini</span></div>
+			<div>  → Base URL: https://api.openai.com/v1</div>
+			<div></div>
+			<div>  🔑 Enter your API key: <span class="syntax-string">****</span></div>
+			<div></div>
+			<div><span class="syntax-success">✅</span> API key saved to ~/.cora/auth.toml</div>
+		</div>
+	</div>
+
+	<div class="docs-term-list">
+		<div class="docs-term-item">
+			<span class="docs-term-key">Known providers</span>
+			<span>Just enter your API key — model and base URL are pre-configured</span>
+		</div>
+		<div class="docs-term-item">
+			<span class="docs-term-key">Custom provider</span>
+			<span>Enter your own base URL, model name, and API key for any OpenAI-compatible API</span>
+		</div>
+		<div class="docs-term-item">
+			<span class="docs-term-key">Provider info stored</span>
+			<span>Provider name, model, and base URL are saved alongside your API key for easy reference</span>
+		</div>
+	</div>
+
+	<p>Check your auth status anytime:</p>
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span class="terminal-dot-red"></span>
+			<span class="terminal-dot-yellow"></span>
+			<span class="terminal-dot-green"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span class="syntax-cmd">$</span> <span class="syntax-highlight">cora auth status</span></div>
+			<div><span class="syntax-success">✅</span> API key is configured.</div>
+			<div>   Source: ~/.cora/auth.toml</div>
+			<div></div>
+			<div>   <span class="syntax-flag">Provider:</span> <span class="syntax-success">openai</span></div>
+			<div>   <span class="syntax-flag">Model:</span> <span class="syntax-success">gpt-4o-mini</span></div>
+			<div>   <span class="syntax-flag">Base URL:</span> https://api.openai.com/v1</div>
+		</div>
+	</div>
+
+	<p>
+		You can also use environment variables instead of <code>cora auth login</code>:
+		<code>CORA_API_KEY</code>, <code>OPENAI_API_KEY</code>, <code>ANTHROPIC_API_KEY</code>, etc.
+	</p>
 </div>
 
 <div class="docs-section scroll-reveal">
@@ -109,8 +178,11 @@
 </div>
 
 <div class="docs-section scroll-reveal">
-	<h2>Customizing Your Review</h2>
-	<p>The <code>.cora.yaml</code> file controls how cora reviews your code.</p>
+	<h2>Project Configuration — <code>cora init</code></h2>
+	<p>
+		Create a <code>.cora.yaml</code> config file in your project root to customize review settings.
+		The CI action automatically reads this file when it exists.
+	</p>
 
 	<div class="docs-terminal">
 		<div class="terminal-bar">
@@ -119,26 +191,24 @@
 			<span class="terminal-dot-green"></span>
 		</div>
 		<div class="terminal-body">
-			<div><span class="syntax-comment"># .cora.yaml</span></div>
-			<div><span class="syntax-highlight">review:</span></div>
-			<div>  <span class="syntax-flag">severity:</span> <span class="syntax-string">warning</span></div>
-			<div>  <span class="syntax-flag">focus:</span> <span class="syntax-string">security,performance</span></div>
-			<div></div>
-			<div><span class="syntax-highlight">providers:</span></div>
-			<div>  <span class="syntax-flag">openai:</span></div>
-			<div>    <span class="syntax-flag">model:</span> <span class="syntax-string">gpt-4o</span></div>
+			<div><span class="syntax-cmd">$</span> <span class="syntax-highlight">cora init</span></div>
+			<div><span class="syntax-success">✅</span> Created .cora.yaml with example configuration.</div>
 		</div>
 	</div>
 
+	<p>Key configuration options:</p>
 	<div class="docs-term-list">
 		<div class="text-sm text-[var(--muted-foreground)]">
-			<span class="docs-term-key">review.severity</span> — Minimum severity level (info, minor, major, critical)
+			<span class="docs-term-key">focus</span> — Review focus areas: security, performance, bugs, best_practice
 		</div>
 		<div class="text-sm text-[var(--muted-foreground)]">
-			<span class="docs-term-key">review.focus</span> — Focus areas for review (e.g., security, performance)
+			<span class="docs-term-key">ignore</span> — File patterns and rules to skip
 		</div>
 		<div class="text-sm text-[var(--muted-foreground)]">
-			<span class="docs-term-key">providers</span> — Provider-specific model overrides (openai, anthropic, groq, ollama, zai)
+			<span class="docs-term-key">hook</span> — Pre-commit hook settings: mode, severity threshold, max diff size
+		</div>
+		<div class="text-sm text-[var(--muted-foreground)]">
+			<span class="docs-term-key">llm</span> — LLM parameters: temperature, max_tokens, timeout
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

Three improvements to cora-cli auth and CI experience:

### 1. Configurable CI Action
- CI action now reads `.cora.yaml` from the repo when it exists
- Falls back to 5MB limit when no `.cora.yaml` is present
- Removes hardcoded `max_diff_size: 200000` that was too small for large PRs

### 2. Tiered `cora auth login`
- Interactive provider selection with numbered menu
- **Known providers** (openai, anthropic, groq, ollama, zai): just API key needed — model and base URL pre-configured
- **Custom provider**: collect base URL, model, and API key for any OpenAI-compatible endpoint
- Provider info (name, model, base_url) stored alongside API key in `~/.cora/auth.toml`

### 3. Updated `cora auth status`
- Now displays stored provider name, model, and base URL
- Clearer guidance when no auth is configured

### 4. Documentation Updates
- **README**: Rewrote Quick Start and Authentication sections with full interactive login tutorial
- **Website docs**: Updated getting-started page with auth flow examples, provider selection guide, and project config section

## Files Changed
| File | Change |
|------|--------|
| `.github/actions/cora-review/action.yml` | Read `.cora.yaml` from repo, fallback to CI defaults |
| `src/commands/auth.rs` | Tiered interactive login with provider menu |
| `src/config/loader.rs` | `save_provider_info()`, `load_provider_info()`, `remove_provider_info()` |
| `README.md` | Updated Quick Start, Authentication sections |
| `website/src/routes/docs/getting-started/+page.svelte` | Full auth tutorial |

## Testing
- 353 tests passing
- Clippy clean
- `cargo check` clean