### PR TITLE
fix: add VitePress base '/docs/cora/' to cora config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,10 +3,11 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: 'Cora',
   description: 'AI-Powered Code Review CLI — BYOK, zero config, runs in your terminal',
+  base: '/docs/cora/',
 
   head: [
-    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
-    ['link', { rel: 'alternate icon', type: 'image/png', href: '/favicon.png' }],
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/docs/cora/favicon.svg' }],
+    ['link', { rel: 'alternate icon', type: 'image/png', href: '/docs/cora/favicon.png' }],
     ['meta', { name: 'theme-color', content: '#6366f1' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: 'Cora — AI Code Review CLI' }],
@@ -16,7 +17,7 @@ export default defineConfig({
   ],
 
   themeConfig: {
-    logo: '/logo.svg',
+    logo: '/docs/cora/logo.svg',
 
     nav: [
       { text: 'Codecora', link: 'https://codecora.dev' },


### PR DESCRIPTION
Adds VitePress base config for cora so assets resolve correctly under /docs/cora/ path.