### PR TITLE
docs: update links to codecora.dev + quality gate docs + changelog v0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to cora-cli are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-08
+
+### Added
+
+- **Quality Gate** — configurable threshold-based PASS/FAIL for CI enforcement (#205)
+  - Global thresholds: `max_critical`, `max_major`, `max_minor`, `max_security`
+  - Per-category overrides: `block`, `warn`, `ignore` actions
+  - Terminal-formatted gate output with status table
+  - Exit code 2 on gate failure
+  - 12 unit tests covering all gate scenarios
+- **Diff chunker module** — `src/engine/chunker.rs` for splitting large diffs (#188, integration pending #228)
+- **Multi-platform CI docs** — Gitea/Forgejo, GitLab CI, Bitbucket Pipelines workflow examples (#225)
+
+### Changed
+
+- **README links** — all documentation links now point to `codecora.dev` instead of relative file paths
+- **CI workflows** — removed stale SvelteKit `website/` jobs, replaced with VitePress `docs/` build
+- **13 stale issues closed** — migration epics, website tasks, v0.4 leftovers
+- **15 stale branches deleted** — cleanup after merge
+
+### Removed
+
+- **SvelteKit `website/`** — 6,286 lines removed, replaced by VitePress `docs/`
+- **`Website Lint` CI job** — removed from required status checks
+
 ## [0.4.7] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ cora init  # creates .cora.yaml + installs pre-commit hook
 provider: zai
 model: glm-5.1
 focus: [security, bugs]
+
+# Quality gate — enforce code quality in CI
+quality_gate:
+  enabled: true
+  thresholds:
+    max_critical: 0     # 0 critical = gate FAIL
+    max_security: 0     # 0 security findings = gate FAIL
+  categories:
+    performance:
+      action: warn      # warn only, don't fail CI
+      max_findings: 5
 ```
 
 ```bash
@@ -83,7 +94,7 @@ cora config show --project # .cora.yaml
 | `~/.cora/config.yaml` | Global defaults (provider, model, etc.) |
 | `.cora.yaml` | Per-project overrides |
 
-See **[Configuration →](docs/configuration.md)** for full reference.
+See **[Configuration →](https://codecora.dev/configuration.html)** for full reference.
 
 ## CI/CD
 
@@ -108,7 +119,7 @@ Required secrets: `CORA_API_KEY`, `CORA_BASE_URL` (optional), `CORA_MODEL` (opti
 
 See [GitHub Marketplace](https://github.com/marketplace/actions/cora-ai-code-review) for full documentation.
 
-Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](docs/examples.md#07--gitea--forgejo-ci)
+Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecora.dev/examples.html#_07-gitea-forgejo-ci)
 
 ## Commands
 
@@ -122,7 +133,7 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](docs/examples.m
 | `cora providers` | List available LLM providers |
 | `cora hook install` | Install pre-commit hook |
 
-See **[CLI Reference →](docs/cli-reference.md)** for all flags and examples.
+See **[CLI Reference →](https://codecora.dev/cli-reference.html)** for all flags and examples.
 
 ## Environment Variables
 
@@ -139,12 +150,13 @@ Provider-specific keys are auto-detected: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](docs/getting-started.md) | Install, auth, first review |
-| [Configuration](docs/configuration.md) | Config files, env vars, priority |
-| [CLI Reference](docs/cli-reference.md) | All commands and flags |
-| [Providers](docs/providers.md) | Supported LLM providers |
-| [Examples](docs/examples.md) | Common workflows |
-| [Roadmap](docs/roadmap.md) | Planned features |
+| [Getting Started](https://codecora.dev/getting-started.html) | Install, auth, first review |
+| [Configuration](https://codecora.dev/configuration.html) | Config files, env vars, priority |
+| [CLI Reference](https://codecora.dev/cli-reference.html) | All commands and flags |
+| [Providers](https://codecora.dev/providers.html) | Supported LLM providers |
+| [Examples](https://codecora.dev/examples.html) | Common workflows & CI setup |
+| [Changelog](https://codecora.dev/changelog.html) | Release history |
+| [Roadmap](https://codecora.dev/roadmap.html) | Planned features |
 
 ## Contributing
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,31 @@ All notable changes to cora-cli are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-08
+
+### Added
+
+- **Quality Gate** — configurable threshold-based PASS/FAIL for CI enforcement (#205)
+  - Global thresholds: `max_critical`, `max_major`, `max_minor`, `max_security`
+  - Per-category overrides: `block`, `warn`, `ignore` actions
+  - Terminal-formatted gate output with status table
+  - Exit code 2 on gate failure
+  - 12 unit tests covering all gate scenarios
+- **Diff chunker module** — `src/engine/chunker.rs` for splitting large diffs (#188, integration pending #228)
+- **Multi-platform CI docs** — Gitea/Forgejo, GitLab CI, Bitbucket Pipelines workflow examples (#225)
+
+### Changed
+
+- **README links** — all documentation links now point to `codecora.dev` instead of relative file paths
+- **CI workflows** — removed stale SvelteKit `website/` jobs, replaced with VitePress `docs/` build
+- **13 stale issues closed** — migration epics, website tasks, v0.4 leftovers
+- **15 stale branches deleted** — cleanup after merge
+
+### Removed
+
+- **SvelteKit `website/`** — 6,286 lines removed, replaced by VitePress `docs/`
+- **`Website Lint` CI job** — removed from required status checks
+
 ## [0.4.7] - 2026-06-08
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,6 +152,73 @@ cora uses two mechanisms to prevent the LLM from fabricating findings:
 - **File path injection** — Actual file paths are embedded in the prompt, anchoring the LLM to real files in the diff.
 - **Post-parse filtering** — After parsing, any reported file paths or line numbers that don't exist in the actual diff are discarded.
 
+## Quality Gate
+
+Quality gate evaluates review findings against configurable thresholds to produce a **PASS/FAIL** result. This is useful for CI enforcement — block merges when code quality drops below your standards.
+
+```yaml
+quality_gate:
+  enabled: true
+
+  # Global thresholds — any exceeded = FAIL
+  thresholds:
+    max_critical: 0        # 0 critical issues allowed
+    max_major: 3           # max 3 major issues (disabled by default)
+    max_minor: 10          # max 10 minor issues (disabled by default)
+    max_security: 0        # 0 security findings allowed
+
+  # Per-category overrides
+  categories:
+    security:
+      action: block        # block = any finding → CI fail
+      max_findings: 0
+    performance:
+      action: warn         # warn = comment only, don't fail CI
+      max_findings: 5
+    bug_risk:
+      action: block
+      max_findings: 3
+    style:
+      action: ignore       # skip entirely — don't count toward gate
+```
+
+### How It Works
+
+1. After review, findings are counted by severity and category
+2. Each threshold is checked against actual counts
+3. Category actions determine enforcement:
+   - **block** — exceed threshold = gate FAIL (exit code 2)
+   - **warn** — report but don't fail gate
+   - **ignore** — skip entirely
+4. Overall gate status: **PASSED** or **FAILED**
+
+### CLI Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  QUALITY GATE RESULT
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Status:   ❌ FAILED
+  Findings: 2 critical, 1 major, 4 minor, 0 info
+
+  Threshold Checks:
+  ❌ max_critical          → 2 found   ❌ EXCEEDED
+  ✅ max_major             → 1 found   ✅ OK
+  ✅ max_security          → 0 found   ✅ OK
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|----------|
+| 0 | Gate passed, no issues |
+| 2 | Gate failed (threshold exceeded) |
+
+### Default Behavior
+
+When `quality_gate.enabled` is `false` (default), quality gate is skipped. The existing `--ci` flag and `hook.on_violation` settings continue to work as before.
+
 ## Secrets Pre-Scan
 
 cora runs a deterministic secrets scan before the AI review. 12 built-in patterns detect leaked credentials:


### PR DESCRIPTION
### Updated
| File | Change |
|------|--------|
| `README.md` | All doc links → `codecora.dev`, added quality gate config example |
| `docs/configuration.md` | New Quality Gate section (config, output, exit codes, defaults) |
| `CHANGELOG.md` | v0.5.0 entry |
| `docs/changelog.md` | Synced |

### Links
All documentation links now resolve to `codecora.dev`:
- https://codecora.dev/getting-started.html
- https://codecora.dev/configuration.html
- https://codecora.dev/examples.html
- https://codecora.dev/cli-reference.html
- etc.