### PR TITLE
fix: friendly error when not in a git repo

### DIFF
--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -58,6 +58,16 @@ fn git_cmd(args: &[&str]) -> std::result::Result<String, CoraError> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr_str = stderr.trim();
+
+        // Detect common git errors and provide friendly messages
+        if stderr_str.contains("not a git repository")
+            || stderr_str.contains("unknown option `cached'")
+            || stderr_str.contains("Not a git repository")
+        {
+            return Err(CoraError::NotInGitRepo);
+        }
+
         return Err(CoraError::GitCommand {
             command: args.join(" "),
             stderr: stderr.to_string(),


### PR DESCRIPTION
## Problem
Running `cora review --staged` outside a git repo shows a confusing raw git error:

```
Error: git command `diff --cached` failed: error: unknown option `cached`
```

## Fix
Detect common git errors in stderr and return `CoraError::NotInGitRepo` instead:

```
Error: not inside a git repository
```

## Testing
- 506 tests pass
- Clippy clean
- Manual validation: `cora review --staged` in non-git directory shows friendly error