### PR TITLE
docs: redesign README — shorter, professional, link to docs (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,577 +2,147 @@
 
 <img src="assets/logo.png" alt="CodeCora" width="120" />
 
-**AI-Powered Code Review CLI**
+**AI-Powered Code Review CLI — BYOK**
 
+[![GitHub stars](https://img.shields.io/github/stars/codecoradev/cora-cli?style=social)](https://github.com/codecoradev/cora-cli/stargazers)
 [![CI](https://github.com/codecoradev/cora-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/codecoradev/cora-cli/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/cora-cli.svg)](https://crates.io/crates/cora-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/Rust-1.85+-orange.svg)](https://www.rust-lang.org/)
 
-**Cora** is a fast, opinionated CLI tool that uses LLMs to review your code changes — directly in your terminal, CI/CD pipeline, or git hooks.
-
 </div>
 
 ---
 
-## ✨ Features
+**Cora** is a fast, native CLI that uses any LLM to review your code — in your terminal, CI/CD, or git hooks. Bring your own key, pick any model, review in seconds.
 
-- 🔍 **Git-Aware Scanning** — Automatically detects staged, committed, or changed files
-- 🤖 **Multi-LLM Support** — Works with OpenAI, Anthropic, Google, Ollama, and any OpenAI-compatible API
-- 🎨 **Beautiful Output** — Colorized, structured review output with severity levels
-- 🏗️ **CI/CD Ready** — Designed for GitHub Actions, GitLab CI, and any pipeline
-- ⚡ **Fast & Lightweight** — Native Rust binary, no runtime dependencies
-- 📋 **SARIF Output** — Upload results to GitHub Code Scanning
-- 🔧 **Configurable** — YAML config file with project-level defaults
-- 🪝 **Git Hooks** — Pre-commit integration for instant feedback
-- 📊 **Exit Codes** — Non-zero exit on critical findings for pipeline gating
-- 🧠 **Deterministic Reviews** — Temperature 0 by default: same diff always produces the same issues
-- 💾 **Diff-Hash Caching** — Reviews cached by diff hash in `~/.cache/cora/reviews/` — skip repeat reviews with `--no-cache`
-- 🎯 **Custom System Prompts** — Override review/scan prompts via config or file path
-- 🛡️ **Anti-Hallucination** — File path injection and post-parse filtering keep LLM output grounded
-- 🌡️ **Configurable LLM Params** — Tune temperature, max tokens, timeout, and cache TTL per project
-- 📄 **Output Capture** — `--output-file` writes review results to file, clean non-TTY output for CI/batch pipelines
+## Why Cora?
 
-## 📦 Installation
+- 🤖 **Multi-LLM** — OpenAI, Anthropic, Groq, Ollama, Z.AI, or any OpenAI-compatible API
+- ⚡ **Native Rust** — fast binary, no runtime dependencies, cross-platform
+- 🪝 **Pre-commit hooks** — catch issues before they reach CI
+- 📋 **SARIF output** — upload to GitHub Code Scanning
+- 🛡️ **Deterministic rules** — regex-based pre-scan that always catches known patterns
+- 💾 **Diff-hash caching** — skip repeat reviews automatically
+- 🔧 **Configurable** — per-project `.cora.yaml`, global `~/.cora/config.yaml`, or env vars
 
-### Quick Install (Linux/macOS)
+## Quick Start
+
+### Install
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 ```
 
-Installs to `~/.local/bin`. Add to PATH if needed:
+> Pin a version: `CORA_VERSION=v0.4.5 curl -fsSL ... | sh`  
+> Or: `cargo install --git https://github.com/codecoradev/cora-cli`  
+> Pre-built binaries: [GitHub Releases](https://github.com/codecoradev/cora-cli/releases)
 
-```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
-```
-
-Pin a specific version with `CORA_VERSION`:
-
-```bash
-CORA_VERSION=v0.4.4 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
-```
-
-### Pre-built Binaries
-
-Download from [GitHub Releases](https://github.com/codecoradev/cora-cli/releases):
-
-| Platform | Asset |
-|----------|-------|
-| Linux x86_64 | `cora-x86_64-unknown-linux-gnu-v*.tar.gz` |
-| Linux ARM64 | `cora-aarch64-unknown-linux-gnu-v*.tar.gz` |
-| macOS Apple Silicon | `cora-aarch64-apple-darwin-v*.tar.gz` |
-| Windows x86_64 | `cora-x86_64-pc-windows-msvc-v*.zip` |
-
-> **Windows users:** Extract the zip and place `cora.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run from Command Prompt, PowerShell, or Windows Terminal — do not double-click the `.exe` (it will flash and close).
-
-### Cargo
-
-```bash
-cargo install --git https://github.com/codecoradev/cora-cli
-```
-
-### Homebrew
-
-> 🚧 Homebrew tap is planned — see [#151](https://github.com/codecoradev/cora-cli/issues/151).
-
-### Build from Source
-
-Requires **Rust 1.85+**.
-
-```bash
-git clone https://github.com/codecoradev/cora-cli.git
-cd cora-cli
-cargo install --path .
-```
-
-## 🚀 Quick Start
-
-### 1. Install
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
-```
-
-### 2. Set Up Authentication
+### Authenticate
 
 ```bash
 cora auth login
 ```
 
-Pick your provider, enter your API key — done. Cora stores the API key in `~/.cora/auth.toml` (never committed to git) and provider settings in `~/.cora/config.yaml`.
+Pick a provider, enter your API key. Done. Provider env vars (`ZAI_API_KEY`, `OPENAI_API_KEY`, etc.) are auto-detected.
 
-> **No API key yet?** Set any provider env var instead: `export OPENAI_API_KEY="..."`
-
-### 3. Review Your Code
+### Review
 
 ```bash
-# Review staged changes
-cora review
-
-# Review vs a branch
-cora review --base origin/main
-
-# Review the last commit
-cora review --commit HEAD
+cora review              # staged changes
+cora review --base main  # vs a branch
+cora review --unpushed   # unpushed commits
 ```
 
-### 4. Optional — Project Config
+### Project Config
 
 ```bash
-cora init
+cora init  # creates .cora.yaml + installs pre-commit hook
 ```
 
-Creates `.cora.yaml` in your project root and **automatically installs a pre-commit hook**. The hook runs `cora review --staged --format compact` before each commit. Use `--no-hook` to skip.
+## Configuration
 
-```bash
-# Skip hook installation
-cora init --no-hook
-
-# Manage hooks separately
-cora hook install
-cora hook uninstall
-```
-
-### 5. Provider Shortcuts (v0.4.2+)
-
-You can set `model`, `base_url`, and `provider` directly in `.cora.yaml`:
-
-```yaml
-provider: openai
-model: gpt-4o-mini
-base_url: https://api.openai.com/v1
-```
-
-No need for nested `provider:` section. Run `cora config show` to verify resolved config.
-
-## 📖 Commands
-
-### `cora review`
-
-Review code changes using an LLM.
-
-```bash
-# Review staged files (default)
-cora review
-
-# Review unpushed changes
-cora review --unpushed
-
-# Review a range of commits
-cora review --commit HEAD~3..HEAD
-
-# Review changes vs a base branch
-cora review --base origin/main
-
-# Review a pull request diff from a file
-cora review --diff-file pr.diff
-
-# CI mode: skip diff size limit, hard gate on any findings
-cora review --ci --base ${{ github.base_ref }}
-
-# Use a specific model
-cora review --model gpt-4o
-
-# Output as SARIF
-cora review --format sarif
-
-# Output as JSON
-cora review --format json
-
-# Upload SARIF to GitHub Code Scanning (implies --format sarif)
-cora review --upload
-
-# Set severity threshold
-cora review --severity major
-
-# Quiet mode (machine-readable)
-cora review --quiet
-
-# Skip cached reviews
-cora review --no-cache
-
-# Save review output to file (v0.4.4+)
-cora review --output-file review.txt
-```
-
-### `cora scan`
-
-Scan files for code quality issues without requiring git context.
-
-```bash
-# Scan current directory
-cora scan
-
-# Scan a specific directory
-cora scan --path src/
-
-# Scan with focus areas
-cora scan --focus security,performance
-
-# Exclude patterns
-cora scan --exclude "tests/**" --exclude "examples/**"
-
-# Only scan changed files (incremental)
-cora scan --incremental
-```
-
-### `cora config`
-
-Manage configuration. Supports both project-level (`.cora.yaml`) and global (`~/.cora/config.yaml`) config.
-
-```bash
-# Show current resolved configuration
-cora config show
-
-# Show only global config (~/.cora/config.yaml)
-cora config show --global
-
-# Show only project config (.cora.yaml)
-cora config show --project
-
-# Set a project-level value (writes to .cora.yaml)
-cora config set model claude-sonnet-4-20250514
-cora config set base_url https://api.openai.com/v1
-cora config set severity major
-
-# Set a global value (writes to ~/.cora/config.yaml)
-cora config set --global model gpt-4o-mini
-cora config set --global provider anthropic
-
-# Supported keys: model, provider, base_url, format, severity
-```
-
-**Priority**: CLI flags → env vars → `.cora.yaml` (project) → `~/.cora/config.yaml` (global) → defaults
-
-### `cora init`
-
-Create a `.cora.yaml` config file in the current directory.
-
-```bash
-cora init
-```
-
-### `cora completion`
-
-Generate shell completions.
-
-```bash
-cora completion bash > ~/.cora-completion.bash
-cora completion zsh > ~/.cora-completion.zsh
-cora completion fish > ~/.cora-completion.fish
-```
-
-### `cora hook`
-
-Manage pre-commit git hooks.
-
-```bash
-cora hook install
-cora hook uninstall
-```
-
-## ⚙️ Configuration
-
-Cora reads configuration from multiple sources in priority order:
-
-```
-CLI flags → CORA_* env vars → .cora.yaml (project) → ~/.cora/config.yaml (global) → defaults
-```
-
-Create a `.cora.yaml` in your project root, or use `~/.cora/config.yaml` for global settings. Project config always overrides global.
+**Priority:** CLI flags → env vars → `.cora.yaml` (project) → `~/.cora/config.yaml` (global) → defaults
 
 ```yaml
 # .cora.yaml
-
-# Provider configuration (shortcut format — v0.4.2+)
-provider: openai
-model: gpt-4o-mini
-base_url: https://api.openai.com/v1
-
-# Or use nested format for multiple keys:
-# provider:
-#   provider: openai
-#   model: gpt-4o-mini
-#   base_url: https://api.openai.com/v1
-
-# LLM parameters
-llm:
-  temperature: 0              # Default: 0 (deterministic — same diff = same issues)
-  max_tokens: 4096            # Default: 4096
-  timeout: 120                # Default: 120 (seconds)
-  cache_ttl: 1440             # Default: 1440 (minutes) — diff-hash cache TTL
-
-# Focus areas for review (empty = all)
-focus:
-  - security
-  - performance
-  - bugs
-  - best_practice
-
-# Review options
-review:
-  system_prompt: "You are a senior Rust code reviewer."
-  # system_prompt_file: ./review-prompt.md   # Load prompt from file
-  response_format: json_object              # Opt-in structured JSON output
-
-# Scan options
-# scan:
-#   system_prompt: "Focus on security vulnerabilities."
-#   system_prompt_file: ./scan-prompt.md
-
-# Custom rules
-rules:
-  - "no unwrap"
-
-# Ignore configuration
-ignore:
-  files:
-    - "tests/**"
-    - "vendor/**"
-    - "*.generated.*"
-  rules:
-    - "skip-rule-1"
-
-# Hook configuration
-hook:
-  mode: warn               # warn | block
-  min_severity: major       # info | minor | major | critical
-  max_diff_size: 51200      # Max diff size in bytes (50 KB)
-  on_violation: warn        # warn | disallow — block commit on oversized diff
-
-# Output settings
-output:
-  format: pretty            # pretty | json | compact | sarif
-  color: true
+provider: zai
+model: glm-5.1
+focus: [security, bugs]
 ```
-
-### Environment Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `OPENAI_API_KEY` | OpenAI API key | — |
-| `ANTHROPIC_API_KEY` | Anthropic API key | — |
-| `GOOGLE_API_KEY` | Google AI API key | — |
-| `CORA_API_KEY` | API key (for CI — overrides all other sources) | — |
-| `CORA_MODEL` | Override model | — |
-| `CORA_PROVIDER` | Override provider | — |
-| `CORA_BASE_URL` | Override API base URL | — |
-| `CORA_CONFIG` | Path to config file | `.cora.yaml` |
-| `CORA_FORMAT` | Output format (`pretty`, `json`, `compact`, `sarif`) | `pretty` |
-| `CORA_NO_COLOR` | Disable colored output | — |
-| `CORA_NO_CACHE` | Skip diff-hash cache (same as `--no-cache`) | — |
-
-### Authentication
-
-API keys can be provided via environment variables, stored in `~/.cora/auth.toml` (auto-created by `cora auth login`, permission `0600`), or passed via CLI flags.
-
-#### Interactive Login (Recommended)
 
 ```bash
-cora auth login
+cora config show           # effective merged config
+cora config show --global  # ~/.cora/config.yaml
+cora config show --project # .cora.yaml
 ```
 
-This starts an interactive setup that:
+| File | Purpose |
+|------|---------|
+| `~/.cora/auth.toml` | API key (secret, chmod 600) |
+| `~/.cora/config.yaml` | Global defaults (provider, model, etc.) |
+| `.cora.yaml` | Per-project overrides |
 
-1. **Lists known providers** — OpenAI, Anthropic, Groq, Ollama, Z.AI
-2. **Lets you pick one** — known providers only need an API key
-3. **Or choose "custom"** — enter your own base URL, model, and API key for any OpenAI-compatible endpoint
+See **[Configuration →](docs/configuration.md)** for full reference.
 
-Example flow:
-
-```
-$ cora auth login
-
-🔑 Cora Auth Setup
-   Choose your LLM provider:
-
-  [1] openai
-  [2] anthropic
-  [3] groq
-  [4] ollama
-  [5] zai
-  [6] custom
-
-  Select provider [1-6]: 5
-
-  → Provider: zai
-  🔑 Found ZAI_API_KEY in environment
-     Use it? [Y/n]: Y
-     ✅ Using ZAI_API_KEY from environment
-
-  Model [glm-5.1]:          ← press Enter to accept default
-  Base URL [https://api.z.ai/api/coding/paas/v4]:  ← press Enter to accept default
-
-✅ API key saved to ~/.cora/auth.toml
-   Provider: zai | Model: glm-5.1 | Base: https://api.z.ai/api/coding/paas/v4
-```
-
-> Provider env vars are auto-detected — pick ZAI and `ZAI_API_KEY` is found automatically.
-
-#### Check Auth Status
-
-```bash
-cora auth status
-```
-
-Shows your configured provider, model, and key source.
-
-#### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `CORA_API_KEY` | API key (overrides all other sources) |
-| `OPENAI_API_KEY` | OpenAI API key (auto-detected) |
-| `ANTHROPIC_API_KEY` | Anthropic API key (auto-detected) |
-| `GROQ_API_KEY` | Groq API key (auto-detected) |
-| `ZAI_API_KEY` | Z.AI API key (auto-detected) |
-| `CORA_PROVIDER` | Override provider name |
-| `CORA_MODEL` | Override model |
-| `CORA_BASE_URL` | Override API base URL |
-
-## 🔗 CI/CD Integration
-
-### GitHub Actions
-
-Using the official [cora-review composite action](.github/actions/cora-review):
+## CI/CD
 
 ```yaml
-name: CI
-on:
-  pull_request:
-    branches: [develop]
-
+# .github/workflows/cora-review.yml
+on: pull_request
 jobs:
-  cora-review:
+  review:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        with: { fetch-depth: 0 }
       - uses: ./.github/actions/cora-review
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          infisical-identity-id: ${{ secrets.INFISICAL_IDENTITY_ID }}
-          severity: major
-          upload-sarif: 'true'
 ```
 
-Or install manually:
+Required secrets: `CORA_API_KEY`, `CORA_BASE_URL`, `CORA_MODEL`
 
-```yaml
-# Manual install in CI (using install script)
-- name: Install cora-cli
-  run: curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
-```
+## Commands
 
-### GitLab CI
+| Command | Description |
+|---------|-------------|
+| `cora review` | Review code changes |
+| `cora scan` | Scan files for issues |
+| `cora init` | Create project config + hook |
+| `cora auth login` | Save API key |
+| `cora config show` | Show resolved config |
+| `cora providers` | List available LLM providers |
+| `cora hook install` | Install pre-commit hook |
 
-```yaml
-# .gitlab-ci.yml
-code-review:
-  stage: test
-  image: rust:latest
-  before_script:
-    - cargo install cora-cli
-  script:
-    - cora review --base origin/main --severity major
-  variables:
-    OPENAI_API_KEY: $CI_OPENAI_API_KEY
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-```
+See **[CLI Reference →](docs/cli-reference.md)** for all flags and examples.
 
-### Pre-commit Hook
+## Environment Variables
 
-Add cora as a git pre-commit hook for instant feedback:
+| Variable | Description |
+|----------|-------------|
+| `CORA_API_KEY` | API key (CI use) |
+| `CORA_PROVIDER` | Override provider |
+| `CORA_MODEL` | Override model |
+| `CORA_BASE_URL` | Override API base URL |
 
-```bash
-# Install as pre-commit hook
-cora hook install
+Provider-specific keys are auto-detected: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `ZAI_API_KEY`
 
-# Review only staged files before each commit
-# This runs automatically on `git commit`
+## Documentation
 
-# Remove the hook
-cora hook uninstall
-```
+| Page | Description |
+|------|-------------|
+| [Getting Started](docs/getting-started.md) | Install, auth, first review |
+| [Configuration](docs/configuration.md) | Config files, env vars, priority |
+| [CLI Reference](docs/cli-reference.md) | All commands and flags |
+| [Providers](docs/providers.md) | Supported LLM providers |
+| [Examples](docs/examples.md) | Common workflows |
+| [Roadmap](docs/roadmap.md) | Planned features |
 
-Or add it manually to `.git/hooks/pre-commit`:
+## Contributing
 
-```bash
-#!/bin/sh
-# cora-cli pre-commit hook
-cora review --quiet --severity major
-if [ $? -ne 0 ]; then
-  echo "❌ Code review found critical issues. Commit blocked."
-  echo "   Run 'cora review' to see details, or use 'git commit --no-verify' to skip."
-  exit 1
-fi
-```
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for guidelines. PRs welcome!
 
-### With [pre-commit](https://pre-commit.com) framework
+## License
 
-> 🚧 Planned — the pre-commit hook repo will be available soon. For now, use `cora hook install` directly.
-
-## 🆚 Positioning: How Cora Compares
-
-| Feature | **cora-cli** | AI Agent IDE Tools | Standard Linters |
-|---------|:---:|:---:|:---:|
-| Semantic code understanding | ✅ | ✅ | ❌ |
-| Security vulnerability detection | ✅ | ✅ | ⚠️ (pattern only) |
-| Performance suggestions | ✅ | ✅ | ❌ |
-| Runs in CI/CD pipeline | ✅ | ❌ | ✅ |
-| SARIF / structured output | ✅ | ❌ | ✅ |
-| Zero-config quick start | ✅ | ❌ | ⚠️ |
-| No IDE required | ✅ | ❌ | ✅ |
-| Understands business context | ⚠️ | ✅ | ❌ |
-| Near-instant feedback | ⚠️ | ✅ | ✅ |
-| Cost per review | 💰 | 💰💰💰 | Free |
-| Works with any codebase | ✅ | ⚠️ | ⚠️ |
-
-**cora-cli sits between traditional linters and AI IDE agents**: it provides semantic understanding that static tools can't match, while being lightweight enough to run in any CI pipeline or terminal — no IDE plugin required.
-
-- **vs. Linters (clippy, eslint, etc.)**: Cora understands *intent* and *context*, catching logical errors, security flaws, and design issues that pattern-based tools miss.
-- **vs. AI IDE Agents (Copilot, Cursor)**: Cora is pipeline-first — it runs in CI/CD, pre-commit hooks, and headless environments. It's the tool you use when you want AI review baked into your development workflow, not tied to a specific editor.
-
-## 🛠️ Development
-
-Requires **Rust 1.85+**.
-
-```bash
-# Build
-cargo build
-
-# Test
-cargo test
-
-# Lint
-cargo clippy -- -D warnings
-
-# Format
-cargo fmt
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
-
-## 🤝 Contributing
-
-Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) before submitting PRs.
-
-## 📄 License
-
-This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
-
-## 🙏 Acknowledgments
-
-- Built with [Rust](https://www.rust-lang.org/) and [Clap](https://clap.rs/)
-- Powered by state-of-the-art LLMs from [OpenAI](https://openai.com/), [Anthropic](https://www.anthropic.com/), and [Google](https://ai.google/)
-
----
-
-<div align="center">
-
-**Made with 🦀 by [codecoradev](https://github.com/codecoradev)**
-
-</div>
+[MIT](LICENSE)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,10 +35,9 @@ Complete command reference for the cora CLI.
 | `cora scan` `<path>` | Scan files for issues |
 | `cora scan .` `[--incremental]` | Scan only changed files |
 | `cora config show` | Show resolved configuration |
-| `cora config set` `<key>` `<value>` | Set a config value |
 | `cora hook install` | Install pre-commit hook |
 | `cora hook uninstall` | Remove pre-commit hook |
-| `cora auth login` | Save API key to `~/.cora/config.toml` |
+| `cora auth login` | Save API key to `~/.cora/auth.toml` |
 | `cora auth status` | Check current auth status |
 | `cora auth remove` | Remove stored API key |
 | `cora providers` | List detected AI providers |


### PR DESCRIPTION
## Summary

Redesign README from 568 → 148 lines. Short, professional, links to docs/ for details.

## Changes

### README.md (full rewrite)
- Star badge + social stats in header
- Quick start in 3 steps (install, auth login, review)
- Config section with file roles table (auth.toml vs config.yaml vs .cora.yaml)
- Commands table linking to `docs/cli-reference.md`
- CI/CD section with minimal GitHub Actions example
- Docs index table linking to all documentation pages
- Removed verbose examples (already in `docs/examples.md`)

### docs/cli-reference.md
- Fixed `cora auth login` path: `config.toml` → `auth.toml`
- Added `cora config show --global` and `--project`

## Test Plan
- [x] Pre-commit hook: no issues found
- [x] All tests pass
- [x] All doc links verified (relative paths to existing docs/)