### PR TITLE
fix: align deploy workflow with uteke/trapfall pattern

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -52,4 +52,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           preCommands: npx wrangler pages project create cora --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora --commit-dirty=true --branch=main


### PR DESCRIPTION
## Problem
`cora.pages.dev` still shows "Coming Soon" placeholder despite successful deploy runs.

Root cause: deploy workflow missing `--commit-dirty=true` and `--branch=main` flags that uteke and trapfall use.

## Changes
- Add `--commit-dirty=true` to wrangler deploy command
- Add `--branch=main` to wrangler deploy command
- Keeps `docs:build` (cora-specific, unlike uteke/trapfall which use `build`)

## Reference
This matches the exact pattern from:
- `codecoradev/uteke` → ✅ deploys successfully
- `codecoradev/trapfall` → ✅ deploys successfully