### PR TITLE
docs: sync install docs + v0.4.2 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
 Pin a specific version with `CORA_VERSION`:
 
 ```bash
-CORA_VERSION=v0.4.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+CORA_VERSION=v0.4.2 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 ```
 
 ### Pre-built Binaries
@@ -122,7 +122,28 @@ cora review --commit HEAD
 cora init
 ```
 
-Creates `.cora.yaml` in your project root for custom settings (focus areas, ignore patterns, hook config). The CI action automatically reads this file.
+Creates `.cora.yaml` in your project root and **automatically installs a pre-commit hook**. The hook runs `cora review --staged --format compact` before each commit. Use `--no-hook` to skip.
+
+```bash
+# Skip hook installation
+cora init --no-hook
+
+# Manage hooks separately
+cora hook install
+cora hook uninstall
+```
+
+### 5. Provider Shortcuts (v0.4.2+)
+
+You can set `model`, `base_url`, and `provider` directly in `.cora.yaml`:
+
+```yaml
+provider: openai
+model: gpt-4o-mini
+base_url: https://api.openai.com/v1
+```
+
+No need for nested `provider:` section. Run `cora config show` to verify resolved config.
 
 ## 📖 Commands
 
@@ -254,11 +275,16 @@ Create a `.cora.yaml` in your project root, or use `~/.cora/config.yaml` for glo
 ```yaml
 # .cora.yaml
 
-# Provider configuration
-provider:
-  provider: openai          # openai | anthropic | google | ollama | custom
-  model: gpt-4o-mini
-  base_url: https://api.openai.com/v1   # Override for custom/self-hosted endpoints
+# Provider configuration (shortcut format — v0.4.2+)
+provider: openai
+model: gpt-4o-mini
+base_url: https://api.openai.com/v1
+
+# Or use nested format for multiple keys:
+# provider:
+#   provider: openai
+#   model: gpt-4o-mini
+#   base_url: https://api.openai.com/v1
 
 # LLM parameters
 llm:

--- a/website/src/lib/components/landing/QuickStart.svelte
+++ b/website/src/lib/components/landing/QuickStart.svelte
@@ -18,7 +18,7 @@
 		<TimelineStep number={1} title="Install" description="Single binary, no dependencies.">
 			{#snippet terminalCode()}
 				<TerminalBlock>
-					<span class="syntax-cmd">$</span> <span class="syntax-highlight">curl -fsSL</span> <span class="syntax-string">https://cora.dev/install</span> <span class="syntax-highlight">|</span> <span class="syntax-string">sh</span>
+					<span class="syntax-cmd">$</span> <span class="syntax-highlight">curl -fsSL</span> <span class="syntax-string">https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh</span> <span class="syntax-highlight">|</span> <span class="syntax-string">sh</span>
 				</TerminalBlock>
 			{/snippet}
 		</TimelineStep>

--- a/website/src/routes/docs/getting-started/+page.svelte
+++ b/website/src/routes/docs/getting-started/+page.svelte
@@ -180,8 +180,9 @@
 <div class="docs-section scroll-reveal">
 	<h2>Project Configuration — <code>cora init</code></h2>
 	<p>
-		Create a <code>.cora.yaml</code> config file in your project root to customize review settings.
-		The CI action automatically reads this file when it exists.
+		Create a <code>.cora.yaml</code> config file in your project root.
+		<strong>Automatically installs a pre-commit hook</strong> that runs <code>cora review --staged --format compact</code> before each commit.
+		Use <code>--no-hook</code> to skip hook installation.
 	</p>
 
 	<div class="docs-terminal">
@@ -193,6 +194,22 @@
 		<div class="terminal-body">
 			<div><span class="syntax-cmd">$</span> <span class="syntax-highlight">cora init</span></div>
 			<div><span class="syntax-success">✅</span> Created .cora.yaml with example configuration.</div>
+			<div><span class="syntax-success">✅</span> Pre-commit hook installed at .git/hooks/pre-commit</div>
+		</div>
+	</div>
+
+	<p>Set provider, model, and base URL directly in <code>.cora.yaml</code> (no nested section needed):</p>
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span class="terminal-dot-red"></span>
+			<span class="terminal-dot-yellow"></span>
+			<span class="terminal-dot-green"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span class="syntax-comment"># .cora.yaml — shortcut format</span></div>
+			<div><span class="syntax-flag">provider:</span> openai</div>
+			<div><span class="syntax-flag">model:</span> gpt-4o-mini</div>
+			<div><span class="syntax-flag">base_url:</span> https://api.openai.com/v1</div>
 		</div>
 	</div>
 

--- a/website/src/routes/docs/installation/+page.svelte
+++ b/website/src/routes/docs/installation/+page.svelte
@@ -27,22 +27,8 @@
 </h1>
 
 <div class="docs-section scroll-reveal">
-	<h2>Prerequisites</h2>
-	<p>cora is a Rust binary. You have two installation paths:</p>
-	<div class="docs-term-list">
-		<div class="text-sm text-[var(--muted-foreground)]">
-			<span class="font-semibold text-[var(--accent)]">Via Cargo (recommended)</span> — Requires Rust 1.85 or later with Cargo installed
-		</div>
-		<div class="text-sm text-[var(--muted-foreground)]">
-			<span class="font-semibold text-[var(--accent)]">Binary download</span> — No Rust required; just download and place in your PATH
-		</div>
-	</div>
-	<p>cora works on Linux (x86_64 and arm64), macOS (arm64), and Windows.</p>
-</div>
-
-<div class="docs-section scroll-reveal">
-	<h2>Install via Cargo</h2>
-	<p>The recommended way to install cora is through Cargo:</p>
+	<h2>Quick Install (Recommended)</h2>
+	<p>The fastest way to get cora — single command, no Rust required:</p>
 
 	<div class="docs-terminal">
 		<div class="terminal-bar">
@@ -51,7 +37,49 @@
 			<span class="terminal-dot-green"></span>
 		</div>
 		<div class="terminal-body">
-			<div><span class="syntax-cmd">$</span> <span class="syntax-highlight">cargo install</span>			<span class="syntax-string">cora-cli</span></div>
+			<div><span class="syntax-cmd">$</span> <span class="syntax-highlight">curl -fsSL</span> <span class="syntax-string">https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh</span> <span class="syntax-highlight">|</span> <span class="syntax-string">sh</span></div>
+		</div>
+	</div>
+
+	<p>Installs to <code>~/.local/bin</code>. Add to PATH if needed:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span class="terminal-dot-red"></span>
+			<span class="terminal-dot-yellow"></span>
+			<span class="terminal-dot-green"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span class="syntax-highlight">echo</span> <span class="syntax-string">'export PATH="$HOME/.local/bin:$PATH"'</span> >> ~/.bashrc</div>
+		</div>
+	</div>
+
+	<p>Pin a specific version:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span class="terminal-dot-red"></span>
+			<span class="terminal-dot-yellow"></span>
+			<span class="terminal-dot-green"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span class="syntax-cmd">$</span> <span class="syntax-flag">CORA_VERSION</span>=<span class="syntax-string">v0.4.2</span> <span class="syntax-highlight">curl -fsSL</span> <span class="syntax-string">https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh</span> <span class="syntax-highlight">|</span> <span class="syntax-string">sh</span></div>
+		</div>
+	</div>
+</div>
+
+<div class="docs-section scroll-reveal">
+	<h2>Install via Cargo</h2>
+	<p>If you have Rust 1.85+ installed:</p>
+
+	<div class="docs-terminal">
+		<div class="terminal-bar">
+			<span class="terminal-dot-red"></span>
+			<span class="terminal-dot-yellow"></span>
+			<span class="terminal-dot-green"></span>
+		</div>
+		<div class="terminal-body">
+			<div><span class="syntax-cmd">$</span> <span class="syntax-highlight">cargo install</span> <span class="syntax-string">cora-cli</span></div>
 		</div>
 	</div>
 


### PR DESCRIPTION
## Changes

Sync README and website docs for consistency and v0.4.2 features.

### Fixed
- **CORA_VERSION example**: `v0.4.0` → `v0.4.2`
- **Install URL**: standardized to `raw.githubusercontent.com` (was `cora.dev/install` on landing page)

### Added
- **Quick Install** section on website installation page (curl one-liner as recommended method)
- **cora init hook auto-install** documented on website getting-started page
- **Provider shortcuts** (top-level `model:`, `base_url:`, `provider:`) in README and website
- **`--no-hook`** flag and `cora hook install/uninstall` commands in README
- **PATH setup** instructions on website installation page
- **CORA_VERSION pinning** on website installation page

### Files Changed
| File | Change |
|------|--------|
| `README.md` | Version bump, hook docs, provider shortcuts, config example |
| `QuickStart.svelte` | Fix install URL |
| `installation/+page.svelte` | Add Quick Install section |
| `getting-started/+page.svelte` | Add hook auto-install, provider shortcuts |