### PR TITLE
fix: deploy website only from main, not develop

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -2,7 +2,7 @@ name: Deploy Website to Cloudflare Pages
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-website.yml'
@@ -51,5 +51,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: npx wrangler pages project create cora --production-branch=develop || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora --commit-dirty=true --branch=develop
+          preCommands: npx wrangler pages project create cora --production-branch=main || true
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora --commit-dirty=true --branch=main


### PR DESCRIPTION
### Problem
`deploy-website.yml` triggers on push to `develop`, deploying unreleased docs to production `codecora.dev`.

### Fix
- Trigger: `push to main` + path `docs/**` (was `develop`)
- `workflow_dispatch` kept for manual hotfix docs deploy
- `production-branch` changed to `main`

### Flow After Fix
```
develop (push docs/)  → CI: Website Build check only (no deploy)
main (push docs/)     → Deploy to codecora.dev
tag v*                → release.yml syncs develop → main → deploy triggers
```