### PR TITLE
fix(install): strip macOS Gatekeeper quarantine xattrs (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Extracted exit-code logic into `compute_exit_code()` helper (pure function) with 8 unit tests covering gate pass/fail, CI mode, and hook `block` vs non-`block` modes.
   - Applies to both the single-chunk and auto-chunked (`--auto-chunk`) review paths.
 
+### Fixed — Install (macOS)
+
+- **macOS installer now strips Gatekeeper quarantine attributes (#313)**
+  - Prebuilt macOS binaries (`aarch64-apple-darwin`) are not Apple-notarized. When downloaded directly, macOS attaches `com.apple.quarantine` / `com.apple.provenance` xattrs and kills the binary with `Killed: 9` on first launch.
+  - `install.sh` now runs `xattr -dr` for both attributes on the installed binary on macOS (best-effort, non-fatal).
+  - Added a prominent `<details>` block in the README install section explaining the symptom, the manual `xattr` workaround for users who download the binary directly, and the `cargo` / Homebrew alternatives.
+
 ## [0.6.0] - 2026-06-14
 
 ### Added — Code Intelligence

--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-b
 > Or: `cargo install --git https://github.com/codecoradev/cora-cli`  
 > Pre-built binaries: [GitHub Releases](https://github.com/codecoradev/cora-cli/releases)
 
+<details>
+<summary><b>macOS note — binary killed on launch (<code>Killed: 9</code>)?</b></summary>
+
+The prebuilt `aarch64-apple-darwin` binary is not Apple-notarized. On macOS, downloaded
+binaries may be tagged with `com.apple.quarantine` / `com.apple.provenance` and killed by
+Gatekeeper with **no error message**.
+
+The `install.sh` installer strips these attributes automatically. If you downloaded the
+binary manually (e.g. `gh release download`), strip them yourself:
+
+```bash
+xattr -dr com.apple.quarantine /path/to/cora
+xattr -dr com.apple.provenance /path/to/cora
+```
+
+Or install via `cargo` / Homebrew to sidestep Gatekeeper entirely.
+
+</details>
+
 ### Authenticate
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,16 @@ install() {
 
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
+    # macOS Gatekeeper workaround (#313): strip quarantine/provenance xattrs
+    # that the browser/curl attaches to downloaded binaries. Without this,
+    # macOS kills the unsigned binary with `Killed: 9` and no error message.
+    if [ "$OS" = "darwin" ] && command -v xattr >/dev/null 2>&1; then
+        # Best-effort — failures here are non-fatal (binary may already be clean).
+        xattr -dr com.apple.quarantine "${INSTALL_DIR}/${BINARY_NAME}" 2>/dev/null || true
+        xattr -dr com.apple.provenance "${INSTALL_DIR}/${BINARY_NAME}" 2>/dev/null || true
+        info "Stripped macOS quarantine attributes (Gatekeeper workaround)"
+    fi
+
     # Cleanup
     rm -rf "$TEMP_DIR"
 


### PR DESCRIPTION
## Summary

Fixes #313 — macOS binary release killed by Gatekeeper quarantine (`com.apple.quarantine` / `com.apple.provenance`).

Prebuilt macOS binaries are not Apple-notarized. When downloaded directly (`gh release download`, browser, curl), macOS attaches quarantine xattrs and kills the binary on first launch with `Killed: 9` and **no error output**, making it look like a cora crash.

## Changes

### `install.sh`
After `chmod +x`, on macOS run best-effort:
```sh
xattr -dr com.apple.quarantine "${INSTALL_DIR}/${BINARY_NAME}"
xattr -dr com.apple.provenance "${INSTALL_DIR}/${BINARY_NAME}"
```
Non-fatal on failure (binary may already be clean). Logs `Stripped macOS quarantine attributes (Gatekeeper workaround)`.

### `README.md`
Added a prominent `<details>` block under the Install section explaining:
- The `Killed: 9` symptom,
- The manual `xattr -dr` workaround for direct-download users,
- The `cargo` / Homebrew alternatives that sidestep Gatekeeper entirely.

### `CHANGELOG.md`
Entry under `## [0.6.1] -> Fixed — Install (macOS)`.

## What this does NOT do

The **real fix** is Apple notarization (`codesign` + `xcrun notarytool submit`) in `.github/workflows/release.yml`, which requires an Apple Developer ID certificate + App Store Connect API key. This PR is the **minimum-cost stopgap** explicitly suggested in the issue. A follow-up issue can track notarization once credentials are available — the install.sh strip will remain useful even after notarization (defensive, covers direct-download paths).

## Tests
- `sh -n install.sh` — syntax OK.
- `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` all clean (no Rust changes).

## Versioning

Patch bump `0.6.0` → `0.6.1` (shares the release with #316 and #312).

⚠️ **Merge note**: CHANGELOG and `Cargo.toml` will conflict with #317 and #318. Suggested merge order: #317 → #318 → **this PR**. Conflicts are confined to the `## [0.6.1]` block of `CHANGELOG.md` and the version line in `Cargo.toml`/`Cargo.lock`.

## Checklist
- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] `sh -n install.sh` passes
- [x] CHANGELOG entry under `## [0.6.1]` → `### Fixed — Install (macOS)`
- [x] Version bumped in `Cargo.toml` + `Cargo.lock`