### PR TITLE
fix: cora init installs pre-commit hook + v0.4.1 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-06
+
+### Fixed
+
+- **Regex panic on optional hunk groups** — bare hunk headers like `@@ -1 +1 @@` (without `,count`) caused `caps[4]` index-out-of-bounds panic. Now uses `caps.get(N)` with safe fallback (#167)
+- **Default max_diff_size raised to 5MB** — 50KB was too small for most real PRs (#167)
+- **CI action resilience** — 3× retry on cora review failure, 600s timeout, graceful SARIF fallback when LLM API is unavailable (#174)
+
+### Added
+
+- **`cora init` now installs pre-commit hook** — automatically creates `.git/hooks/pre-commit` alongside `.cora.yaml`. Use `--no-hook` to skip. Falls back gracefully when not in a git repo (#176)
+- **Tiered `cora auth login`** — interactive provider selection with numbered menu. Known providers (openai, anthropic, groq, ollama, zai) pre-fill base URL and model. Custom providers ask for base URL + model + key (#172)
+- **Configurable CI action** — reads `.cora.yaml` from repo when present, falls back to 5MB limit when absent. Removes hardcoded `max_diff_size: 200000` (#172)
+- **`on_violation` config + `--ci` mode** — hard gate for CI: `on_violation: disallow` makes cora exit non-zero on any finding. `--ci` flag enables strict non-interactive mode (#152)
+- **`cora hook install/uninstall`** — explicit hook management commands (previously only via `cora init`)
+
+### Changed
+
+- **CI action reads `.cora.yaml`** — project config takes precedence over hardcoded fallback. `max_diff_size`, `hook.mode`, `llm.timeout` all respected in CI (#172)
+
 ## [0.4.0] - 2026-06-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "cora-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use tracing::debug;
 
+use crate::hook;
+
 /// Example .cora.yaml template content.
 const CONFIG_TEMPLATE: &str = r#"# Cora Code Review Configuration
 # See: https://github.com/codecoradev/cora-cli
@@ -48,8 +50,8 @@ output:
   color: true
 "#;
 
-/// Execute the init command: create a `.cora.yaml` file in the current directory.
-pub fn execute_init() -> Result<()> {
+/// Execute the init command: create a `.cora.yaml` file and install pre-commit hook.
+pub fn execute_init(skip_hook: bool) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let config_path = cwd.join(".cora.yaml");
 
@@ -78,11 +80,21 @@ pub fn execute_init() -> Result<()> {
         "   API keys should be set via CORA_API_KEY env var or `cora auth login`.".dimmed()
     );
 
+    // Install pre-commit hook unless --no-hook is specified
+    if !skip_hook {
+        install_hook_silent();
+    } else {
+        println!(
+            "{}",
+            "   Skipped hook installation (--no-hook). Run `cora hook install` later.".dimmed()
+        );
+    }
+
     Ok(())
 }
 
 /// Execute the init command with --force flag.
-pub fn execute_init_force() -> Result<()> {
+pub fn execute_init_force(skip_hook: bool) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let config_path = cwd.join(".cora.yaml");
 
@@ -96,5 +108,44 @@ pub fn execute_init_force() -> Result<()> {
         config_path.display()
     );
 
+    // Install pre-commit hook unless --no-hook is specified
+    if !skip_hook {
+        install_hook_silent();
+    } else {
+        println!(
+            "{}",
+            "   Skipped hook installation (--no-hook). Run `cora hook install` later.".dimmed()
+        );
+    }
+
     Ok(())
+}
+
+/// Install hook silently — warns on failure but doesn't fail init.
+fn install_hook_silent() {
+    match hook::install_hook() {
+        Ok(path) => {
+            println!(
+                "{} Installed pre-commit hook to {}",
+                "✅".green().bold(),
+                path
+            );
+            println!(
+                "{}",
+                "   The hook will run `cora review --staged --format compact` before each commit.".dimmed()
+            );
+        }
+        Err(e) => {
+            // Don't fail init if hook install fails (e.g. not a git repo)
+            println!(
+                "{} Could not install pre-commit hook: {}",
+                "⚠️".yellow().bold(),
+                e
+            );
+            println!(
+                "{}",
+                "   Run `cora hook install` later from inside a git repository.".dimmed()
+            );
+        }
+    }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -132,7 +132,8 @@ fn install_hook_silent() {
             );
             println!(
                 "{}",
-                "   The hook will run `cora review --staged --format compact` before each commit.".dimmed()
+                "   The hook will run `cora review --staged --format compact` before each commit."
+                    .dimmed()
             );
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,11 +192,15 @@ enum Command {
         token: Option<String>,
     },
 
-    /// Create a .cora.yaml config file in the current directory
+    /// Create a .cora.yaml config file and install pre-commit hook
     Init {
         /// Overwrite existing config file
         #[clap(long)]
         force: bool,
+
+        /// Skip pre-commit hook installation
+        #[clap(long)]
+        no_hook: bool,
     },
 
     /// Manage pre-commit git hooks
@@ -371,11 +375,11 @@ async fn main() -> Result<()> {
             };
             upload::execute_upload(&opts).await?
         }
-        Command::Init { force } => {
+        Command::Init { force, no_hook } => {
             if force {
-                init::execute_init_force()?;
+                init::execute_init_force(no_hook)?;
             } else {
-                init::execute_init()?;
+                init::execute_init(no_hook)?;
             }
             0
         }


### PR DESCRIPTION
## Summary

### Problem
`cora init` only creates `.cora.yaml` config — it does **not** install the pre-commit hook. Users had to manually run `cora hook install` as a separate step, which is easily forgotten.

### Fix
- `cora init` now **automatically installs** the pre-commit hook to `.git/hooks/pre-commit`
- Added `--no-hook` flag to skip hook installation when needed
- Graceful fallback: if not in a git repo, warns but does not fail init
- Bump version to `0.4.1` with full CHANGELOG entry covering all fixes since v0.4.0

### Changes
| File | Change |
|------|--------|
| `src/commands/init.rs` | Add `skip_hook` param, call `hook::install_hook()` with silent error handling |
| `src/main.rs` | Add `--no-hook` flag to `Init` subcommand |
| `CHANGELOG.md` | Full v0.4.1 entry (regex panic fix, CI resilience, auth login, hook install) |
| `Cargo.toml` | Bump `0.4.0` → `0.4.1` |

### Test
```
$ cora init --help
  --no-hook    Skip pre-commit hook installation

$ cora init
✅ Created .cora.yaml with example configuration.
✅ Installed pre-commit hook to .git/hooks/pre-commit
```

Fixes #176