### PR TITLE
fix: restore missing [0.4.5] compare link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.5.0...develop
 [0.5.0]: https://github.com/codecoradev/cora-cli/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...v0.4.6
+[0.4.5]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/codecoradev/cora-cli/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/codecoradev/cora-cli/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/codecoradev/cora-cli/compare/v0.4.1...v0.4.2


### PR DESCRIPTION
## Fix
Resolves code scanning alert #100 — release link for v0.4.5 was accidentally removed from the compare links section at the bottom of CHANGELOG.md.

## Changes
- Added `[0.4.5]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...v0.4.5` between the v0.4.6 and v0.4.4 entries

## Verification
- Diff is 1 line addition, no deletions
- All other compare links remain intact