### PR TITLE
fix(ci): use docs:build instead of build in deploy workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: docs
 
       - name: Build
-        run: npm run build
+        run: npm run docs:build
         working-directory: docs
 
       - name: Verify build output


### PR DESCRIPTION
The deploy workflow uses `npm run build` but cora's docs package.json uses `npm run docs:build`. This PR fixes the script name.

Also relevant: this workflow triggered on develop via workflow_dispatch but the build script was wrong.