### PR TITLE
fix: add rules/ to default exclude paths + close already-fixed issues

### DIFF
--- a/src/engine/rules/matching.rs
+++ b/src/engine/rules/matching.rs
@@ -102,6 +102,7 @@ const DEFAULT_EXCLUDE_PATHS: &[&str] = &[
     "spec/",
     "fixtures/",
     "examples/",
+    "rules/",
     // File patterns handled in glob_matches: *_test.*, *_spec.*
 ];
 


### PR DESCRIPTION
## Summary

Small fix + housekeeping of already-fixed bugs.

## Changes

- **#185**: Add `rules/` to `DEFAULT_EXCLUDE_PATHS` — prevents deterministic rules from firing on their own pattern definitions in `src/engine/rules/*`

## Already-fixed issues (closing)

- **#182**: `config show` now displays effective config with source annotations (`[from: env CORA_PROVIDER]`)
- **#183**: `provider: zai` as bare string resolves preset defaults correctly
- **#187**: `auth.toml` auto-fixes permissions, `config.yaml` created on `cora auth login`
- **#189**: `config show` displays resolved effective config, not file values

## Test Plan

- [x] All 333+ tests pass
- [x] Pre-commit hook passed (no issues found)