### PR TITLE
chore: pre-release audit — test count 523, changelog sync

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -8,7 +8,7 @@ Before creating any release PR, verify ALL of the following are updated:
 
 - [ ] `Cargo.toml` — version bump
 - [ ] All target issues merged to `develop`
-- [ ] `cargo test` — all 517+ tests pass
+- [ ] `cargo test` — all 523+ tests pass
 - [ ] `cargo clippy --all-targets -- -D warnings` — clean
 - [ ] `cargo fmt --all -- --check` — clean
 - [ ] `cargo build --release` — no errors

--- a/AGENT.md
+++ b/AGENT.md
@@ -17,7 +17,7 @@ no managed API, no cloud service. Runs locally against diffs, scans, or branches
 ```bash
 cargo build              # Build (debug)
 cargo build --release    # Build (release)
-cargo test               # Run all 517 tests
+cargo test               # Run all 523 tests
 cargo clippy --all-targets -- -D warnings  # Lint (strict)
 cargo fmt --all -- --check  # Format check
 ```
@@ -102,7 +102,7 @@ src/
 ## Testing
 
 ```bash
-cargo test               # 517 tests total
+cargo test               # 523 tests total
                          #   484 unit tests
                          #    16 CLI integration tests
                          #     6 config tests
@@ -234,7 +234,7 @@ Missing any = release blocker.
 ### 1. Code
 
 - [ ] All target issues merged to `develop`
-- [ ] `cargo test` — all 517+ tests pass
+- [ ] `cargo test` — all 523+ tests pass
 - [ ] `cargo clippy --all-targets -- -D warnings` — clean
 - [ ] `cargo fmt --all -- --check` — clean
 - [ ] `cargo build --release` — no errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `chat_completion_raw()` + `chat_completion_stream_raw()` in `engine/llm.rs`
   - 22 unit tests
 
+### Fixed
+
+- **Uteke recall flag** — `--format json` → `--json` (uteke v0.0.13+ API change) (#259)
+- **Uteke recall JSON parser** — handle both bare `[]` and wrapped `{"results":[]}` formats (uteke v0.1.0+)
+- Extracted `parse_recall_json()` with 6 unit tests for format compatibility
+
 ## [0.5.0] - 2026-06-10
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `chat_completion_raw()` + `chat_completion_stream_raw()` in `engine/llm.rs`
   - 22 unit tests
 
+### Fixed
+
+- **Uteke recall flag** — `--format json` → `--json` (uteke v0.0.13+ API change) (#259)
+- **Uteke recall JSON parser** — handle both bare `[]` and wrapped `{"results":[]}` formats (uteke v0.1.0+)
+- Extracted `parse_recall_json()` with 6 unit tests for format compatibility
+
 ## [0.5.0] - 2026-06-10
 
 ### Added


### PR DESCRIPTION
## Pre-Release Final Audit

### Changes
- **AGENT.md**: test count 517→523 (3 locations: build commands, testing section, checklist)
- **.agent.md**: test count 517→523
- **CHANGELOG.md**: add `### Fixed` section for uteke recall bugs (#259)
- **docs/changelog.md**: sync from root CHANGELOG.md

### Pre-Release Verification Matrix

| Check | Status |
|-------|--------|
| `cargo test` | ✅ 523 pass |
| `cargo clippy -- -D warnings` | ✅ clean |
| `cargo fmt --check` | ✅ clean |
| `cargo build --release` | ✅ |
| VitePress build | ✅ 2.91s |
| cora commit documented | ✅ all 10 docs |
| Uteke v0.0.13 compat | ✅ |
| Uteke v0.1.0 compat | ✅ (runtime verified) |
| cora review --memory | ✅ recall + enrich works |

### Feature Summary (v0.5.x unreleased)

| Feature | Issue | Tests |
|---------|-------|-------|
| `cora commit` (HITL+YOLO) | #262 | 22 |
| Uteke recall flag fix | #259 | — |
| Uteke v0.1.0 parser fix | #259 | 6 |
| **Total new** | | **28** |