### PR TITLE
feat: Cora + Uteke bundle installer + cross-product docs (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cora + Uteke bundle installer** (`install-bundle.sh`) — single command installs both tools (#235)
+- **Documentation** — Uteke memory integration docs across README, usage, getting-started, cli-reference
+
 ## [0.5.1] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@
 ### Install
 
 ```bash
+# Cora only (standalone)
 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+
+# Or install both Cora + Uteke (code review with memory)
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
 ```
 
 > Pin a version: `CORA_VERSION=v0.5.1 curl -fsSL ... | sh`  
@@ -147,6 +151,30 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora hook install` | Install pre-commit hook |
 
 See **[CLI Reference →](https://codecora.dev/cli-reference.html)** for all flags and examples.
+
+## Uteke Memory Integration
+
+Cora works 100% standalone. Install [Uteke](https://github.com/codecoradev/uteke) to unlock **memory-powered reviews** that learn from your codebase history.
+
+| Mode | Command | What it does |
+|------|---------|-------------|
+| Standalone (default) | `cora review` | AI review, zero deps |
+| Memory recall | `cora review --memory` | Recall project patterns before review |
+| Learning | `cora review --memory --learn` | Recall + save findings after review |
+
+```bash
+# Install Uteke separately
+curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
+
+# Or install both at once
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+
+# Enable memory
+export PATH="$HOME/.local/bin:$PATH"
+cora review --staged --memory --learn
+```
+
+Your code review gets smarter every sprint.
 
 ## Environment Variables
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cora + Uteke bundle installer** (`install-bundle.sh`) — single command installs both tools (#235)
+- **Documentation** — Uteke memory integration docs across README, usage, getting-started, cli-reference
+
 ## [0.5.1] - 2026-06-13
 
 ### Added

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -96,3 +96,11 @@ $ cora commit
 # YOLO mode — auto-commit, no prompts
 $ cora commit --yolo
 ```
+
+```bash
+# Install both Cora + Uteke (code review with memory)
+$ curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+
+# Then review with memory:
+$ cora review --staged --memory --learn
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,6 +150,28 @@ Or skip the prompt in CI/trusted workflows:
 cora commit --yolo    # auto-commit, no prompts
 ```
 
+### Memory-Powered Reviews (Optional)
+
+Install [Uteke](https://github.com/codecoradev/uteke) to give Cora a memory:
+
+```bash
+# Install both tools
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+```
+
+Then enable memory in reviews:
+
+```bash
+cora review --staged --memory         # recall project patterns
+cora review --staged --memory --learn # recall + save findings
+```
+
+- `--memory` — Cora recalls past review findings and code patterns from Uteke before reviewing
+- `--learn` — After review, Cora saves findings to Uteke for future recall
+- Works with any review mode (staged, unpushed, branch)
+
+Your code review gets smarter every sprint.
+
 ## AI Agent Integration
 
 cora includes a built-in MCP server for AI coding agents. After installation:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -175,6 +175,47 @@ $ cora review --staged --exclude "**/*.test.ts" --exclude "**/generated/**"
 
 Alternatively, set include/exclude patterns in `.cora.yaml` for persistent configuration.
 
+## Uteke Memory Integration
+
+Cora works standalone. Install [Uteke](https://github.com/codecoradev/uteke) to unlock reviews that learn from your codebase history.
+
+### Three Levels
+
+| Level | Command | Uteke Required | What It Does |
+|-------|---------|:---:|-------------|
+| **Standalone** | `cora review` | No | AI review, zero deps |
+| **Recall** | `cora review --memory` | Yes | Recall project patterns before review |
+| **Learning** | `cora review --memory --learn` | Yes | Recall + save findings after review |
+
+### Install Both
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+```
+
+### Usage
+
+```bash
+# Review with memory recall
+cora review --staged --memory
+
+# Review + save to memory (reviews improve over time)
+cora review --staged --memory --learn
+
+# Works with all review modes
+cora review --base main --memory --learn
+cora commit --memory  # Note: --memory only on review, not commit
+```
+
+### How It Works
+
+1. Before review, Cora calls `uteke recall` to find relevant memories (past findings, code patterns)
+2. These memories are injected into the LLM prompt as context
+3. After review (with `--learn`), findings are saved to Uteke via `uteke remember`
+4. Next review benefits from accumulated knowledge
+
+Cora auto-detects Uteke on PATH. If not installed, memory features are silently disabled.
+
 ## Exit Codes
 
 cora uses standard exit codes for scripting and CI integration:

--- a/install-bundle.sh
+++ b/install-bundle.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+#
+# cora + uteke bundle installer
+# Installs both Cora (AI code review) and Uteke (AI memory) in one command.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+#
+# With version pinning:
+#   CORA_VERSION=v0.5.1 UTEKE_VERSION=v0.1.0 curl -fsSL ... | sh
+
+set -e
+
+# Colors
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    CYAN='\033[0;36m'
+    BOLD='\033[1m'
+    DIM='\033[2m'
+    NC='\033[0m'
+else
+    RED='' GREEN='' YELLOW='' CYAN='' BOLD='' DIM='' NC=''
+fi
+
+info()  { printf "${CYAN}[INFO]${NC} %s\n" "$1"; }
+ok()    { printf "${GREEN}[OK]${NC} %s\n" "$1"; }
+warn()  { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; exit 1; }
+
+BINARY_DIR="${HOME}/.local/bin"
+
+# Ensure binary dir exists
+mkdir -p "$BINARY_DIR"
+
+# ─── Install Cora ───
+install_cora() {
+    info "Installing Cora — AI code review CLI..."
+
+    if command -v cora >/dev/null 2>&1; then
+        EXISTING=$(cora --version 2>/dev/null | head -1 || echo "unknown")
+        info "Cora already installed: $EXISTING"
+        if [ -z "${CORA_FORCE:-}" ]; then
+            info "Skipping (set CORA_FORCE=1 to reinstall)"
+            return 0
+        fi
+    fi
+
+    curl -fsSL "https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh" | sh
+    ok "Cora installed: $(cora --version 2>/dev/null | head -1)"
+}
+
+# ─── Install Uteke ───
+install_uteke() {
+    info "Installing Uteke — AI memory engine..."
+
+    if command -v uteke >/dev/null 2>&1; then
+        EXISTING=$(uteke --version 2>/dev/null | head -1 || echo "unknown")
+        info "Uteke already installed: $EXISTING"
+        if [ -z "${UTEKE_FORCE:-}" ]; then
+            info "Skipping (set UTEKE_FORCE=1 to reinstall)"
+            return 0
+        fi
+    fi
+
+    curl -fsSL "https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh" | sh
+    ok "Uteke installed: $(uteke --version 2>/dev/null | head -1)"
+}
+
+# ─── Verify ───
+verify() {
+    info "Verifying installation..."
+
+    CORA_OK="no"
+    UTEKE_OK="no"
+
+    if command -v cora >/dev/null 2>&1; then
+        CORA_VER=$(cora --version 2>/dev/null | head -1)
+        CORA_OK="yes"
+        ok "Cora: $CORA_VER"
+    else
+        warn "Cora not found in PATH"
+    fi
+
+    if command -v uteke >/dev/null 2>&1; then
+        UTEKE_VER=$(uteke --version 2>/dev/null | head -1)
+        UTEKE_OK="yes"
+        ok "Uteke: $UTEKE_VER"
+    else
+        warn "Uteke not found in PATH"
+    fi
+
+    echo ""
+    printf "${BOLD}━━━ Setup Complete ━━━${NC}\n"
+    echo ""
+
+    if [ "$CORA_OK" = "yes" ] && [ "$UTEKE_OK" = "yes" ]; then
+        printf "${GREEN}Both tools installed!${NC} You now have AI code review with memory.\n\n"
+        echo "  ${BOLD}Quick start:${NC}"
+        echo "    cora auth login          # Set your API key"
+        echo "    cora review --staged     # Review staged changes"
+        echo "    cora review --memory     # Review with project memory"
+        echo "    cora commit              # Review + auto commit message"
+        echo ""
+        echo "  ${BOLD}Memory workflow:${NC}"
+        echo "    cora review --memory --learn   # Review + save to memory"
+        echo "    uteke stats                     # Check memory stats"
+        echo ""
+        printf "  ${DIM}Your code review gets smarter every sprint.${NC}\n"
+    elif [ "$CORA_OK" = "yes" ]; then
+        printf "${YELLOW}Cora installed.${NC} Install Uteke separately for memory features:\n"
+        echo "    curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh"
+    elif [ "$UTEKE_OK" = "yes" ]; then
+        printf "${YELLOW}Uteke installed.${NC} Install Cora separately for code review:\n"
+        echo "    curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh"
+    else
+        error "Neither tool was installed successfully."
+    fi
+
+    # PATH check
+    case ":$PATH:" in
+        *":$BINARY_DIR:"*) ;;
+        *)
+            echo ""
+            warn "Add $BINARY_DIR to your PATH:"
+            echo "    echo 'export PATH=\"$BINARY_DIR:\$PATH\"' >> ~/.bashrc"
+            echo "    source ~/.bashrc"
+            ;;
+    esac
+}
+
+# ─── Main ───
+echo ""
+printf "${BOLD}${CYAN}╔══════════════════════════════════════════════╗${NC}\n"
+printf "${BOLD}${CYAN}║  CodeCoraDev Bundle — Cora + Uteke          ║${NC}\n"
+printf "${BOLD}${CYAN}║  AI code review that remembers and learns   ║${NC}\n"
+printf "${BOLD}${CYAN}╚══════════════════════════════════════════════╝${NC}\n"
+echo ""
+
+install_cora
+echo ""
+install_uteke
+echo ""
+verify
+echo ""


### PR DESCRIPTION
## Cora + Uteke Cross-Product Bundle (#235)

Completes the cross-product integration story. Subprocess integration was already working — this PR adds the **packaging and documentation layer**.

### What's New

**`install-bundle.sh`** — Single command installs both tools:
```bash
curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
```
- Detects existing installs (skip unless `CORA_FORCE=1` / `UTEKE_FORCE=1`)
- Verification + quick start guide
- PATH check with helpful message
- Tested runtime: ✅ installs cora 0.5.1 + uteke 0.1.0

### Documentation Updates (5 files)

| File | Change |
|------|--------|
| **README.md** | Bundle install option + new "Uteke Memory Integration" section |
| **docs/getting-started.md** | "Memory-Powered Reviews" section with install + usage |
| **docs/usage.md** | Full "Uteke Memory Integration" section (3 levels, how it works) |
| **docs/cli-reference.md** | Bundle install example |
| **CHANGELOG.md** | Bundle + docs entry |

### Acceptance Criteria

| Criteria | Status |
|----------|--------|
| `cora review` works without Uteke (zero regression) | ✅ |
| `cora review --memory --learn` works when Uteke installed | ✅ |
| Documentation covers both standalone and combined usage | ✅ |
| Install script sets up both tools | ✅ |
| Cross-referencing README mentions in both repos | ✅ (cora → uteke, uteke → cora pending in uteke repo) |

### Tests
- 567 pass, clippy clean
- VitePress build OK
- Bundle installer tested end-to-end