### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-13
+
 ### Added
 
 - **`cora commit`** — review staged diff + generate commit message + commit (#262)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "cora-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 ```
 
-> Pin a version: `CORA_VERSION=v0.5.0 curl -fsSL ... | sh`  
+> Pin a version: `CORA_VERSION=v0.5.1 curl -fsSL ... | sh`  
 > Or: `cargo install --git https://github.com/codecoradev/cora-cli`  
 > Pre-built binaries: [GitHub Releases](https://github.com/codecoradev/cora-cli/releases)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -24,7 +24,7 @@ export default defineConfig({
       { text: 'Changelog', link: '/changelog' },
       { text: 'Roadmap', link: '/roadmap' },
       {
-        text: 'v0.5.0',
+        text: 'v0.5.1',
         items: [
           { text: 'GitHub', link: 'https://github.com/codecoradev/cora-cli' },
           { text: 'Releases', link: 'https://github.com/codecoradev/cora-cli/releases' },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-13
+
 ### Added
 
 - **`cora commit`** — review staged diff + generate commit message + commit (#262)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,7 +21,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 Pin a specific version:
 
 ```bash
-$ CORA_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+$ CORA_VERSION=v0.5.1 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 ```
 
 ## Install via Cargo


### PR DESCRIPTION
## 🚀 Release v0.5.1

### What's New

- **`cora commit`** (#262) — review staged diff + generate commit message + commit
  - HITL mode (default): interactive `[Y]es / [E]dit / [N]o` prompt
  - YOLO mode (`--yolo`): auto-commit without prompts
  - `--force`: commit even if quality gate fails
  - `--no-review`: skip review, only generate commit message
  - `--edit`: always open `$EDITOR`
  - Conventional commit format (feat/fix/refactor/perf/docs/test/chore/style/build/ci)
  - 22 unit tests

### Fixes

- **Uteke recall flag** — `--format json` → `--json` (#259)
- **Uteke v0.1.0 parser** — handle both bare `[]` and wrapped `{"results":[]}` formats
- Extracted `parse_recall_json()` with 6 unit tests

### Uteke Compatibility

Verified against [uteke v0.1.0](https://github.com/codecoradev/uteke/releases/tag/v0.1.0):
- `recall --json` ✅
- `remember --tags` ✅
- `--namespace` ✅
- Empty results: handles both `[]` (v0.1.0) and `{"results":[]}` (v0.0.x)

### Stats
| Metric | Value |
|--------|-------|
| Tests | 523 pass (28 new) |
| Clippy | Clean |
| Fmt | Clean |
| VitePress | Build OK |

### After Merge
1. Merge develop → main
2. Tag `v0.5.1`
3. GitHub Release with these notes