### PR TITLE
fix: vitepress build path for CI working-directory

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,9 +2,9 @@
   "name": "cora-docs",
   "private": true,
   "scripts": {
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:dev": "vitepress dev",
+    "docs:build": "vitepress build",
+    "docs:preview": "vitepress preview"
   },
   "devDependencies": {
     "vitepress": "^1.6.3",


### PR DESCRIPTION
## Problem

Deploy workflow fails at 'Verify build output' step — `vitepress build docs` when CWD is already `docs/` looks for `docs/docs/` instead of the actual docs source.

## Fix

Change all scripts from `vitepress build docs` to `vitepress build` (no args). VitePress auto-detects the docs root from CWD.