### PR TITLE
chore: release v0.5.0

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -52,6 +52,17 @@ Before creating any release PR, verify ALL of the following are updated:
 - [ ] `codecora.dev` reflects new docs
 - [ ] Marketplace action still works
 
+## Release Authority
+
+**Owner approval required before ANY release.** Agent must:
+1. Complete Pre-Release Checklist (all green)
+2. Generate validation report
+3. Present to owner
+4. Wait for explicit approval ("oke kerjakan" / "go ahead" / "rilis")
+5. Only then: bump version + tag + push
+
+Agent must NEVER trigger release without owner approval.
+
 ## Branch Conventions
 
 - All PRs target `develop` (not `main`)
@@ -61,7 +72,7 @@ Before creating any release PR, verify ALL of the following are updated:
 - Pre-commit hook must pass before each commit
 - **One issue = one branch = one PR = wait CI green = merge = next**
 
-## Config Architecture (v0.4.6+)
+## Config Architecture (v0.5.0+)
 
 | File | Contents |
 |------|----------|

--- a/AGENT.md
+++ b/AGENT.md
@@ -286,6 +286,129 @@ After merging to `main`:
 - [ ] Website (`codecora.dev`) reflects new docs
 - [ ] Marketplace action still works (test on a PR)
 
+## Release Workflow
+
+Release authority belongs to the project owner only. The agent NEVER triggers a release
+without explicit approval. This workflow was established during v0.5.0 development.
+
+### Phase 1: Pre-Release Preparation (agent does this)
+
+Complete ALL items in the Pre-Release Checklist above. Every single checkbox must be green.
+
+### Phase 2: Validation Report (agent generates, owner reviews)
+
+Generate a comprehensive pre-release report covering:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║           LAPORAN PRE-RELEASE vX.Y.Z — FINAL               ║
+╚══════════════════════════════════════════════════════════════╝
+
+📦 REPOSITORY: codecoradev/cora-cli
+🌿 BRANCH:     develop (N commits ahead of main)
+🏷️  TAG:       Next → vX.Y.Z
+📋 CARGO:      version = "0.X.Y" (needs bump)
+
+✅ TESTS:        N pass (unit + CLI + config)
+✅ CLIPPY:       Clean
+✅ FORMAT:       Clean
+✅ CI:           10/10 green
+✅ CODE SCANNING: 0 open
+✅ OPEN PRs:      0
+✅ OPEN ISSUES:   N (all post-release scope)
+
+📋 vX.Y.Z FEATURES:
+   1. ...
+   2. ...
+
+📄 DOCS VERIFICATION:
+   ✅ README.md         — ...
+   ✅ CHANGELOG.md       — ...
+   ✅ docs/*             — ...
+   ✅ AGENT.md           — ...
+
+⚠️ REMAINING (post-release):
+   • ...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+👍 SIAP RILIS — menunggu approval.
+```
+
+### Phase 3: Acceptance (owner decides)
+
+The owner reviews the report and either:
+- **APPROVES** → "oke kerjakan" / "go ahead" / "rilis"
+- **REQUESTS CHANGES** → specifies what to fix first
+- **POSTPONES** → "belum, tunggu dulu"
+
+**The agent must NEVER proceed without explicit approval.**
+
+### Phase 4: Release Execution (only after approval)
+
+```bash
+# 1. Bump version
+sed -i '' 's/version = "0.X.Y"/version = "0.X.Z"/' Cargo.toml
+
+# 2. Update version references in docs
+#    - docs/installation.md: CORA_VERSION pin example
+#    - AGENT.md: test count if changed
+#    - docs/.vitepress/config.ts: nav bar version
+
+# 3. Commit and tag
+git add -A && git commit -m "chore: bump version to X.Y.Z"
+git tag vX.Y.Z
+git push origin develop --tags
+
+# 4. release.yml auto-triggers:
+#    → sync develop → main (force push)
+#    → build 4 platforms (Linux x86_64, Linux ARM64, macOS ARM64, Windows)
+#    → publish to crates.io
+#    → create GitHub Release with changelog excerpt
+
+# 5. deploy-website.yml auto-triggers (on push to main):
+#    → build VitePress docs
+#    → deploy to codecora.dev
+```
+
+### Phase 5: Post-Release Verification (agent does this)
+
+After release completes, verify:
+
+- [ ] GitHub Release page shows vX.Y.Z with correct changelog
+- [ ] 4 platform binaries attached to release
+- [ ] SHA256 checksums file included
+- [ ] `crates.io` shows new version: `cargo search cora-cli`
+- [ ] `codecora.dev` reflects new docs
+- [ ] Marketplace action still works (test on a test PR)
+- [ ] Close the released milestone/issues
+- [ ] Update roadmap: mark released items
+
+### Rollback Procedure
+
+If release fails or has critical bugs:
+
+1. Delete the tag: `git push origin --delete vX.Y.Z`
+2. Delete the GitHub Release
+3. Yank from crates.io: `cargo yank cora-cli@X.Y.Z`
+4. Fix on develop, re-tag when ready
+
+### Version Numbering Convention
+
+- **Patch** (0.4.6 → 0.4.7): Bug fixes, docs updates, no new features
+- **Minor** (0.4.x → 0.5.0): New features, backwards compatible
+- **Major** (0.x → 1.0.0): Breaking changes
+- **Pre-release**: Tag with suffix (v0.5.0-beta.1) — `release.yml` marks as prerelease
+
+### Key Lessons from v0.5.0 Release
+
+1. **Documentation drift is the biggest risk.** PRs from other agents may merge code
+   without updating docs. Always audit docs coverage BEFORE release.
+2. **Ghost versions in CHANGELOG are dangerous.** If a version entry exists but has
+   no tag, merge it into the next real version before release.
+3. **Test count changes with every PR.** Verify actual test count matches AGENT.md.
+4. **Deploy-website trigger must be main-only.** develop pushes should never deploy to production.
+5. **Code Scanning alerts accumulate.** Dismiss false positives with reason, fix real ones.
+
 ## External Submissions
 
 When submitting cora to directories, aggregators, or showcases (Trendshift, etc.):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "cora-cli"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.4.6"
+version = "0.5.0"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 ```
 
-> Pin a version: `CORA_VERSION=v0.4.6 curl -fsSL ... | sh`  
+> Pin a version: `CORA_VERSION=v0.5.0 curl -fsSL ... | sh`  
 > Or: `cargo install --git https://github.com/codecoradev/cora-cli`  
 > Pre-built binaries: [GitHub Releases](https://github.com/codecoradev/cora-cli/releases)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -24,7 +24,7 @@ export default defineConfig({
       { text: 'Changelog', link: '/changelog' },
       { text: 'Roadmap', link: '/roadmap' },
       {
-        text: 'v0.4.6',
+        text: 'v0.5.0',
         items: [
           { text: 'GitHub', link: 'https://github.com/codecoradev/cora-cli' },
           { text: 'Releases', link: 'https://github.com/codecoradev/cora-cli/releases' },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,7 +21,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 Pin a specific version:
 
 ```bash
-$ CORA_VERSION=v0.4.6 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+$ CORA_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 ```
 
 ## Install via Cargo


### PR DESCRIPTION
Version bump + docs update for v0.5.0 release.

After merge:
- Tag `v0.5.0`
- `release.yml` auto-triggers (build + publish)
- `deploy-website.yml` auto-triggers (deploy docs)