### PR TITLE
release: v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-06-07
+
+### Changed
+
+- **Config architecture redesign** — clear separation of concerns between config files (#209)
+  - `~/.cora/auth.toml` now stores **only the API key** (secret)
+  - `~/.cora/config.yaml` stores provider, model, base_url, and other settings (global)
+  - `.cora.yaml` (project) overrides global config per-project
+  - `CORA_API_KEY` env var reserved for CI use only
+- **Provider info auto-migration** — if `auth.toml` still contains provider/model/base_url, automatically moved to `config.yaml` on first run
+- **Deterministic rules** — `rules/` added to default exclude paths, preventing rules from matching their own source definitions (#185)
+
+### Fixed
+
+- **`cora config show`** — now displays the **effective resolved config** with source annotations like `[from: env CORA_PROVIDER]` instead of raw file values (#189)
+- **`cora config show --global`** — new flag to show only `~/.cora/config.yaml` contents
+- **`cora config show --project`** — new flag to show only `.cora.yaml` contents (mutually exclusive with `--global`)
+- **`cora review` sends to wrong provider** — provider info from `auth.toml`/`config.yaml` was ignored at runtime, always defaulting to OpenAI. Now correctly reads from merged config (#209)
+- **`save_provider_info` data loss** — parse failure on `config.yaml` no longer silently replaces the entire file with defaults (now returns error)
+- **`cora auth login` interactive flow** — now auto-detects provider env vars (e.g. pick ZAI → detects `ZAI_API_KEY`), suggests model and base URL defaults from presets (enter to accept) (#203)
+- **`cora auth login --provider zai`** — now auto-detects `ZAI_API_KEY` from environment, no need for `--api-key` flag (#184)
+- **Env var override visibility** — `cora config show` now annotates which values come from env vars vs config files (#182)
+- **Truncated JSON repair tests** — 12 new tests confirming `repair_truncated_json()` works correctly for all edge cases (#186)
+
+### Added
+
+- **`--global` / `--project` flags** on `cora config show` for scoped config inspection
+- **Clap `conflicts_with`** on `--global`/`--project` — `cora config show --global --project` now rejected at CLI level
+- **Interactive model/base URL prompts** — during `cora auth login`, shows preset defaults and allows override with enter-to-accept
+
 ## [0.4.4] - 2026-06-06
 
 ### Fixed
@@ -300,7 +330,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...develop
+[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...develop
+[0.4.5]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/codecoradev/cora-cli/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/codecoradev/cora-cli/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/codecoradev/cora-cli/compare/v0.4.1...v0.4.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "cora-cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Manage configuration. Supports both project-level (`.cora.yaml`) and global (`~/
 
 ```bash
 # Show current resolved configuration
- cora config show
+cora config show
 
 # Show only global config (~/.cora/config.yaml)
 cora config show --global

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.s
 cora auth login
 ```
 
-Pick your provider, enter your API key — done. Cora stores it securely in `~/.cora/auth.toml` (never committed to git).
+Pick your provider, enter your API key — done. Cora stores the API key in `~/.cora/auth.toml` (never committed to git) and provider settings in `~/.cora/config.yaml`.
 
 > **No API key yet?** Set any provider env var instead: `export OPENAI_API_KEY="..."`
 
@@ -223,7 +223,13 @@ Manage configuration. Supports both project-level (`.cora.yaml`) and global (`~/
 
 ```bash
 # Show current resolved configuration
-cora config show
+ cora config show
+
+# Show only global config (~/.cora/config.yaml)
+cora config show --global
+
+# Show only project config (.cora.yaml)
+cora config show --project
 
 # Set a project-level value (writes to .cora.yaml)
 cora config set model claude-sonnet-4-20250514
@@ -348,7 +354,7 @@ output:
 | `OPENAI_API_KEY` | OpenAI API key | — |
 | `ANTHROPIC_API_KEY` | Anthropic API key | — |
 | `GOOGLE_API_KEY` | Google AI API key | — |
-| `CORA_API_KEY` | API key (overrides provider-specific keys) | — |
+| `CORA_API_KEY` | API key (for CI — overrides all other sources) | — |
 | `CORA_MODEL` | Override model | — |
 | `CORA_PROVIDER` | Override provider | — |
 | `CORA_BASE_URL` | Override API base URL | — |
@@ -381,24 +387,28 @@ $ cora auth login
 🔑 Cora Auth Setup
    Choose your LLM provider:
 
-  [1] openai — https://api.openai.com/v1 (model: gpt-4o-mini)
-  [2] anthropic — https://api.anthropic.com/v1 (model: claude-3-haiku-20240307)
-  [3] groq — https://api.groq.com/openai/v1 (model: llama-3.1-8b-instant)
-  [4] ollama — http://localhost:11434/v1 (model: llama3.1)
-  [5] zai — https://api.z.ai/api/coding/paas/v4 (model: glm-5.1)
-  [6] custom — use any OpenAI-compatible endpoint
+  [1] openai
+  [2] anthropic
+  [3] groq
+  [4] ollama
+  [5] zai
+  [6] custom
 
-  Select provider [1-6]: 1
+  Select provider [1-6]: 5
 
-  → Provider: openai
-  → Model: gpt-4o-mini
-  → Base URL: https://api.openai.com/v1
+  → Provider: zai
+  🔑 Found ZAI_API_KEY in environment
+     Use it? [Y/n]: Y
+     ✅ Using ZAI_API_KEY from environment
 
-  🔑 Enter your API key: sk-...
+  Model [glm-5.1]:          ← press Enter to accept default
+  Base URL [https://api.z.ai/api/coding/paas/v4]:  ← press Enter to accept default
 
 ✅ API key saved to ~/.cora/auth.toml
-   Provider: openai | Model: gpt-4o-mini | Base: https://api.openai.com/v1
+   Provider: zai | Model: glm-5.1 | Base: https://api.z.ai/api/coding/paas/v4
 ```
+
+> Provider env vars are auto-detected — pick ZAI and `ZAI_API_KEY` is found automatically.
 
 #### Check Auth Status
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,17 +4,34 @@ title: Configuration
 
 # Configuration
 
-cora uses a layered config system. Later sources override earlier ones.
+cora uses a layered config system with clear separation of concerns. Later sources override earlier ones.
+
+## File Roles
+
+| File | Contents | Used by |
+|------|----------|--------|
+| `~/.cora/auth.toml` | API key only (secret, chmod 600) | Local dev |
+| `~/.cora/config.yaml` | Provider, model, base_url, focus, hook, output, etc. | Global default |
+| `.cora.yaml` | Per-project config overrides | Project + CI |
+| `CORA_API_KEY` env var | API key for CI/one-shot | CI only |
 
 ## Config Resolution Order
 
 Settings are resolved in this order (highest priority first):
 
 1. **CLI flags** — `--provider`, `--model`, `--base-url`, etc.
-2. **Environment variables** — `CORA_API_KEY`, `CORA_PROVIDER`, `CORA_MODEL`, etc.
+2. **Environment variables** — `CORA_PROVIDER`, `CORA_MODEL`, `CORA_BASE_URL`
 3. **.cora.yaml** — Project root config file
-4. **~/.cora/config.yaml** — Global config (optional)
-5. **Built-in defaults** — Sensible defaults for all settings
+4. **~/.cora/config.yaml** — Global config
+5. **Auto-detect** — Provider-specific env vars (`OPENAI_API_KEY`, `ZAI_API_KEY`, etc.)
+6. **Built-in defaults** — Sensible defaults for all settings
+
+### API Key Resolution
+
+1. `--api-key` flag (one-shot)
+2. `CORA_API_KEY` env var (CI)
+3. `~/.cora/auth.toml` (local dev)
+4. Provider-specific env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
 
 ## .cora.yaml Example
 
@@ -55,7 +72,7 @@ ignore:
 
 | Variable | Description |
 |----------|-------------|
-| `CORA_API_KEY` | API key for the active provider |
+| `CORA_API_KEY` | API key for CI (overrides auth.toml) |
 | `CORA_PROVIDER` | Active provider (openai, anthropic, groq, ollama, zai) |
 | `CORA_MODEL` | Model name override |
 | `CORA_BASE_URL` | Custom API base URL |


### PR DESCRIPTION
## Summary

Release v0.4.5 — config architecture redesign, auth improvements, bug fixes, and documentation updates.

## Changes Since v0.4.4

### Changed
- Config architecture redesign (#209) — auth.toml for secrets only, config.yaml for settings
- Provider info auto-migration from auth.toml → config.yaml
- Deterministic rules exclude `rules/` path (#185)

### Fixed
- `cora review` sends to wrong provider — now reads from merged config (#209)
- `cora config show` displays effective resolved config with source annotations (#189)
- `cora auth login` auto-detects provider env vars, suggests model/base URL defaults (#203)
- `save_provider_info` data loss on parse failure
- Env var override visibility (#182)
- Truncated JSON repair — 12 new tests (#186)

### Added
- `cora config show --global` / `--project` flags (mutually exclusive)
- Interactive model/base URL prompts with enter-to-accept defaults

### Docs
- README: updated auth flow, config show flags, CORA_API_KEY description
- docs/configuration.md: new file roles table, API key resolution section
- CHANGELOG.md: full v0.4.5 entry

## Files Changed
- `Cargo.toml` — version bump 0.4.4 → 0.4.5
- `CHANGELOG.md` — v0.4.5 entry
- `README.md` — auth flow, config section, env var table
- `docs/configuration.md` — file roles, resolution order, API key resolution

## Test Plan
- [x] All tests pass (333+ unit, 16 CLI, 6 config)
- [x] Pre-commit hook: no issues found
- [x] `cora auth status` shows correct provider
- [x] `cora config show` shows effective config
- [x] `cora review` sends to correct provider