### PR TITLE
fix: rename CF Pages project cora → cora-cli

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: npx wrangler pages project create cora --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora --commit-dirty=true --branch=main
+          preCommands: npx wrangler pages project create cora-cli --production-branch=main || true
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora-cli --commit-dirty=true --branch=main


### PR DESCRIPTION
cora.pages.dev is owned by someone else. Changed project-name to cora-cli.