### PR TITLE
fix: VitePress base + CF Pages _redirects

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,1 @@
+/docs/cora/*  /:splat  200


### PR DESCRIPTION
Adds base config and _redirects for CF Pages routing.