### PR TITLE
fix(v0.4.3): 6 UX fixes from full codebase review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-06-06
+
+### Fixed
+
+- **Provider shortcut now resolves preset defaults** — bare `provider: zai` in `.cora.yaml` auto-fills `base_url` and `model` from the preset table (#183)
+- **Env var override warnings** — `CORA_PROVIDER`, `CORA_MODEL`, `CORA_BASE_URL` now warn when they override config file settings (#182)
+- **`config show` displays effective (resolved) config** — shows actual runtime values with `[from: env ...]` annotations when env vars override config (#189)
+- **Auth file permissions auto-fix** — `~/.cora/auth.toml` permissions auto-corrected to 600 instead of just warning (#187)
+- **Deterministic rules exclude own source files** — security rules no longer match against `rules/` and `tests/` directories, eliminating false positives (#185)
+
+### Added
+
+- **Non-interactive `cora auth login`** — `--provider`, `--api-key`, `--model`, `--base-url`, `--force` flags for scriptable setup (#184)
+
 ## [0.4.2] - 2026-06-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -6,8 +6,100 @@ use colored::Colorize;
 use crate::config::loader;
 use crate::config::providers::PRESETS;
 
-/// Execute `auth login` — interactive tiered provider selection and API key setup.
-pub fn execute_auth_login() -> Result<()> {
+/// Execute `auth login` — interactive or non-interactive provider selection and API key setup.
+///
+/// When `--provider` and `--api-key` flags are provided, runs non-interactively (scriptable).
+/// Otherwise falls back to interactive mode.
+pub fn execute_auth_login(
+    cli_provider: Option<&str>,
+    cli_api_key: Option<&str>,
+    cli_model: Option<&str>,
+    cli_base_url: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    // Non-interactive mode: both provider and api_key provided via flags
+    if let (Some(provider), Some(api_key)) = (cli_provider, cli_api_key) {
+        return execute_auth_login_noninteractive(
+            provider,
+            api_key,
+            cli_model,
+            cli_base_url,
+            force,
+        );
+    }
+
+    // If only one of provider/api_key is given, that's an error
+    if cli_provider.is_some() || cli_api_key.is_some() {
+        anyhow::bail!("Both --provider and --api-key are required for non-interactive login");
+    }
+
+    // Interactive mode (original behavior)
+    execute_auth_login_interactive()
+}
+
+/// Non-interactive auth login — used when --provider and --api-key flags are provided.
+fn execute_auth_login_noninteractive(
+    provider: &str,
+    api_key: &str,
+    cli_model: Option<&str>,
+    cli_base_url: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    // Check if already logged in
+    if !force {
+        let status = loader::auth_status()?;
+        if status.has_key {
+            eprintln!(
+                "{}",
+                "⚠️  An API key is already configured.".yellow().bold()
+            );
+            eprintln!("   Source: {}", status.source);
+            eprintln!("   Use --force to overwrite.");
+            anyhow::bail!("Aborted: key already exists. Use --force to overwrite.");
+        }
+    }
+
+    if api_key.is_empty() {
+        anyhow::bail!("API key cannot be empty");
+    }
+
+    // Resolve preset defaults for the provider
+    let (base_url, model) = if let Some(preset) = PRESETS.iter().find(|p| p.name == provider) {
+        (
+            cli_base_url.unwrap_or(preset.default_base_url).to_string(),
+            cli_model.unwrap_or(preset.default_model).to_string(),
+        )
+    } else {
+        // Custom provider — model and base_url required
+        let base_url = cli_base_url
+            .ok_or_else(|| anyhow::anyhow!("--base-url is required for custom provider '{}'. Use a known provider or provide all flags.", provider))?;
+        let model = cli_model
+            .ok_or_else(|| anyhow::anyhow!("--model is required for custom provider '{}'. Use a known provider or provide all flags.", provider))?;
+        (base_url.to_string(), model.to_string())
+    };
+
+    // Save
+    loader::save_api_key(api_key)?;
+    loader::save_provider_info(provider, &base_url, &model)?;
+
+    println!(
+        "{} API key saved to {}",
+        "✅".green().bold(),
+        "~/.cora/auth.toml".green()
+    );
+    println!(
+        "{} Provider: {} | Model: {} | Base: {}",
+        "   ".dimmed(),
+        provider.bold(),
+        model.bold(),
+        base_url.dimmed()
+    );
+
+    Ok(())
+}
+
+/// Interactive auth login — original behavior with prompts.
+fn execute_auth_login_interactive() -> Result<()> {
     // Check if already logged in
     let status = loader::auth_status()?;
     if status.has_key {
@@ -194,6 +286,10 @@ pub fn execute_auth_status() -> Result<()> {
         println!("{} No API key configured.", "❌".red().bold());
         println!("   Set it via:");
         println!("     • {} (interactive setup)", "cora auth login".cyan());
+        println!(
+            "     • {} (non-interactive)",
+            "cora auth login --provider zai --api-key KEY".cyan()
+        );
         println!("     • CORA_API_KEY environment variable");
         println!("     • Provider-specific env vars: OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.");
     }

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -10,13 +10,41 @@ use crate::config::schema::{CoraFile, HookSection, OutputSection, ProviderSectio
 pub fn execute_config_show() -> Result<()> {
     let config = loader::load_config(None, None, None, None, None, false)?;
 
+    // Resolve effective values (env vars can override config file)
+    let eff_provider = std::env::var("CORA_PROVIDER")
+        .ok()
+        .unwrap_or_else(|| config.provider.provider.clone());
+    let eff_model = std::env::var("CORA_MODEL")
+        .ok()
+        .unwrap_or_else(|| config.provider.model.clone());
+    let eff_base_url = std::env::var("CORA_BASE_URL")
+        .ok()
+        .unwrap_or_else(|| config.provider.base_url.clone());
+
+    // Source annotations
+    let provider_src = if std::env::var("CORA_PROVIDER").is_ok() {
+        " [from: env CORA_PROVIDER]"
+    } else {
+        ""
+    };
+    let model_src = if std::env::var("CORA_MODEL").is_ok() {
+        " [from: env CORA_MODEL]"
+    } else {
+        ""
+    };
+    let url_src = if std::env::var("CORA_BASE_URL").is_ok() {
+        " [from: env CORA_BASE_URL]"
+    } else {
+        ""
+    };
+
     println!(
         "{}",
         "╔══════════════════════════════════════════╗".cyan().bold()
     );
     println!(
         "{}",
-        "║          Current Configuration            ║"
+        "║       Effective Configuration             ║"
             .cyan()
             .bold()
     );
@@ -27,15 +55,22 @@ pub fn execute_config_show() -> Result<()> {
     println!();
 
     println!(
-        "{} {}",
+        "{} {}{}",
         "provider:".bold(),
-        config.provider.provider.green()
+        eff_provider.green(),
+        provider_src.dimmed()
     );
-    println!("{} {}", "  model:".dimmed(), config.provider.model.green());
     println!(
-        "{} {}",
-        "  base_url:".dimmed(),
-        config.provider.base_url.green()
+        "  {} {}{}",
+        "model:".dimmed(),
+        eff_model.green(),
+        model_src.dimmed()
+    );
+    println!(
+        "  {} {}{}",
+        "base_url:".dimmed(),
+        eff_base_url.green(),
+        url_src.dimmed()
     );
 
     println!(

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -333,6 +333,32 @@ pub fn build_llm_config(
     let cora_model = std::env::var("CORA_MODEL").ok();
     let cora_base_url = std::env::var("CORA_BASE_URL").ok();
 
+    // Warn when env vars override config file settings
+    if let Some(ref env_p) = cora_provider {
+        if env_p != &config.provider.provider {
+            eprintln!(
+                "⚠️  CORA_PROVIDER={env_p} overrides config provider={}",
+                config.provider.provider
+            );
+        }
+    }
+    if let Some(ref env_m) = cora_model {
+        if env_m != &config.provider.model {
+            eprintln!(
+                "⚠️  CORA_MODEL={env_m} overrides config model={}",
+                config.provider.model
+            );
+        }
+    }
+    if let Some(ref env_u) = cora_base_url {
+        if env_u != &config.provider.base_url {
+            eprintln!(
+                "⚠️  CORA_BASE_URL overrides config base_url={}",
+                config.provider.base_url
+            );
+        }
+    }
+
     let provider = cora_provider
         .or_else(|| auto_preset.map(|p| p.name.to_string()))
         .unwrap_or_else(|| config.provider.provider.clone());
@@ -382,11 +408,17 @@ pub fn load_api_key_from_auth_file() -> std::result::Result<Option<String>, Cora
         if let Ok(meta) = std::fs::metadata(&path) {
             let mode = meta.permissions().mode();
             if mode & 0o077 != 0 {
-                tracing::warn!(
-                    "auth file has overly permissive permissions ({:o}). Run: chmod 600 {}",
-                    mode & 0o777,
-                    path.display()
-                );
+                // Auto-fix: restrict permissions to owner-only
+                let fixed = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+                if fixed.is_ok() {
+                    debug!("auto-fixed auth file permissions: {:o} → 600", mode & 0o777);
+                } else {
+                    tracing::warn!(
+                        "auth file has overly permissive permissions ({:o}). Run: chmod 600 {}",
+                        mode & 0o777,
+                        path.display()
+                    );
+                }
             }
         }
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -335,6 +335,20 @@ impl CoraFile {
         if let Some(p) = &self.provider {
             if let Some(v) = &p.provider {
                 config.provider.provider.clone_from(v);
+
+                // Resolve preset defaults (base_url, model) when provider is a known preset
+                // and the corresponding field wasn't explicitly set in the config file.
+                if let Some(preset) = crate::config::providers::PRESETS
+                    .iter()
+                    .find(|pr| pr.name == v)
+                {
+                    if p.base_url.is_none() && self.base_url.is_none() {
+                        config.provider.base_url = preset.default_base_url.to_string();
+                    }
+                    if p.model.is_none() && self.model.is_none() {
+                        config.provider.model = preset.default_model.to_string();
+                    }
+                }
             }
             if let Some(v) = &p.model {
                 config.provider.model.clone_from(v);
@@ -558,8 +572,24 @@ base_url: https://api.z.ai/api/coding/paas/v4
         };
         cora.merge_into(&mut cfg);
         assert_eq!(cfg.provider.provider, "ollama");
-        assert_eq!(cfg.provider.model, "gpt-4o-mini"); // unchanged
-        assert_eq!(cfg.provider.base_url, "https://api.openai.com/v1"); // unchanged
+        assert_eq!(cfg.provider.model, "llama3.1"); // resolved from ollama preset
+        assert_eq!(cfg.provider.base_url, "http://localhost:11434/v1"); // resolved from ollama preset
+    }
+
+    #[test]
+    fn merge_shortcut_provider_resolves_preset() {
+        let mut cfg = Config::default();
+        let cora = CoraFile::from_str(
+            r"
+provider: zai
+",
+        )
+        .unwrap();
+
+        cora.merge_into(&mut cfg);
+        assert_eq!(cfg.provider.provider, "zai");
+        assert_eq!(cfg.provider.model, "glm-5.1"); // resolved from zai preset
+        assert_eq!(cfg.provider.base_url, "https://api.z.ai/api/coding/paas/v4"); // resolved from zai preset
     }
 
     #[test]

--- a/src/engine/rules/builtin.rs
+++ b/src/engine/rules/builtin.rs
@@ -13,7 +13,7 @@ pub fn builtin_rules() -> Vec<CustomRule> {
             severity: Severity::Critical,
             message: "Possible hardcoded secret/credential detected. Use environment variables or a secrets manager.".to_string(),
             languages: vec!["all".to_string()],
-            exclude: vec![],
+            exclude: vec!["rules/".to_string(), "tests/".to_string(), "test/".to_string()],
         },
         CustomRule {
             id: "sec-sql-concat".to_string(),
@@ -22,7 +22,7 @@ pub fn builtin_rules() -> Vec<CustomRule> {
             severity: Severity::Critical,
             message: "Possible SQL injection via string concatenation in query. Use parameterized queries.".to_string(),
             languages: vec!["all".to_string()],
-            exclude: vec![],
+            exclude: vec!["rules/".to_string(), "tests/".to_string(), "test/".to_string()],
         },
         CustomRule {
             id: "sec-hardcoded-url".to_string(),
@@ -31,7 +31,7 @@ pub fn builtin_rules() -> Vec<CustomRule> {
             severity: Severity::Major,
             message: "Insecure HTTP URL detected (not https). Use HTTPS for all external connections.".to_string(),
             languages: vec!["all".to_string()],
-            exclude: vec![],
+            exclude: vec!["rules/".to_string(), "tests/".to_string(), "test/".to_string()],
         },
         CustomRule {
             id: "sec-tls-disabled".to_string(),
@@ -39,7 +39,7 @@ pub fn builtin_rules() -> Vec<CustomRule> {
             severity: Severity::Critical,
             message: "TLS verification disabled. This allows man-in-the-middle attacks.".to_string(),
             languages: vec!["rs".to_string(), "py".to_string(), "go".to_string()],
-            exclude: vec![],
+            exclude: vec!["rules/".to_string(), "tests/".to_string(), "test/".to_string()],
         },
         // --- Bugs ---
         CustomRule {

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,23 @@ enum HookAction {
 #[derive(Subcommand, Debug)]
 enum AuthAction {
     /// Save an API key to local config
-    Login,
+    Login {
+        /// Provider name (e.g. openai, zai, anthropic, ollama) — skips interactive selection
+        #[clap(long)]
+        provider: Option<String>,
+        /// API key — skips interactive prompt
+        #[clap(long)]
+        api_key: Option<String>,
+        /// Model name (e.g. glm-5.1, gpt-4o-mini) — used with --provider
+        #[clap(long)]
+        model: Option<String>,
+        /// Base URL — used with --provider for custom endpoints
+        #[clap(long)]
+        base_url: Option<String>,
+        /// Skip confirmation when overwriting existing key
+        #[clap(long)]
+        force: bool,
+    },
     /// Check if an API key is configured
     Status,
     /// Remove the stored API key
@@ -395,7 +411,21 @@ async fn main() -> Result<()> {
         },
         Command::Auth { action } => {
             match action {
-                AuthAction::Login => auth::execute_auth_login()?,
+                AuthAction::Login {
+                    provider,
+                    api_key,
+                    model,
+                    base_url,
+                    force,
+                } => {
+                    auth::execute_auth_login(
+                        provider.as_deref(),
+                        api_key.as_deref(),
+                        model.as_deref(),
+                        base_url.as_deref(),
+                        force,
+                    )?;
+                }
                 AuthAction::Status => auth::execute_auth_status()?,
                 AuthAction::Remove => auth::execute_auth_remove()?,
             }


### PR DESCRIPTION
## Changes

Fixes from full codebase review pain points discovered during testing.

### Fixed
- **#183** — Provider shortcut (`provider: zai`) now resolves preset `base_url` and `model` defaults
- **#182** — Warning when `CORA_PROVIDER`/`CORA_MODEL`/`CORA_BASE_URL` env vars override config file
- **#189** — `cora config show` displays effective (resolved) config with `[from: env ...]` annotations
- **#187** — Auth file permissions auto-corrected to 600 (was: warning only)
- **#185** — Deterministic rules now exclude `rules/` and `tests/` directories (no more self-scan false positives)

### Added
- **#184** — Non-interactive `cora auth login` with `--provider`, `--api-key`, `--model`, `--base-url`, `--force` flags

### Files changed (8 files, +260/-23 lines)
| File | Change |
|------|--------|
| `src/config/schema.rs` | Preset resolve in `merge_into()` + new test |
| `src/config/loader.rs` | Env var override warnings + auth file auto-chmod |
| `src/commands/auth.rs` | Non-interactive mode via CLI flags |
| `src/commands/config_cmd.rs` | Effective config display |
| `src/engine/rules/builtin.rs` | Default exclude patterns for security rules |
| `src/main.rs` | `AuthAction::Login` struct with flags |
| `CHANGELOG.md` | v0.4.3 entry |
| `Cargo.toml` | Version bump 0.4.2 → 0.4.3 |

### Test Results
- 52 unit tests passed (including new `merge_shortcut_provider_resolves_preset`)
- 16 CLI integration tests passed
- 6 config loading tests passed
- `cargo fmt` clean
- `cargo clippy` clean

### Open Issues (not in this PR — enhancement backlog)
- **#181** — Review output cannot be captured (writes to /dev/tty)
- **#186** — Repair truncated JSON from LLM responses
- **#188** — Auto-chunking for large diffs