### PR TITLE
fix(ci): deploy to CF Pages production (remove --branch flag)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -52,4 +52,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           preCommands: npx wrangler pages project create cora --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora --commit-dirty=true --branch=main
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora


### PR DESCRIPTION
wrangler pages deploy with --branch=main creates preview deployment, not production. Remove --branch so it deploys to production.