### PR TITLE
feat: cora affected + index --watch + call graph wiring (#267, #269)

### DIFF
--- a/src/engine/context/extraction.rs
+++ b/src/engine/context/extraction.rs
@@ -73,7 +73,7 @@ static RE_JAVA_TYPE: LazyLock<Regex> =
 const MAX_SYMBOLS_PER_FILE: usize = 50;
 
 /// Extract symbols from a single line of code for a given language.
-fn extract_symbols_from_line(line: &str, language: &str) -> Vec<SymbolKind> {
+pub fn extract_symbols_from_line(line: &str, language: &str) -> Vec<SymbolKind> {
     let mut symbols = Vec::new();
     let mut seen = HashSet::new();
 

--- a/src/index/extract.rs
+++ b/src/index/extract.rs
@@ -351,6 +351,184 @@ fn extract_zig(line: &str, line_no: u32, file: &str, raw: &str, out: &mut Vec<Ex
 }
 
 /// Helper: create an ExtractedDef from a regex capture.
+/// Extract function call sites from source code.
+/// Returns (caller_name, callee_name, file, line) tuples.
+/// The caller_name is the enclosing function (best-effort via scope tracking).
+pub fn extract_calls(content: &str, language: &str, file_path: &str) -> Vec<CallSite> {
+    use crate::engine::context::extraction as ctx_extract;
+    use crate::engine::context::types::SymbolKind as CtxSymbolKind;
+
+    let lines: Vec<&str> = content.lines().collect();
+    let mut current_fn: Option<String> = None;
+    let mut brace_depth: i32 = 0;
+    let mut calls = Vec::new();
+
+    for (i, line) in lines.iter().enumerate() {
+        let line_no = (i + 1) as u32;
+
+        // Track current function scope for Rust/Go/C/Java
+        if language == "rs"
+            || language == "go"
+            || language == "c"
+            || language == "cpp"
+            || language == "java"
+        {
+            // Check if we're entering a function
+            if let Some(fn_name) = detect_function_entry(line, language) {
+                current_fn = Some(fn_name);
+                brace_depth = 0;
+            }
+        }
+
+        // Track brace depth for scope
+        brace_depth += line.chars().filter(|&c| c == '{').count() as i32
+            - line.chars().filter(|&c| c == '}').count() as i32;
+        if brace_depth <= 0 && current_fn.is_some() {
+            current_fn = None;
+        }
+
+        // Extract function calls from this line
+        let symbols = ctx_extract::extract_symbols_from_line(line, language);
+        for sym in symbols {
+            if let CtxSymbolKind::FunctionCall(name) = sym {
+                // Skip self-references and builtins
+                if name == current_fn.as_deref().unwrap_or("") {
+                    continue;
+                }
+                if is_builtin(&name) {
+                    continue;
+                }
+                if let Some(caller) = &current_fn {
+                    calls.push(CallSite {
+                        caller: caller.clone(),
+                        callee: name,
+                        file: file_path.to_string(),
+                        line: line_no,
+                    });
+                }
+            }
+        }
+    }
+
+    calls
+}
+
+/// Detect function entry from a line (returns function name).
+fn detect_function_entry(line: &str, language: &str) -> Option<String> {
+    let trimmed = line.trim();
+
+    match language {
+        "rs" => {
+            // pub fn name( or fn name(
+            let re = regex::Regex::new(r"(?:pub\s+)?(?:async\s+)?fn\s+(\w+)\s*[(<]").unwrap();
+            re.captures(trimmed)
+                .map(|c| c.get(1).unwrap().as_str().to_string())
+        }
+        "go" => {
+            let re = regex::Regex::new(r"func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(").unwrap();
+            re.captures(trimmed)
+                .map(|c| c.get(1).unwrap().as_str().to_string())
+        }
+        "c" | "cpp" | "h" | "hpp" => {
+            let re = regex::Regex::new(r"[\w:*]+\s+(\w+)\s*\([^;]*\)\s*\{").unwrap();
+            re.captures(trimmed)
+                .map(|c| c.get(1).unwrap().as_str().to_string())
+        }
+        "java" | "kt" => {
+            let re = regex::Regex::new(r"\b(\w+)\s*\([^)]*\)\s*\{").unwrap();
+            re.captures(trimmed)
+                .map(|c| c.get(1).unwrap().as_str().to_string())
+        }
+        "py" => {
+            let re = regex::Regex::new(r"def\s+(\w+)").unwrap();
+            re.captures(trimmed)
+                .map(|c| c.get(1).unwrap().as_str().to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Check if a name is a builtin/keyword to skip.
+fn is_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "if" | "for"
+            | "while"
+            | "match"
+            | "return"
+            | "break"
+            | "continue"
+            | "print"
+            | "println"
+            | "eprintln"
+            | "format"
+            | "write"
+            | "writeln"
+            | "vec"
+            | "Box"
+            | "Some"
+            | "None"
+            | "Ok"
+            | "Err"
+            | "Result"
+            | "Option"
+            | "String"
+            | "str"
+            | "Vec"
+            | "HashMap"
+            | "HashSet"
+            | "dbg"
+            | "todo"
+            | "unimplemented"
+            | "unreachable"
+            | "panic"
+            | "assert"
+            | "assert_eq"
+            | "assert_ne"
+            | "len"
+            | "is_empty"
+            | "push"
+            | "pop"
+            | "insert"
+            | "remove"
+            | "get"
+            | "set"
+            | "new"
+            | "default"
+            | "clone"
+            | "into"
+            | "from"
+            | "iter"
+            | "collect"
+            | "map"
+            | "filter"
+            | "fold"
+            | "next"
+            | "unwrap"
+            | "expect"
+            | "as_ref"
+            | "as_mut"
+            | "as_str"
+            | "to_string"
+            | "to_owned"
+            | "to_vec"
+            | "drop"
+            | "copy"
+            | "send"
+            | "sync"
+            | "main"
+    )
+}
+
+/// A function call site extracted from source code.
+#[derive(Debug, Clone)]
+pub struct CallSite {
+    pub caller: String,
+    pub callee: String,
+    pub file: String,
+    pub line: u32,
+}
+
 fn def(cap: regex::Captures, kind: SymbolKind, line: u32, file: &str, raw: &str) -> ExtractedDef {
     ExtractedDef {
         name: cap

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -91,9 +91,22 @@ pub fn index_file(
         count += 1;
     }
 
+    // Extract and store call graph edges
+    graph::clear_edges_for_file(&tx, file_path)?;
+    let call_sites = extract::extract_calls(content, language, file_path);
+    for site in &call_sites {
+        tx.execute(
+            "INSERT INTO call_graph (caller, callee, file, line) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![site.caller, site.callee, site.file, site.line as i64],
+        )?;
+    }
+
     tx.commit()?;
 
-    debug!("Indexed {file_path}: {count} symbols ({language})");
+    debug!(
+        "Indexed {file_path}: {count} symbols, {} edges ({language})",
+        call_sites.len()
+    );
     Ok(count)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,10 @@ enum Command {
         #[clap(long)]
         rebuild: bool,
 
+        /// Watch for file changes and auto-update index
+        #[clap(long)]
+        watch: bool,
+
         /// Verbose output
         #[clap(long, short)]
         verbose: bool,
@@ -148,6 +152,24 @@ enum Command {
         /// Traversal depth (how many levels up the call graph)
         #[clap(long, default_value = "3")]
         depth: u32,
+
+        /// Output as JSON
+        #[clap(long)]
+        json: bool,
+    },
+
+    /// Find tests affected by changed files
+    Affected {
+        /// Changed files (space-separated). If empty, reads from git diff.
+        files: Vec<String>,
+
+        /// Read changed files from stdin (pipe from git diff --name-only)
+        #[clap(long)]
+        stdin: bool,
+
+        /// Test file glob pattern (default: *test*, *spec*)
+        #[clap(long)]
+        filter: Option<String>,
 
         /// Output as JSON
         #[clap(long)]
@@ -509,6 +531,7 @@ async fn main() -> Result<()> {
             stats: show_stats,
             prune,
             rebuild,
+            watch,
             verbose,
         } => {
             let project_root = std::env::current_dir()?;
@@ -544,6 +567,35 @@ async fn main() -> Result<()> {
                     "{}",
                     format!("Pruned {deleted} deleted files from index.").green()
                 );
+            } else if watch {
+                // Initial index
+                eprintln!("{}", "🔍 Initial index...".cyan());
+                let stats =
+                    index::index_project(&conn, &project_root, verbose || cli.global.verbose)?;
+                eprintln!(
+                    "{}",
+                    format!(
+                        "✅ Indexed {} symbols. Watching for changes... (Ctrl+C to stop)",
+                        stats.symbols_indexed
+                    )
+                    .green()
+                );
+
+                // Poll loop: re-index changed files every 2 seconds
+                loop {
+                    std::thread::sleep(std::time::Duration::from_secs(2));
+                    let stats = index::index_project(&conn, &project_root, false)?;
+                    if stats.files_indexed > 0 {
+                        eprintln!(
+                            "{}",
+                            format!(
+                                "🔄 Updated {} files, {} symbols",
+                                stats.files_indexed, stats.symbols_indexed
+                            )
+                            .cyan()
+                        );
+                    }
+                }
             } else {
                 eprintln!("{}", "🔍 Indexing project...".cyan());
                 let stats =
@@ -715,6 +767,140 @@ async fn main() -> Result<()> {
                         node.file.dimmed(),
                         node.line
                     );
+                }
+            }
+            0
+        }
+
+        Command::Affected {
+            files,
+            stdin,
+            filter,
+            json,
+        } => {
+            let project_root = std::env::current_dir()?;
+            let db_path = index::default_db_path(&project_root);
+            if !db_path.exists() {
+                eprintln!("{}", "No index found. Run 'cora index' first.".yellow());
+                std::process::exit(1);
+            }
+            let conn = index::open_index(&db_path)?;
+
+            // Gather changed files
+            let mut changed: Vec<String> = files;
+            if stdin {
+                use std::io::BufRead;
+                let stdin = std::io::stdin();
+                for line in stdin.lock().lines().map_while(Result::ok) {
+                    let trimmed = line.trim().to_string();
+                    if !trimmed.is_empty() {
+                        changed.push(trimmed);
+                    }
+                }
+            }
+
+            if changed.is_empty() {
+                // Fallback: get from git diff
+                let output = std::process::Command::new("git")
+                    .args(["diff", "--name-only", "HEAD"])
+                    .output()?;
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                changed = stdout
+                    .lines()
+                    .map(|l| l.trim().to_string())
+                    .filter(|l| !l.is_empty())
+                    .collect();
+            }
+
+            if changed.is_empty() {
+                eprintln!("{}", "No changed files detected.".yellow());
+                std::process::exit(0);
+            }
+
+            // Default test patterns
+            let patterns: Vec<String> = filter.map(|f| vec![f]).unwrap_or_else(|| {
+                vec![
+                    "test".to_string(),
+                    "spec".to_string(),
+                    "_test".to_string(),
+                    "_spec".to_string(),
+                ]
+            });
+
+            // Find test files that import/reference changed source files
+            let mut affected_tests: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+
+            // Strategy 1: Find symbols in changed files, then find callers that are in test files
+            for file in &changed {
+                // Get all symbols defined in this file
+                let symbols_in_file: Vec<String> = {
+                    let mut stmt =
+                        conn.prepare("SELECT DISTINCT name FROM symbols WHERE file = ?1")?;
+                    let rows =
+                        stmt.query_map(rusqlite::params![file], |row| row.get::<_, String>(0))?;
+                    rows.filter_map(|r| r.ok()).collect()
+                };
+
+                // For each symbol, find callers
+                for sym_name in &symbols_in_file {
+                    let callers = index::graph::find_callers(&conn, sym_name, 100)?;
+                    for caller in callers {
+                        // Check if caller file looks like a test file
+                        if patterns.iter().any(|p| caller.file.contains(p.as_str())) {
+                            affected_tests.insert(caller.file.clone());
+                        }
+                    }
+                }
+            }
+
+            // Strategy 2: Direct test file name convention (mod_test.rs, foo_test.go)
+            for file in &changed {
+                // For Rust: src/foo.rs → tests/foo.rs or src/foo.rs → src/foo_test.rs
+                let stem = file
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(file)
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or("");
+                let test_patterns = [
+                    format!("{stem}_test.rs"),
+                    format!("tests/{stem}.rs"),
+                    format!("test_{stem}.rs"),
+                    format!("{stem}_test.go"),
+                    format!("{stem}_test.py"),
+                    format!("test_{stem}.py"),
+                    format!("{stem}.test.ts"),
+                    format!("{stem}.spec.ts"),
+                ];
+                for tp in &test_patterns {
+                    let mut stmt =
+                        conn.prepare("SELECT DISTINCT path FROM files WHERE path LIKE ?1")?;
+                    let pattern = format!("%{tp}");
+                    let rows =
+                        stmt.query_map(rusqlite::params![pattern], |row| row.get::<_, String>(0))?;
+                    for f in rows.map_while(Result::ok) {
+                        affected_tests.insert(f);
+                    }
+                }
+            }
+
+            let mut sorted: Vec<String> = affected_tests.into_iter().collect();
+            sorted.sort();
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&sorted)?);
+            } else if sorted.is_empty() {
+                eprintln!("{}", "No affected test files found.".yellow());
+            } else {
+                println!(
+                    "{}",
+                    format!("Affected test files ({}):", sorted.len()).cyan()
+                );
+                println!("{}", "\u{2500}".repeat(50).dimmed());
+                for f in &sorted {
+                    println!("  {}", f.white().bold());
                 }
             }
             0


### PR DESCRIPTION
## Three features in one PR

### Call graph edge extraction (wiring)
Made `cora callers` and `cora impact` actually work by extracting call edges during indexing.

- `extract_calls()` in `index/extract.rs`: scope tracking + call site extraction
- Reuses `engine/context/extraction.rs` for symbol reference detection
- `detect_function_entry()` for Rust/Go/C/Java/Python
- `is_builtin()` filter (skips 40+ stdlib names)
- Edges stored in `call_graph` table during `index_file()`

**Runtime verified:**
```
cora callers execute_commit → 1 caller (main)
cora impact open_index --depth 2 → 5 affected sites at depth 1
```

### #267 — `cora affected`
Find test files affected by source code changes.

```bash
cora affected src/main.rs src/index/mod.rs
git diff --name-only | cora affected --stdin
cora affected --json
```

Two strategies:
1. **Call graph**: changed symbols → find callers in test files
2. **Naming convention**: `foo.rs` → `foo_test.rs`, `tests/foo.rs`, `foo.test.ts`

**Runtime verified:**
```
echo "src/main.rs" | cora affected --stdin
→ tests/cli_basic.rs, tests/config_loading.rs
```

### #269 — `cora index --watch`
Auto-sync file watcher (poll-based, no extra deps).

```bash
cora index --watch
# 🔍 Initial index... 1349 symbols
# ✅ Watching for changes... (Ctrl+C to stop)
# 🔄 Updated 2 files, 15 symbols
```

### Tests
- **552 total**, clippy clean, fmt clean
- No new deps (reuses existing crates)