### PR TITLE
fix: uteke recall flag and JSON parser (#259)

### DIFF
--- a/src/engine/memory.rs
+++ b/src/engine/memory.rs
@@ -61,7 +61,7 @@ impl MemoryBackend {
 
     /// Recall project patterns from Uteke before review.
     ///
-    /// Calls: `uteke recall "{project} code-pattern" --namespace cora --limit 5`
+    /// Calls: `uteke recall "{project} code-pattern" --namespace cora --limit 5 --json`
     pub fn recall_context(&self, project: &str) -> Vec<String> {
         if !self.enabled {
             return Vec::new();
@@ -77,8 +77,7 @@ impl MemoryBackend {
                 &self.namespace,
                 "--limit",
                 "5",
-                "--format",
-                "json",
+                "--json",
             ])
             .output()
         {
@@ -97,13 +96,18 @@ impl MemoryBackend {
             return Vec::new();
         }
 
-        // Parse JSON output — each line is a result with "content" field
+        // Parse JSON output — uteke --json returns a JSON array:
+        // [{"memory":{"content":"...",...},"score":0.xx}, ...]
         let stdout = String::from_utf8_lossy(&output.stdout);
         let mut memories = Vec::new();
 
-        for line in stdout.lines() {
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-                if let Some(content) = val.get("content").and_then(|c| c.as_str()) {
+        if let Ok(arr) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
+            for val in arr {
+                if let Some(content) = val
+                    .get("memory")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_str())
+                {
                     memories.push(content.to_string());
                 }
             }


### PR DESCRIPTION
## Bug Fix: Uteke recall broken since v0.0.13

### Root Cause
Uteke v0.0.13 changed the `recall` CLI flags:
- **Before:** `--format json`
- **After:** `--json`

Cora was still using the old flag, causing `uteke recall` to exit non-zero → **0 memories recalled every time**.

Secondary bug: the JSON parser assumed line-delimited JSON with `content` at top level, but uteke `--json` outputs a JSON array with nested structure: `[{"memory":{"content":"..."},"score":0.xx}]`.

### Fix
1. `--format json` → `--json` (1 flag instead of 2)
2. Parse as JSON array, extract `memory.content` (not top-level `content`)

### Verification

**Before fix:**
```
Uteke recall returned non-zero: error: unexpected argument '--format' found
Recalled 0 memories from Uteke
```

**After fix:**
```
Uteke detected — memory integration enabled
Recalled 2 memories from Uteke
ℹ Review enriched with Uteke memory context.
```

### Files Changed
| File | Change |
|------|--------|
| `src/engine/memory.rs` | Fix flag + parser in `recall_context()` |

### Testing
- `cargo test` — 517/517 pass
- `cargo clippy --all-targets -- -D warnings` — clean
- Runtime verified: `cora review --staged --memory` recalls 2 memories