### PR TITLE
docs: sync changelog, roadmap, and getting-started with v0.5 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to cora-cli are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2026-06-08
+## [0.5.0] - 2026-06-10
 
 ### Added
 
@@ -15,15 +15,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Terminal-formatted gate output with status table
   - Exit code 2 on gate failure
   - 12 unit tests covering all gate scenarios
-- **Diff chunker module** — `src/engine/chunker.rs` for splitting large diffs (#188, integration pending #228)
+- **Static Security Scanner** — 11 regex patterns for common vulnerabilities (#234)
+  - Weak crypto (MD5/SHA1 for passwords), hardcoded secrets, SQL injection, eval(), command injection
+  - Hardcoded roles, debug mode, CORS wildcard, SSL verify disabled
+  - Auto-skips test files; only scans added lines
+  - Findings injected into LLM prompt as additional context
+- **Language-Specific Analyzers** — tailored review guidance for 6 languages (#233)
+  - Dart/Flutter: widget lifecycle, state management, null safety
+  - Svelte/TypeScript: reactivity, stores, SSR, type safety
+  - Go: error handling, concurrency, goroutine leaks
+  - Rust: ownership, lifetimes, unsafe, idioms
+  - Python: type hints, async, security patterns
+- **MCP Server** — expose rules and config to AI coding agents (#207)
+  - JSON-RPC 2.0 over stdio transport
+  - 5 tools: `list_rules`, `check_snippet`, `get_quality_gate`, `get_config`, `list_profiles`
+  - `cora mcp` subcommand
+  - Brace-depth stdin parsing (handles pretty-printed JSON)
+  - 17 unit tests
+- **Auto-chunking** — large diffs split into reviewable chunks automatically (#188)
+  - `--no-auto-chunk` flag to disable
+  - `src/engine/chunker.rs` module (~310 lines)
 - **Multi-platform CI docs** — Gitea/Forgejo, GitLab CI, Bitbucket Pipelines workflow examples (#225)
 
 ### Changed
 
 - **README links** — all documentation links now point to `codecora.dev` instead of relative file paths
 - **CI workflows** — removed stale SvelteKit `website/` jobs, replaced with VitePress `docs/` build
+- **`merge_into()` returns `Result`** — fail-fast on invalid profile config instead of silently continuing
+- **Language context reuses parsed diff** — `build_language_context_from_chunks()` eliminates redundant `parse_diff()` call
 - **13 stale issues closed** — migration epics, website tasks, v0.4 leftovers
 - **15 stale branches deleted** — cleanup after merge
+
+### Fixed
+
+- **Profiles bugs** — path resolution with project root, fail-fast on invalid config, dedup merge by `id` (#238)
+- **Code Scanning alert #79** — eliminated redundant `parse_diff()` call in language context injection
 
 ### Removed
 
@@ -398,8 +424,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.4.6...develop
-[0.4.6]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...v0.4.6
+[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.5.0...develop
+[0.5.0]: https://github.com/codecoradev/cora-cli/compare/v0.4.7...v0.5.0
+[0.4.7]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/codecoradev/cora-cli/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/codecoradev/cora-cli/compare/v0.4.2...v0.4.3

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to cora-cli are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2026-06-08
+## [0.5.0] - 2026-06-10
 
 ### Added
 
@@ -15,15 +15,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Terminal-formatted gate output with status table
   - Exit code 2 on gate failure
   - 12 unit tests covering all gate scenarios
-- **Diff chunker module** — `src/engine/chunker.rs` for splitting large diffs (#188, integration pending #228)
+- **Static Security Scanner** — 11 regex patterns for common vulnerabilities (#234)
+  - Weak crypto (MD5/SHA1 for passwords), hardcoded secrets, SQL injection, eval(), command injection
+  - Hardcoded roles, debug mode, CORS wildcard, SSL verify disabled
+  - Auto-skips test files; only scans added lines
+  - Findings injected into LLM prompt as additional context
+- **Language-Specific Analyzers** — tailored review guidance for 6 languages (#233)
+  - Dart/Flutter: widget lifecycle, state management, null safety
+  - Svelte/TypeScript: reactivity, stores, SSR, type safety
+  - Go: error handling, concurrency, goroutine leaks
+  - Rust: ownership, lifetimes, unsafe, idioms
+  - Python: type hints, async, security patterns
+- **MCP Server** — expose rules and config to AI coding agents (#207)
+  - JSON-RPC 2.0 over stdio transport
+  - 5 tools: `list_rules`, `check_snippet`, `get_quality_gate`, `get_config`, `list_profiles`
+  - `cora mcp` subcommand
+  - Brace-depth stdin parsing (handles pretty-printed JSON)
+  - 17 unit tests
+- **Auto-chunking** — large diffs split into reviewable chunks automatically (#188)
+  - `--no-auto-chunk` flag to disable
+  - `src/engine/chunker.rs` module (~310 lines)
 - **Multi-platform CI docs** — Gitea/Forgejo, GitLab CI, Bitbucket Pipelines workflow examples (#225)
 
 ### Changed
 
 - **README links** — all documentation links now point to `codecora.dev` instead of relative file paths
 - **CI workflows** — removed stale SvelteKit `website/` jobs, replaced with VitePress `docs/` build
+- **`merge_into()` returns `Result`** — fail-fast on invalid profile config instead of silently continuing
+- **Language context reuses parsed diff** — `build_language_context_from_chunks()` eliminates redundant `parse_diff()` call
 - **13 stale issues closed** — migration epics, website tasks, v0.4 leftovers
 - **15 stale branches deleted** — cleanup after merge
+
+### Fixed
+
+- **Profiles bugs** — path resolution with project root, fail-fast on invalid config, dedup merge by `id` (#238)
+- **Code Scanning alert #79** — eliminated redundant `parse_diff()` call in language context injection
 
 ### Removed
 
@@ -398,8 +424,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.4.6...develop
-[0.4.6]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...v0.4.6
+[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.5.0...develop
+[0.5.0]: https://github.com/codecoradev/cora-cli/compare/v0.4.7...v0.5.0
+[0.4.7]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/codecoradev/cora-cli/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/codecoradev/cora-cli/compare/v0.4.2...v0.4.3

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,6 +130,31 @@ Now that you have cora running, explore these topics to get the most out of it:
 
 - [Installation](./installation) — install options and shell completions
 - [Usage](./usage) — review modes, output formats, and configuration
-- [Configuration](./configuration) — full .cora.yaml reference
+- [Configuration](./configuration) — full .cora.yaml reference, quality gate, security scanner, MCP server
 - [Providers](./providers) — setting up OpenAI, Anthropic, Groq, Ollama, and Z.AI
 - [CLI Reference](./cli-reference) — full command documentation
+- [Examples](./examples) — CI/CD setup for GitHub, GitLab, Gitea, Bitbucket
+
+## AI Agent Integration
+
+cora includes a built-in MCP server for AI coding agents. After installation:
+
+```bash
+# Start MCP server
+$ cora mcp
+```
+
+Configure in Claude Code (`.claude/settings.json`) or Cursor (`.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "cora": {
+      "command": "cora",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+See [Configuration → MCP Server](./configuration#mcp-server) for full setup guides.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,17 +65,19 @@ Demand-gated — we build what people actually need. Track progress on [GitHub I
 
 ## v0.5 — Agent & Quality
 
-- [#205](https://github.com/codecoradev/cora-cli/issues/205) Quality gate — CI pass/fail thresholds — ◎ Planned
-- [#207](https://github.com/codecoradev/cora-cli/issues/207) MCP server — expose rules to AI agents — ◎ Planned
-- [#208](https://github.com/codecoradev/cora-cli/issues/208) Quality profiles — preset rule sets — ◎ Planned
+- [#205](https://github.com/codecoradev/cora-cli/issues/205) Quality gate — CI pass/fail thresholds — ✓ Done
+- [#234](https://github.com/codecoradev/cora-cli/issues/234) Static security scanner — 11 patterns — ✓ Done
+- [#233](https://github.com/codecoradev/cora-cli/issues/233) Language-specific analyzers (Dart, Svelte, TS, Go, Rust, Python) — ✓ Done
+- [#207](https://github.com/codecoradev/cora-cli/issues/207) MCP server — expose rules to AI agents — ✓ Done
+- [#238](https://github.com/codecoradev/cora-cli/issues/238) Quality profiles bug fix — path resolution, fail-fast, dedup — ✓ Done
+- [#188](https://github.com/codecoradev/cora-cli/issues/188) Auto-chunking for large diffs — ✓ Done
 - [#206](https://github.com/codecoradev/cora-cli/issues/206) Tech debt metrics — review history — ◎ Planned
-- [#188](https://github.com/codecoradev/cora-cli/issues/188) Auto-chunking for large diffs — ◎ Planned
 
 ## v0.6 — Growth & Marketplace
 
-- [#47](https://github.com/codecoradev/cora-cli/issues/47) GitHub Marketplace action — ◎ Planned
+- [#47](https://github.com/codecoradev/cora-cli/issues/47) GitHub Marketplace action — ✓ Done
+- [#196](https://github.com/codecoradev/cora-cli/issues/196) VitePress docs site — ✓ Done
 - [#161](https://github.com/codecoradev/cora-cli/issues/161) `cora gain` — local stats + viral sharing — ◎ Planned
-- [#196](https://github.com/codecoradev/cora-cli/issues/196) VitePress docs site — ◎ Planned
 - [#160](https://github.com/codecoradev/cora-cli/issues/160) Landing page redesign — ◎ Planned
 
 ## Future — What's Next


### PR DESCRIPTION
### CHANGELOG.md + docs/changelog.md
- v0.5.0 expanded: Security Scanner (#234), Language Analyzers (#233), MCP Server (#207), Auto-chunking (#188), Profiles fix (#238), Code Scanning fix (#79)
- Date updated Jun 8 → Jun 10
- Link references added (v0.5.0)

### docs/roadmap.md
- v0.5: 5 items ◎ Planned → ✓ Done
- v0.6: Marketplace + VitePress → ✓ Done

### docs/getting-started.md
- MCP server setup section (Claude Code/Cursor config)
- Updated Next Steps links