### PR TITLE
fix: remove VitePress base — Worker handles routing

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: 'Cora',
   description: 'AI-Powered Code Review CLI — BYOK, zero config, runs in your terminal',
-  base: '/docs/cora/',
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],


### PR DESCRIPTION
VitePress base removed. CF Pages serves at root. Worker injects `<base href>` for correct asset resolution under /docs/{project}/.