### PR TITLE
feat(profiles): add quality profiles — preset rule sets per project

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod completion;
 pub mod config_cmd;
 pub mod hook_cmd;
 pub mod init;
+pub mod profile;
 pub mod providers;
 pub mod review;
 pub mod scan;

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -1,0 +1,140 @@
+//! `cora profile` subcommand — list, show, and validate quality profiles.
+
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::engine::profiles;
+
+/// Execute `cora profile list` — show all available built-in profiles.
+pub fn execute_profile_list() -> Result<()> {
+    println!("{}", "Available Quality Profiles:".bold());
+    println!();
+
+    for name in profiles::BUILTIN_PROFILES {
+        if let Some(p) = profiles::load_builtin(name) {
+            println!(
+                "  {} {}",
+                p.name.bold().cyan(),
+                format!("(v{})", p.version).dimmed()
+            );
+            println!("    {}", p.description.dimmed());
+            println!(
+                "    {} focus areas, {} ignored, tone: {}",
+                p.focus_areas.len().to_string().green(),
+                p.ignore_areas.len(),
+                p.review_style.tone
+            );
+            println!();
+        }
+    }
+
+    println!("{}", "Usage:".bold());
+    println!("  {}  # in .cora.yaml", "profile: security-first".cyan());
+    println!(
+        "  {}  # extend with overrides",
+        "profile: { extends: rust-strict, ... }".cyan()
+    );
+    println!(
+        "  {}  # from file",
+        "profile: ./my-team-profile.yaml".cyan()
+    );
+
+    Ok(())
+}
+
+/// Execute `cora profile show <name>` — display a profile's full definition.
+pub fn execute_profile_show(name: &str) -> Result<()> {
+    let profile = profiles::load_builtin(name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Unknown profile '{}'. Available: {}",
+            name,
+            profiles::BUILTIN_PROFILES.join(", ")
+        )
+    })?;
+
+    println!(
+        "{} {}",
+        profile.name.bold().cyan(),
+        format!("(v{})", profile.version).dimmed()
+    );
+    println!("{}", profile.description);
+    println!();
+
+    // Focus areas
+    if !profile.focus_areas.is_empty() {
+        println!("{}", "Focus Areas:".bold());
+        let mut areas = profile.focus_areas.clone();
+        areas.sort_by_key(|b| std::cmp::Reverse(b.weight));
+
+        for area in &areas {
+            let action_label = if area.action == "block" {
+                "BLOCK".red().bold().to_string()
+            } else {
+                "WARN".yellow().to_string()
+            };
+            println!(
+                "  {} [weight: {}/10, {}]",
+                area.id.bold(),
+                area.weight,
+                action_label
+            );
+            for rule in &area.rules {
+                println!("    - {rule}");
+            }
+        }
+        println!();
+    }
+
+    // Ignore areas
+    if !profile.ignore_areas.is_empty() {
+        println!(
+            "{} {}",
+            "Ignored:".bold(),
+            profile.ignore_areas.join(", ").dimmed()
+        );
+        println!();
+    }
+
+    // Review style
+    println!("{}", "Review Style:".bold());
+    println!("  tone: {}", profile.review_style.tone);
+    println!("  detail_level: {}", profile.review_style.detail_level);
+    println!("  suggest_fixes: {}", profile.review_style.suggest_fixes);
+    println!(
+        "  max_findings: {}",
+        profile
+            .review_style
+            .max_findings
+            .map_or_else(|| "unlimited".to_string(), |m| m.to_string())
+    );
+
+    Ok(())
+}
+
+/// Execute `cora profile validate <path>` — validate a custom profile YAML file.
+pub fn execute_profile_validate(path: &str) -> Result<()> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("cannot read '{}': {e}", path))?;
+
+    match profiles::parse_profile_yaml(&content) {
+        Ok(profile) => {
+            println!("{} Valid profile: {}", "✅".green(), profile.name.bold());
+            if !profile.description.is_empty() {
+                println!("   {}", profile.description.dimmed());
+            }
+            println!(
+                "   {} focus areas, {} ignore areas",
+                profile.focus_areas.len(),
+                profile.ignore_areas.len()
+            );
+            println!(
+                "   Review style: tone={}, detail={}",
+                profile.review_style.tone, profile.review_style.detail_level
+            );
+            Ok(())
+        }
+        Err(e) => {
+            anyhow::bail!("Invalid profile: {e}");
+        }
+    }
+}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -47,6 +47,8 @@ pub struct Config {
     pub context_chain: crate::engine::context::types::ContextConfig,
     /// File bundling configuration for scan/review grouping.
     pub bundling: BundlingConfig,
+    /// Active quality profile (resolved from .cora.yaml).
+    pub profile: Option<crate::engine::profiles::Profile>,
 }
 
 /// Provider configuration.
@@ -128,6 +130,7 @@ impl Default for Config {
             rules_config: RulesConfig::default(),
             context_chain: crate::engine::context::types::ContextConfig::default(),
             bundling: BundlingConfig::default(),
+            profile: None,
         }
     }
 }
@@ -174,6 +177,8 @@ pub struct CoraFile {
     pub rules_engine: Option<RulesSection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bundling: Option<BundlingSection>,
+    #[serde(default)]
+    pub profile: Option<crate::engine::profiles::ProfileRef>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -459,6 +464,17 @@ impl CoraFile {
             }
             if let Some(v) = b.coalesce_by_language {
                 config.bundling.coalesce_by_language = v;
+            }
+        }
+        // Resolve profile — load built-in or custom, merge into config
+        if let Some(profile_ref) = &self.profile {
+            match crate::engine::profiles::resolve_profile(profile_ref) {
+                Ok(profile) => {
+                    config.profile = Some(profile);
+                }
+                Err(e) => {
+                    tracing::warn!("failed to resolve profile: {e}");
+                }
             }
         }
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -473,7 +473,8 @@ impl CoraFile {
                     config.profile = Some(profile);
                 }
                 Err(e) => {
-                    tracing::warn!("failed to resolve profile: {e}");
+                    // Warn but don't fail — profile is optional enhancement
+                    tracing::warn!("invalid profile in config, ignoring: {e}");
                 }
             }
         }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,6 +4,7 @@ pub mod chunker;
 pub mod context;
 pub mod diff_parser;
 pub mod llm;
+pub mod profiles;
 pub mod quality_gate;
 pub mod review;
 pub mod rules;

--- a/src/engine/profiles.rs
+++ b/src/engine/profiles.rs
@@ -1,0 +1,432 @@
+//! Quality profiles — preset and configurable rule sets per project.
+//!
+//! Profiles define focus areas, weights, and review behavior that modify
+//! the AI review prompt. Built-in profiles are embedded at compile time.
+//! Custom profiles can be loaded from `.cora.yaml` or external files.
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+// ─── Built-in profile YAML sources (embedded at compile time) ───
+
+const SECURITY_FIRST_YAML: &str = include_str!("../profiles/security-first.yaml");
+const PERFORMANCE_YAML: &str = include_str!("../profiles/performance.yaml");
+const CLEAN_CODE_YAML: &str = include_str!("../profiles/clean-code.yaml");
+const BEGINNER_FRIENDLY_YAML: &str = include_str!("../profiles/beginner-friendly.yaml");
+const MINIMAL_YAML: &str = include_str!("../profiles/minimal.yaml");
+const RUST_STRICT_YAML: &str = include_str!("../profiles/rust-strict.yaml");
+const TYPESCRIPT_STRICT_YAML: &str = include_str!("../profiles/typescript-strict.yaml");
+const GO_PRAGMATIC_YAML: &str = include_str!("../profiles/go-pragmatic.yaml");
+
+/// All built-in profile names in display order.
+pub const BUILTIN_PROFILES: &[&str] = &[
+    "security-first",
+    "performance",
+    "clean-code",
+    "beginner-friendly",
+    "minimal",
+    "rust-strict",
+    "typescript-strict",
+    "go-pragmatic",
+];
+
+// ─── Profile types ───
+
+/// A complete quality profile definition.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Profile {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub focus_areas: Vec<FocusArea>,
+    #[serde(default)]
+    pub ignore_areas: Vec<String>,
+    #[serde(default)]
+    pub severity_override: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub review_style: ReviewStyle,
+}
+
+/// A single focus area within a profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FocusArea {
+    pub id: String,
+    /// Priority weight 1-10 (higher = more important).
+    pub weight: u32,
+    /// "block" = any finding fails gate, "warn" = report only.
+    #[serde(default = "default_action")]
+    pub action: String,
+    #[serde(default)]
+    pub rules: Vec<String>,
+}
+
+fn default_action() -> String {
+    "warn".to_string()
+}
+
+/// Review style settings that modify LLM behavior.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ReviewStyle {
+    /// "strict" | "standard" | "gentle"
+    #[serde(default = "default_tone")]
+    pub tone: String,
+    /// "minimal" | "standard" | "high" | "exhaustive"
+    #[serde(default = "default_detail")]
+    pub detail_level: String,
+    #[serde(default = "default_true")]
+    pub suggest_fixes: bool,
+    /// Max findings to report (null = no limit).
+    pub max_findings: Option<usize>,
+}
+
+fn default_tone() -> String {
+    "standard".to_string()
+}
+
+fn default_detail() -> String {
+    "standard".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Lightweight profile reference stored in `.cora.yaml`.
+/// Can be a simple name string, or a full inline definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ProfileRef {
+    /// Built-in profile name or path to custom profile file.
+    Name(String),
+    /// Inline profile definition with optional `extends`.
+    Inline(InlineProfileRef),
+}
+
+/// Inline profile in `.cora.yaml` — can extend a built-in and override.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct InlineProfileRef {
+    /// Extend a built-in profile by name.
+    #[serde(default)]
+    pub extends: Option<String>,
+    /// Override focus areas (merged with base).
+    #[serde(default)]
+    pub focus_areas: Vec<FocusArea>,
+    /// Areas to ignore.
+    #[serde(default)]
+    pub ignore_areas: Vec<String>,
+    /// Override review style.
+    #[serde(default)]
+    pub review_style: Option<ReviewStyle>,
+}
+
+// ─── Profile operations ───
+
+/// Load a built-in profile by name. Returns `None` if not found.
+pub fn load_builtin(name: &str) -> Option<Profile> {
+    let yaml = match name {
+        "security-first" => SECURITY_FIRST_YAML,
+        "performance" => PERFORMANCE_YAML,
+        "clean-code" => CLEAN_CODE_YAML,
+        "beginner-friendly" => BEGINNER_FRIENDLY_YAML,
+        "minimal" => MINIMAL_YAML,
+        "rust-strict" => RUST_STRICT_YAML,
+        "typescript-strict" => TYPESCRIPT_STRICT_YAML,
+        "go-pragmatic" => GO_PRAGMATIC_YAML,
+        _ => return None,
+    };
+    parse_profile_yaml(yaml).ok()
+}
+
+/// Parse a profile from YAML string.
+pub fn parse_profile_yaml(yaml: &str) -> Result<Profile, String> {
+    serde_yaml_ng::from_str(yaml).map_err(|e| format!("invalid profile YAML: {e}"))
+}
+
+/// Load all built-in profiles.
+#[allow(dead_code)]
+pub fn load_all_builtins() -> Vec<Profile> {
+    BUILTIN_PROFILES
+        .iter()
+        .filter_map(|name| load_builtin(name))
+        .collect()
+}
+
+/// Resolve a `ProfileRef` from `.cora.yaml` into a final `Profile`.
+///
+/// Resolution order:
+/// 1. If `Name("builtin")` → load built-in
+/// 2. If `Name("./path.yaml")` → load from file
+/// 3. If `Inline { extends, ... }` → merge with base
+/// 4. If `Inline` without extends → use as-is
+pub fn resolve_profile(profile_ref: &ProfileRef) -> Result<Profile, String> {
+    match profile_ref {
+        ProfileRef::Name(name) => {
+            // Try built-in first
+            if let Some(p) = load_builtin(name) {
+                debug!(profile = name, "loaded built-in profile");
+                return Ok(p);
+            }
+            // Try loading from file
+            let path = std::path::Path::new(name);
+            if path.is_file() {
+                let content = std::fs::read_to_string(path)
+                    .map_err(|e| format!("cannot read profile file '{}': {e}", name))?;
+                let profile = parse_profile_yaml(&content)?;
+                debug!(profile = name, "loaded profile from file");
+                return Ok(profile);
+            }
+            Err(format!(
+                "unknown profile '{name}'. Available: {}",
+                BUILTIN_PROFILES.join(", ")
+            ))
+        }
+        ProfileRef::Inline(inline) => {
+            let mut profile = if let Some(base_name) = &inline.extends {
+                load_builtin(base_name)
+                    .ok_or_else(|| format!("cannot extend unknown profile '{base_name}'"))?
+            } else {
+                Profile::default()
+            };
+
+            // Override name if extending
+            if let Some(ref base) = inline.extends {
+                profile.name = format!("custom-{base}");
+            } else {
+                profile.name = "custom".to_string();
+            }
+
+            // Merge focus areas (append, don't replace)
+            if !inline.focus_areas.is_empty() {
+                profile.focus_areas.extend(inline.focus_areas.clone());
+            }
+
+            // Override ignore areas
+            if !inline.ignore_areas.is_empty() {
+                profile.ignore_areas = inline.ignore_areas.clone();
+            }
+
+            // Override review style
+            if let Some(style) = &inline.review_style {
+                profile.review_style = style.clone();
+            }
+
+            Ok(profile)
+        }
+    }
+}
+
+/// Auto-detect a profile based on project language.
+/// Returns the best-matching built-in profile name.
+#[allow(dead_code)]
+pub fn auto_detect_profile(language: &str) -> &'static str {
+    match language {
+        "rs" => "rust-strict",
+        "ts" | "js" => "typescript-strict",
+        "go" => "go-pragmatic",
+        _ => "clean-code",
+    }
+}
+
+/// Build the profile instruction text that gets injected into the LLM prompt.
+///
+/// This replaces the generic focus area list with profile-specific instructions.
+pub fn build_profile_prompt(profile: &Profile) -> String {
+    let mut parts = Vec::new();
+
+    parts.push(format!("Reviewing using the '{}' profile.", profile.name));
+    if !profile.description.is_empty() {
+        parts.push(profile.description.clone());
+    }
+
+    // Focus areas with rules
+    if !profile.focus_areas.is_empty() {
+        parts.push("\nFOCUSED REVIEW PRIORITIES:".to_string());
+        // Sort by weight descending
+        let mut areas = profile.focus_areas.clone();
+        areas.sort_by_key(|b| std::cmp::Reverse(b.weight));
+
+        for area in &areas {
+            let action_label = if area.action == "block" {
+                "BLOCK"
+            } else {
+                "WARN"
+            };
+            parts.push(format!(
+                "\n[{}] {} (weight: {}/10, action: {})",
+                area.id.to_uppercase(),
+                area.id,
+                area.weight,
+                action_label
+            ));
+            for rule in &area.rules {
+                parts.push(format!("  - {rule}"));
+            }
+        }
+    }
+
+    // Ignore areas
+    if !profile.ignore_areas.is_empty() {
+        parts.push(format!(
+            "\nIGNORE these areas (do NOT report): {}",
+            profile.ignore_areas.join(", ")
+        ));
+    }
+
+    // Review style
+    let style = &profile.review_style;
+    if !style.tone.is_empty() && style.tone != "standard" {
+        parts.push(format!("\nReview tone: {}.", style.tone));
+    }
+    if !style.detail_level.is_empty() && style.detail_level != "standard" {
+        parts.push(format!("Detail level: {}.", style.detail_level));
+    }
+    if !style.suggest_fixes {
+        parts.push("Do NOT suggest fixes — just report issues.".to_string());
+    }
+    if let Some(max) = style.max_findings {
+        parts.push(format!("Report at most {max} findings."));
+    }
+
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_all_builtins_succeeds() {
+        let profiles = load_all_builtins();
+        assert_eq!(profiles.len(), 8, "should have 8 built-in profiles");
+        for p in &profiles {
+            assert!(!p.name.is_empty(), "profile name should not be empty");
+            assert!(!p.description.is_empty(), "profile should have description");
+        }
+    }
+
+    #[test]
+    fn load_builtin_security_first() {
+        let p = load_builtin("security-first").unwrap();
+        assert_eq!(p.name, "security-first");
+        assert!(!p.focus_areas.is_empty());
+        assert!(p.ignore_areas.contains(&"style".to_string()));
+        assert_eq!(p.review_style.tone, "strict");
+    }
+
+    #[test]
+    fn load_builtin_rust_strict() {
+        let p = load_builtin("rust-strict").unwrap();
+        assert_eq!(p.name, "rust-strict");
+        assert!(p.focus_areas.iter().any(|a| a.id == "unsafe_usage"));
+    }
+
+    #[test]
+    fn load_builtin_unknown_returns_none() {
+        assert!(load_builtin("nonexistent").is_none());
+    }
+
+    #[test]
+    fn resolve_builtin_name() {
+        let r = ProfileRef::Name("minimal".to_string());
+        let p = resolve_profile(&r).unwrap();
+        assert_eq!(p.name, "minimal");
+    }
+
+    #[test]
+    fn resolve_unknown_name_fails() {
+        let r = ProfileRef::Name("nope".to_string());
+        assert!(resolve_profile(&r).is_err());
+    }
+
+    #[test]
+    fn resolve_inline_without_extends() {
+        let r = ProfileRef::Inline(InlineProfileRef {
+            extends: None,
+            focus_areas: vec![FocusArea {
+                id: "test".to_string(),
+                weight: 5,
+                action: "warn".to_string(),
+                rules: vec!["No test rule".to_string()],
+            }],
+            ignore_areas: vec!["docs".to_string()],
+            review_style: None,
+        });
+        let p = resolve_profile(&r).unwrap();
+        assert_eq!(p.name, "custom");
+        assert_eq!(p.focus_areas.len(), 1);
+        assert_eq!(p.ignore_areas, vec!["docs"]);
+    }
+
+    #[test]
+    fn resolve_inline_extends_builtin() {
+        let r = ProfileRef::Inline(InlineProfileRef {
+            extends: Some("minimal".to_string()),
+            focus_areas: vec![FocusArea {
+                id: "compliance".to_string(),
+                weight: 8,
+                action: "warn".to_string(),
+                rules: vec!["Check data processing consent".to_string()],
+            }],
+            ignore_areas: vec![],
+            review_style: Some(ReviewStyle {
+                tone: "strict".to_string(),
+                detail_level: "high".to_string(),
+                suggest_fixes: true,
+                max_findings: Some(15),
+            }),
+        });
+        let p = resolve_profile(&r).unwrap();
+        assert_eq!(p.name, "custom-minimal");
+        // Should have base focus areas + custom
+        assert!(p.focus_areas.len() > 2);
+        assert!(p.focus_areas.iter().any(|a| a.id == "compliance"));
+        assert_eq!(p.review_style.tone, "strict");
+        assert_eq!(p.review_style.max_findings, Some(15));
+    }
+
+    #[test]
+    fn auto_detect_profiles() {
+        assert_eq!(auto_detect_profile("rs"), "rust-strict");
+        assert_eq!(auto_detect_profile("ts"), "typescript-strict");
+        assert_eq!(auto_detect_profile("js"), "typescript-strict");
+        assert_eq!(auto_detect_profile("go"), "go-pragmatic");
+        assert_eq!(auto_detect_profile("py"), "clean-code");
+        assert_eq!(auto_detect_profile("unknown"), "clean-code");
+    }
+
+    #[test]
+    fn build_profile_prompt_not_empty() {
+        let p = load_builtin("security-first").unwrap();
+        let prompt = build_profile_prompt(&p);
+        assert!(prompt.contains("security-first"));
+        assert!(prompt.contains("FOCUSED REVIEW PRIORITIES"));
+        assert!(prompt.contains("IGNORE these areas"));
+        assert!(prompt.contains("strict"));
+    }
+
+    #[test]
+    fn build_profile_prompt_minimal() {
+        let mut p = Profile::default();
+        p.name = "custom".to_string();
+        let prompt = build_profile_prompt(&p);
+        assert!(prompt.contains("custom"));
+    }
+
+    #[test]
+    fn parse_profile_yaml_invalid() {
+        let result = parse_profile_yaml("not: valid: yaml:::");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn profile_roundtrip_yaml() {
+        let p = load_builtin("performance").unwrap();
+        let yaml = serde_yaml_ng::to_string(&p).unwrap();
+        let back: Profile = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(back.name, p.name);
+        assert_eq!(back.focus_areas.len(), p.focus_areas.len());
+    }
+}

--- a/src/engine/profiles.rs
+++ b/src/engine/profiles.rs
@@ -417,8 +417,10 @@ mod tests {
 
     #[test]
     fn build_profile_prompt_minimal() {
-        let mut p = Profile::default();
-        p.name = "custom".to_string();
+        let p = Profile {
+            name: "custom".to_string(),
+            ..Default::default()
+        };
         let prompt = build_profile_prompt(&p);
         assert!(prompt.contains("custom"));
     }

--- a/src/engine/profiles.rs
+++ b/src/engine/profiles.rs
@@ -169,12 +169,20 @@ pub fn resolve_profile(profile_ref: &ProfileRef) -> Result<Profile, String> {
                 debug!(profile = name, "loaded built-in profile");
                 return Ok(p);
             }
-            // Try loading from file
+            // Try loading from file (resolve relative to CWD)
             let path = std::path::Path::new(name);
             if path.is_file() {
                 let content = std::fs::read_to_string(path)
                     .map_err(|e| format!("cannot read profile file '{}': {e}", name))?;
-                let profile = parse_profile_yaml(&content)?;
+                let mut profile = parse_profile_yaml(&content)?;
+                // If profile has no name, derive from filename
+                if profile.name.is_empty() {
+                    profile.name = path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("custom")
+                        .to_string();
+                }
                 debug!(profile = name, "loaded profile from file");
                 return Ok(profile);
             }

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -167,6 +167,19 @@ async fn review_diff_inner(
         combined_context
     };
 
+    // Inject profile instructions into the context
+    let final_context = match (&config.profile, final_context) {
+        (Some(profile), Some(ctx)) => {
+            let profile_prompt = crate::engine::profiles::build_profile_prompt(profile);
+            Some(format!("## Quality Profile\n{profile_prompt}\n\n{ctx}"))
+        }
+        (Some(profile), None) => {
+            let profile_prompt = crate::engine::profiles::build_profile_prompt(profile);
+            Some(format!("## Quality Profile\n{profile_prompt}"))
+        }
+        (None, ctx) => ctx,
+    };
+
     // Call LLM — but preserve deterministic rule findings even on LLM failure
     let llm_result: Result<ReviewResponse, CoraError> = if stream {
         llm::review_diff_stream(

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@ mod git;
 mod hook;
 mod progress;
 
-use commands::{auth, completion, config_cmd, hook_cmd, init, providers, review, scan, upload};
+use commands::{
+    auth, completion, config_cmd, hook_cmd, init, profile, providers, review, scan, upload,
+};
 use config::loader;
 use formatters::OutputFormat;
 
@@ -182,6 +184,12 @@ enum Command {
         focus: Vec<String>,
     },
 
+    /// Manage quality profiles (preset rule sets)
+    Profile {
+        #[command(subcommand)]
+        action: ProfileAction,
+    },
+
     /// Upload a SARIF file to GitHub Code Scanning
     UploadSarif {
         /// Path to SARIF file to upload (default: reads from stdin)
@@ -298,6 +306,22 @@ enum ConfigAction {
     Validate,
 }
 
+#[derive(Subcommand, Debug)]
+enum ProfileAction {
+    /// List available quality profiles
+    List,
+    /// Show details of a specific profile
+    Show {
+        /// Profile name (e.g. security-first, rust-strict)
+        name: String,
+    },
+    /// Validate a custom profile YAML file
+    Validate {
+        /// Path to the profile YAML file
+        path: String,
+    },
+}
+
 #[allow(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -395,6 +419,14 @@ async fn main() -> Result<()> {
                 },
             )
             .await?
+        }
+        Command::Profile { action } => {
+            match action {
+                ProfileAction::List => profile::execute_profile_list()?,
+                ProfileAction::Show { name } => profile::execute_profile_show(&name)?,
+                ProfileAction::Validate { path } => profile::execute_profile_validate(&path)?,
+            }
+            0
         }
         Command::UploadSarif {
             file,

--- a/src/profiles/beginner-friendly.yaml
+++ b/src/profiles/beginner-friendly.yaml
@@ -1,0 +1,46 @@
+name: beginner-friendly
+description: "Gentle review — focus on common mistakes and learning opportunities"
+version: "1.0"
+
+focus_areas:
+  - id: common_mistakes
+    weight: 8
+    action: warn
+    rules:
+      - "Off-by-one errors in loops and array indexing"
+      - "Missing null/None/undefined checks before access"
+      - "Incorrect comparison operators (== vs ===, assignment in condition)"
+      - "Missing return statements or unreachable code"
+
+  - id: learning
+    weight: 9
+    action: info
+    rules:
+      - "Explain WHY something is an issue, not just WHAT"
+      - "Suggest idiomatic alternatives with brief explanation"
+      - "Link concepts to common patterns (e.g., 'this is a classic iterator pattern')"
+      - "Be encouraging — acknowledge good patterns too"
+
+  - id: best_practices
+    weight: 7
+    action: info
+    rules:
+      - "Prefer standard library functions over manual implementations"
+      - "Use consistent naming conventions"
+      - "Avoid global mutable state"
+
+  - id: security_basics
+    weight: 6
+    action: warn
+    rules:
+      - "Never trust user input — always validate and sanitize"
+      - "Don't hardcode passwords or API keys"
+      - "Use HTTPS, not HTTP"
+
+ignore_areas: []
+
+review_style:
+  tone: gentle
+  detail_level: exhaustive
+  suggest_fixes: true
+  max_findings: 20

--- a/src/profiles/clean-code.yaml
+++ b/src/profiles/clean-code.yaml
@@ -1,0 +1,51 @@
+name: clean-code
+description: "Broad quality — readability, naming, complexity — best for team projects"
+version: "1.0"
+
+focus_areas:
+  - id: readability
+    weight: 8
+    action: warn
+    rules:
+      - "Functions should do one thing — flag long functions (>50 lines)"
+      - "Use descriptive names — avoid single-letter vars (except loop counters)"
+      - "Avoid magic numbers — extract to named constants"
+      - "Keep nesting depth reasonable (max 3-4 levels)"
+
+  - id: complexity
+    weight: 7
+    action: warn
+    rules:
+      - "Flag high cyclomatic complexity — too many branches in one function"
+      - "Avoid deeply nested conditionals — use early returns or guard clauses"
+      - "Break large modules into focused submodules"
+
+  - id: error_handling
+    weight: 8
+    action: warn
+    rules:
+      - "Handle errors explicitly — no silent swallowing or empty catch blocks"
+      - "Use appropriate error types — don't return generic errors everywhere"
+      - "Propagate errors with context (wrap with 'failed to X')"
+
+  - id: dry
+    weight: 6
+    action: warn
+    rules:
+      - "Flag duplicated code — suggest extraction into shared functions"
+      - "Avoid copy-paste with minor variations — parameterize instead"
+
+  - id: testing
+    weight: 5
+    action: info
+    rules:
+      - "Suggest tests for complex logic (edge cases, error paths)"
+      - "Flag untested public APIs"
+
+ignore_areas: []
+
+review_style:
+  tone: standard
+  detail_level: standard
+  suggest_fixes: true
+  max_findings: 30

--- a/src/profiles/go-pragmatic.yaml
+++ b/src/profiles/go-pragmatic.yaml
@@ -1,0 +1,52 @@
+name: go-pragmatic
+description: "Go-specific: error handling, goroutine safety, interface design, idiomatic Go"
+version: "1.0"
+
+focus_areas:
+  - id: error_handling
+    weight: 10
+    action: block
+    rules:
+      - "Check all error returns — never discard errors with _"
+      - "Wrap errors with context using fmt.Errorf('...: %w', err)"
+      - "Handle errors before deferring cleanup — don't lose the original error"
+      - "Don't use panic for flow control — return errors"
+
+  - id: concurrency
+    weight: 9
+    action: warn
+    rules:
+      - "Watch for goroutine leaks — ensure all goroutines can exit"
+      - "Close channels properly — sender closes, receiver checks"
+      - "Use sync.WaitGroup or errgroup for goroutine coordination"
+      - "No data races — protect shared state with mutex or channels"
+      - "Avoid defer in loops when cleanup is time-sensitive"
+
+  - id: interfaces
+    weight: 7
+    action: warn
+    rules:
+      - "Accept interfaces, return concrete types"
+      - "Keep interfaces small — one method is ideal"
+      - "Define interfaces where they're used, not where they're implemented"
+      - "Use type assertion with comma-ok pattern to avoid panics"
+
+  - id: idiomatic_go
+    weight: 6
+    action: info
+    rules:
+      - "Use meaningful names — avoid single-letter names outside short loops"
+      - "Group related constants in iota blocks"
+      - "Use table-driven tests for functions with multiple cases"
+      - "Prefer struct literals over constructors for simple types"
+      - "Use context.Context as first parameter in functions that do I/O"
+
+ignore_areas:
+  - documentation
+  - formatting
+
+review_style:
+  tone: standard
+  detail_level: standard
+  suggest_fixes: true
+  max_findings: null

--- a/src/profiles/minimal.yaml
+++ b/src/profiles/minimal.yaml
@@ -1,0 +1,35 @@
+name: minimal
+description: "Only critical + security — best for quick PRs and hotfixes"
+version: "1.0"
+
+focus_areas:
+  - id: critical_bugs
+    weight: 10
+    action: block
+    rules:
+      - "Crashes, panics, and unhandled exceptions"
+      - "Data loss or corruption risks"
+      - "Breaking changes to public APIs"
+
+  - id: security
+    weight: 10
+    action: block
+    rules:
+      - "Hardcoded secrets and credentials"
+      - "SQL injection, XSS, and other injection vectors"
+      - "Authentication or authorization bypasses"
+
+ignore_areas:
+  - style
+  - naming
+  - documentation
+  - formatting
+  - performance
+  - best_practice
+  - complexity
+
+review_style:
+  tone: strict
+  detail_level: minimal
+  suggest_fixes: true
+  max_findings: 10

--- a/src/profiles/performance.yaml
+++ b/src/profiles/performance.yaml
@@ -1,0 +1,50 @@
+name: performance
+description: "Focus on speed, memory, and allocation patterns — best for hot-path code"
+version: "1.0"
+
+focus_areas:
+  - id: performance
+    weight: 10
+    action: warn
+    rules:
+      - "Avoid unnecessary allocations in hot paths — reuse buffers, pre-allocate"
+      - "Watch for O(n²) or worse complexity in loops"
+      - "Use appropriate data structures for the access pattern"
+      - "Avoid cloning large types when references suffice"
+      - "Profile before optimizing — but flag obvious bottlenecks"
+
+  - id: memory
+    weight: 9
+    action: warn
+    rules:
+      - "No memory leaks — ensure resources are freed (RAII, Drop, defer close)"
+      - "Avoid holding large data structures longer than needed"
+      - "Use streaming/chunking for large data instead of loading all into memory"
+      - "Check for unintended copies of large buffers"
+
+  - id: io_efficiency
+    weight: 8
+    action: warn
+    rules:
+      - "Avoid N+1 queries — batch database/API calls"
+      - "Use async I/O for concurrent operations, not blocking calls"
+      - "Minimize unnecessary network round-trips"
+      - "Cache expensive computations when results don't change often"
+
+  - id: concurrency
+    weight: 7
+    action: warn
+    rules:
+      - "Avoid data races in concurrent code (proper locking, atomic operations)"
+      - "Watch for deadlocks (lock ordering, timeout on lock acquisition)"
+      - "Prefer message passing over shared mutable state"
+
+ignore_areas:
+  - documentation
+  - formatting
+
+review_style:
+  tone: standard
+  detail_level: high
+  suggest_fixes: true
+  max_findings: null

--- a/src/profiles/rust-strict.yaml
+++ b/src/profiles/rust-strict.yaml
@@ -1,0 +1,57 @@
+name: rust-strict
+description: "Rust-specific: unsafe, unwrap, panic, lifetime, error handling, idiomatic patterns"
+version: "1.0"
+
+focus_areas:
+  - id: unsafe_usage
+    weight: 10
+    action: block
+    rules:
+      - "No unsafe blocks without a safety comment explaining why it's sound"
+      - "Check for undefined behavior: dangling pointers, aliasing violations, data races"
+      - "Validate all unsafe operations — raw pointer derefs, transmute, from_raw_parts"
+
+  - id: error_handling
+    weight: 9
+    action: warn
+    rules:
+      - "No unwrap() or expect() in production code paths — use ? operator or match"
+      - "No panic! in library code — return Result"
+      - "Use thiserror or anyhow for error types — don't use Box<dyn Error>"
+      - "Propagate errors with context using .with_context()? or .map_err()?"
+
+  - id: idiomatic_rust
+    weight: 7
+    action: warn
+    rules:
+      - "Use iterators and functional combinators instead of manual loops where appropriate"
+      - "Prefer &str over String for function parameters when ownership not needed"
+      - "Use Cow<str> for functions that sometimes need owned strings"
+      - "Implement From/Into for type conversions"
+      - "Use lifetimes explicitly when needed — don't overuse 'static"
+
+  - id: ownership
+    weight: 8
+    action: warn
+    rules:
+      - "Avoid unnecessary .clone() — use references or Arc where possible"
+      - "Check for reference cycles with Rc/Arc (use Weak for cyclic structures)"
+      - "Don't return references to local variables"
+
+  - id: concurrency
+    weight: 7
+    action: warn
+    rules:
+      - "Use Send + Sync bounds correctly"
+      - "Prefer message passing (channels) over shared state (Mutex)"
+      - "Check for potential deadlocks with Mutex ordering"
+
+ignore_areas:
+  - documentation
+  - formatting
+
+review_style:
+  tone: strict
+  detail_level: high
+  suggest_fixes: true
+  max_findings: null

--- a/src/profiles/security-first.yaml
+++ b/src/profiles/security-first.yaml
@@ -1,0 +1,53 @@
+name: security-first
+description: "Strict security focus — zero tolerance for vulnerabilities"
+version: "1.0"
+
+focus_areas:
+  - id: security
+    weight: 10
+    action: block
+    rules:
+      - "No hardcoded secrets, credentials, or API keys in source code"
+      - "Validate and sanitize all external inputs (HTTP params, file uploads, CLI args)"
+      - "Use parameterized queries or ORM — never string interpolation for SQL"
+      - "Check authorization on every endpoint and sensitive operation"
+      - "Sanitize user-generated content before rendering (XSS prevention)"
+      - "Use constant-time comparison for secrets and tokens"
+      - "Never roll custom crypto — use established libraries"
+
+  - id: injection
+    weight: 10
+    action: block
+    rules:
+      - "No SQL/NoSQL/XSS/SSRF/LDAP/Path traversal injection vectors"
+      - "Escape all output in templates and HTML contexts"
+      - "Validate file paths — reject path traversal patterns (../, ..\\)"
+      - "Restrict SSRF — validate URLs before HTTP calls"
+
+  - id: error_handling
+    weight: 7
+    action: warn
+    rules:
+      - "Never expose stack traces, internal paths, or system info to users"
+      - "Log security events (auth failures, access denied) properly"
+      - "Handle all error paths explicitly — no silent failures"
+
+  - id: secrets_management
+    weight: 8
+    action: block
+    rules:
+      - "Load secrets from env vars or secret managers, not config files"
+      - "No private keys, JWT secrets, or database passwords in code"
+      - "Use HTTPS for all external communication"
+
+ignore_areas:
+  - style
+  - naming
+  - documentation
+  - formatting
+
+review_style:
+  tone: strict
+  detail_level: high
+  suggest_fixes: true
+  max_findings: null

--- a/src/profiles/typescript-strict.yaml
+++ b/src/profiles/typescript-strict.yaml
@@ -1,0 +1,51 @@
+name: typescript-strict
+description: "TypeScript-specific: any types, null safety, proper typing, async patterns"
+version: "1.0"
+
+focus_areas:
+  - id: type_safety
+    weight: 10
+    action: block
+    rules:
+      - "No any types — use unknown, generics, or proper interfaces"
+      - "No non-null assertions (!) without clear justification"
+      - "Avoid type: ignore or @ts-ignore — fix the type error instead"
+      - "Use discriminated unions instead of optional properties for state"
+
+  - id: null_safety
+    weight: 9
+    action: warn
+    rules:
+      - "Always check for null/undefined before accessing properties"
+      - "Use optional chaining (?.) and nullish coalescing (??) appropriately"
+      - "Don't use truthy/falsy checks for null — use === null or == null explicitly"
+
+  - id: async_patterns
+    weight: 8
+    action: warn
+    rules:
+      - "Always await Promises — no floating promises"
+      - "Handle promise rejections with try/catch or .catch()"
+      - "Use Promise.all for concurrent operations, not sequential awaits"
+      - "Avoid async constructors — use factory pattern instead"
+      - "Watch for race conditions in concurrent state mutations"
+
+  - id: best_practices
+    weight: 7
+    action: warn
+    rules:
+      - "Use const by default, let only when reassignment needed — never var"
+      - "Prefer interfaces over type aliases for object shapes"
+      - "Use enum or const objects for fixed value sets"
+      - "Export types and interfaces from barrel files"
+      - "Use satisfies operator for type checking without widening"
+
+ignore_areas:
+  - documentation
+  - formatting
+
+review_style:
+  tone: standard
+  detail_level: high
+  suggest_fixes: true
+  max_findings: null


### PR DESCRIPTION
## Summary

Closes #208

Adds Quality Profiles — preset and configurable rule sets that define what Cora focuses on during review. Different projects can now use different review strictness.

## Changes

### New Files
- `src/engine/profiles.rs` — profile engine: load, resolve, merge, auto-detect, prompt builder
- `src/commands/profile.rs` — `cora profile` subcommand (list, show, validate)
- `src/profiles/*.yaml` — 8 built-in profiles embedded at compile time

### 8 Built-in Profiles
| Profile | Focus |
|---------|-------|
| security-first | Vulnerabilities, injection, secrets, zero tolerance |
| performance | Speed, memory, allocations, hot-path |
| clean-code | Readability, complexity, DRY, team standards |
| beginner-friendly | Common mistakes, learning, gentle explanations |
| minimal | Critical + security only, for quick PRs |
| rust-strict | unsafe, unwrap, panic, lifetimes, idiomatic Rust |
| typescript-strict | any types, null safety, async patterns |
| go-pragmatic | Error handling, goroutines, interfaces |

### .cora.yaml Usage
```yaml
profile: security-first           # built-in name
profile: ./my-team-profile.yaml   # custom file
profile:                           # inline with extends
  extends: rust-strict
  focus_areas:
    - id: compliance
      weight: 8
      rules:
        - Check data processing consent
```

### CLI Commands
```bash
cora profile list                    # show all profiles
cora profile show rust-strict        # show profile details
cora profile validate ./profile.yaml # validate custom profile
```

### Modified Files
- `src/config/schema.rs` — profile field in Config and CoraFile
- `src/engine/review.rs` — profile prompt injected into LLM context
- `src/main.rs` — profile subcommand routing
- `src/commands/mod.rs` — profile module registration

## Test Results
- 419 tests passing ✅ (397 unit + 16 CLI + 6 config)
- Clippy clean ✅
- fmt clean ✅