### PR TITLE
fix(v0.4.4): output capture + truncated JSON repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-06
+
+### Fixed
+
+- **Spinner auto-hides in non-TTY** — `indicatif` progress spinners in `llm.rs` and `scanner.rs` now detect piped/redirected stderr and auto-hide, preventing ANSI pollution in captured output (#181)
+- **Truncated JSON repair** — LLM responses cut off by max_tokens are now auto-repaired by closing unclosed strings/brackets before parse, preserving partial findings instead of failing completely (#186)
+
+### Added
+
+- **`--output-file <PATH>` flag** — write formatted review output to a file instead of stdout, guaranteeing capture in CI/batch pipelines (#181)
+
 ## [0.4.3] - 2026-06-06
 
 ### Fixed
@@ -289,7 +300,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.4.0...develop
+[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...develop
+[0.4.4]: https://github.com/codecoradev/cora-cli/compare/v0.4.3...v0.4.4
 [0.4.0]: https://github.com/codecoradev/cora-cli/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/codecoradev/cora-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/codecoradev/cora-cli/compare/v0.1.8...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "cora-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/src/engine/llm.rs
+++ b/src/engine/llm.rs
@@ -1,5 +1,5 @@
 use crate::error::CoraError;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::LazyLock;
@@ -244,8 +244,16 @@ async fn chat_completion(
 }
 
 /// Create an animated spinner for LLM operations.
+///
+/// Automatically hidden when stderr is not a TTY (piped/redirected),
+/// preventing ANSI pollution in captured output.
 fn create_spinner(message: &str) -> ProgressBar {
     let spinner = ProgressBar::new_spinner();
+    // Hide spinner when stderr is not a terminal (piped/redirected)
+    if !atty_check() {
+        spinner.set_draw_target(ProgressDrawTarget::hidden());
+        return spinner;
+    }
     spinner.enable_steady_tick(std::time::Duration::from_millis(80));
     spinner.set_style(
         ProgressStyle::with_template("{spinner:.cyan} {msg}")
@@ -254,6 +262,12 @@ fn create_spinner(message: &str) -> ProgressBar {
     );
     spinner.set_message(message.to_string());
     spinner
+}
+
+/// Check if stderr is connected to a TTY.
+fn atty_check() -> bool {
+    use std::io::IsTerminal;
+    std::io::stderr().is_terminal()
 }
 
 /// Review a diff using the LLM. Returns a `ReviewResponse`.
@@ -650,8 +664,30 @@ pub(crate) fn parse_review_response(
     // Repair common LLM JSON mistakes before strict parse
     let json_str = repair_json_string(&json_str);
 
-    let issues: Vec<ReviewIssue> =
-        serde_json::from_str(&json_str).map_err(|e| CoraError::LlmParse(e.to_string()))?;
+    // Attempt strict parse first; if it fails due to truncation, try to repair
+    let issues: Vec<ReviewIssue> = match serde_json::from_str(&json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            let err_msg = e.to_string();
+            if err_msg.contains("EOF") || err_msg.contains("unexpected end") {
+                debug!(error = %err_msg, "attempting truncated JSON repair");
+                let repaired = repair_truncated_json(&json_str);
+                match serde_json::from_str(&repaired) {
+                    Ok(v) => {
+                        debug!("truncated JSON repair succeeded — some data may be partial");
+                        v
+                    }
+                    Err(repair_err) => {
+                        return Err(CoraError::LlmParse(format!(
+                            "parse failed (original: {err_msg}, after repair: {repair_err})"
+                        )));
+                    }
+                }
+            } else {
+                return Err(CoraError::LlmParse(e.to_string()));
+            }
+        }
+    };
 
     Ok((issues, summary, None))
 }
@@ -667,8 +703,30 @@ pub(crate) fn parse_scan_response(
     // Repair common LLM JSON mistakes before strict parse
     let json_str = repair_json_string(&json_str);
 
-    let issues: Vec<ReviewIssue> =
-        serde_json::from_str(&json_str).map_err(|e| CoraError::LlmParse(e.to_string()))?;
+    // Attempt strict parse first; if it fails due to truncation, try to repair
+    let issues: Vec<ReviewIssue> = match serde_json::from_str(&json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            let err_msg = e.to_string();
+            if err_msg.contains("EOF") || err_msg.contains("unexpected end") {
+                debug!(error = %err_msg, "attempting truncated JSON repair for scan response");
+                let repaired = repair_truncated_json(&json_str);
+                match serde_json::from_str(&repaired) {
+                    Ok(v) => {
+                        debug!("truncated JSON repair succeeded — some data may be partial");
+                        v
+                    }
+                    Err(repair_err) => {
+                        return Err(CoraError::LlmParse(format!(
+                            "parse failed (original: {err_msg}, after repair: {repair_err})"
+                        )));
+                    }
+                }
+            } else {
+                return Err(CoraError::LlmParse(e.to_string()));
+            }
+        }
+    };
 
     let summary = if summary.is_empty() {
         None
@@ -730,6 +788,55 @@ fn repair_json_string(json_str: &str) -> String {
         debug!("applied backslash repair to LLM JSON output");
         repaired
     }
+}
+
+/// Repair truncated JSON by closing unclosed strings, arrays, and objects.
+///
+/// When an LLM response is cut off due to max_tokens, the JSON is often
+/// incomplete — unclosed string values, missing `]` or `}` brackets.
+/// This function walks the JSON tracking nesting depth and string state,
+/// then appends the necessary closing characters.
+fn repair_truncated_json(json: &str) -> String {
+    let mut stack: Vec<char> = Vec::new();
+    let mut in_string = false;
+    let mut escape_next = false;
+
+    for ch in json.chars() {
+        if escape_next {
+            escape_next = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => escape_next = true,
+            '"' => in_string = !in_string,
+            '{' | '[' if !in_string => stack.push(ch),
+            '}' if !in_string && stack.last() == Some(&'{') => {
+                stack.pop();
+            }
+            ']' if !in_string && stack.last() == Some(&'[') => {
+                stack.pop();
+            }
+            _ => {}
+        }
+    }
+
+    let mut repaired = json.to_string();
+
+    // Close unclosed string
+    if in_string {
+        repaired.push('"');
+    }
+
+    // Close brackets in reverse order
+    for ch in stack.iter().rev() {
+        match ch {
+            '{' => repaired.push('}'),
+            '[' => repaired.push(']'),
+            _ => {}
+        }
+    }
+
+    repaired
 }
 
 /// Replace invalid escape sequences in JSON string values.

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeSet;
+use std::io::IsTerminal;
 use std::path::Path;
 
 use crate::error::CoraError;
 use glob::Pattern;
 use ignore::WalkBuilder;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use tracing::debug;
 
 /// A file to be scanned, with its relative path and content.
@@ -64,13 +65,18 @@ pub fn walk_project(
     let mut entries = Vec::new();
 
     let spinner = ProgressBar::new_spinner();
-    spinner.enable_steady_tick(std::time::Duration::from_millis(80));
-    spinner.set_style(
-        ProgressStyle::with_template("{spinner:.cyan} {msg}")
-            .unwrap()
-            .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),
-    );
-    spinner.set_message("Scanning files…");
+    // Hide spinner when stderr is not a terminal (piped/redirected)
+    if std::io::stderr().is_terminal() {
+        spinner.enable_steady_tick(std::time::Duration::from_millis(80));
+        spinner.set_style(
+            ProgressStyle::with_template("{spinner:.cyan} {msg}")
+                .unwrap()
+                .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),
+        );
+        spinner.set_message("Scanning files…");
+    } else {
+        spinner.set_draw_target(ProgressDrawTarget::hidden());
+    }
 
     let walker = WalkBuilder::new(root)
         .hidden(true) // respect hidden files (skip dotfiles)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use tracing::Level;
@@ -116,6 +116,10 @@ enum Command {
         /// Suppress all output except the formatted review result
         #[clap(long, short)]
         quiet: bool,
+
+        /// Write formatted output to a file instead of stdout
+        #[clap(long, value_name = "PATH")]
+        output_file: Option<String>,
 
         /// Filter results by minimum severity (info, minor, major, critical)
         #[clap(long, value_parser = ["info", "minor", "major", "critical"])]
@@ -324,6 +328,7 @@ async fn main() -> Result<()> {
             stream,
             progress,
             quiet,
+            output_file,
             severity,
             no_cache,
             ci,
@@ -345,6 +350,7 @@ async fn main() -> Result<()> {
                     stream,
                     progress,
                     quiet,
+                    output_file,
                     severity,
                     upload,
                     repo,
@@ -468,6 +474,7 @@ struct ReviewOpts {
     stream: bool,
     progress: bool,
     quiet: bool,
+    output_file: Option<String>,
     severity: Option<String>,
     upload: bool,
     repo: Option<String>,
@@ -552,8 +559,16 @@ async fn cmd_review(globals: &GlobalOptions, opts: ReviewOpts) -> Result<i32> {
     )
     .await?;
 
-    // Print the formatted output
-    print!("{}", result.output);
+    // Print the formatted output (to file if --output-file, else stdout)
+    if let Some(ref path) = opts.output_file {
+        std::fs::write(path, &result.output)
+            .with_context(|| format!("failed to write output file: {path}"))?;
+        if !opts.quiet {
+            eprintln!("{}", format!("Output written to {path}").dimmed());
+        }
+    } else {
+        print!("{}", result.output);
+    }
 
     // If --upload, send the SARIF output to GitHub Code Scanning
     if opts.upload {


### PR DESCRIPTION
## Changes

### #181 — Output capture
- Spinner (`indicatif::ProgressBar`) in `llm.rs` and `scanner.rs` now auto-hides when stderr is not a TTY (piped/redirected), preventing ANSI pollution
- New `--output-file <PATH>` flag writes formatted review output to a file instead of stdout

### #186 — Truncated JSON repair
- New `repair_truncated_json()` function tracks unclosed strings/brackets and closes them before parse
- Both `parse_review_response()` and `parse_scan_response()` attempt truncated repair on EOF errors
- Preserves partial findings instead of failing completely

## Testing
- 74/74 tests passed
- `cargo clippy` clean
- `cargo fmt --check` clean

## Do NOT release yet
- This PR is ready for review but should NOT be tagged/released until instructed