### PR TITLE
docs(install): warn about multiple distribution channels (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `install.sh` now runs `xattr -dr` for both attributes on the installed binary on macOS (best-effort, non-fatal).
   - Added a prominent `<details>` block in the README install section explaining the symptom, the manual `xattr` workaround for users who download the binary directly, and the `cargo` / Homebrew alternatives.
 
+### Changed — Docs
+
+- **Install section now warns about multiple distribution channels (#314)**
+  - Recommends a single install method per platform and lists the supported channels (installer script, `cargo`, pre-built binaries).
+  - Adds a `which -a cora && cora --version` check snippet and guidance for removing stale copies when more than one `cora` is on `PATH` (e.g. `~/.local/bin` vs `~/.cargo/bin` vs npm global).
+  - Cross-links the original issue for background.
+
 ## [0.6.0] - 2026-06-14
 
 ### Added — Code Intelligence

--- a/README.md
+++ b/README.md
@@ -36,17 +36,35 @@
 
 ### Install
 
+Pick **one** install method — mixing channels can leave stale binaries on your `PATH`.
+
+| Method | When to use |
+|---|---|
+| **`curl … install.sh`** (recommended) | Quick standalone install; fetches the latest GitHub release binary |
+| **`cargo install --git …`** | You already have a Rust toolchain; builds from source |
+| **Pre-built binaries** | Manual download from [Releases](https://github.com/codecoradev/cora-cli/releases) |
+
 ```bash
-# Cora only (standalone)
+# Recommended: Cora only (standalone)
 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
 
 # Or install both Cora + Uteke (code review with memory)
 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+
+# Or build from source with cargo
+cargo install --git https://github.com/codecoradev/cora-cli
 ```
 
-> Pin a version: `CORA_VERSION=v0.6.0 curl -fsSL ... | sh`  
-> Or: `cargo install --git https://github.com/codecoradev/cora-cli`  
-> Pre-built binaries: [GitHub Releases](https://github.com/codecoradev/cora-cli/releases)
+> Pin a version: `CORA_VERSION=v0.6.0 curl -fsSL ... | sh`
+
+**Verify which `cora` you're running** — `which -a cora` will reveal stale copies from other channels:
+
+```bash
+which -a cora            # list every `cora` on your PATH (one entry = healthy)
+cora --version           # should match the latest release
+```
+
+If `which -a cora` shows more than one path (e.g. `~/.local/bin/cora` and `~/.cargo/bin/cora`), remove the one you don't want or reorder your `PATH`. See [Issue #314](https://github.com/codecoradev/cora-cli/issues/314) for background.
 
 <details>
 <summary><b>macOS note — binary killed on launch (<code>Killed: 9</code>)?</b></summary>


### PR DESCRIPTION
## Summary

Fixes #314 — install instructions don't warn about multiple distribution channels causing PATH conflicts.

The install docs listed several methods (installer script, `cargo`, pre-built binaries, npm) without warning that having more than one on `$PATH` silently resolves to whichever appears first. On a real developer machine three copies were present simultaneously (`~/.local/bin/cora`, `~/.cargo/bin/cora`, `~/.bun/bin/cora`) and the **stale npm v0.2.4** was being invoked, causing confusing behavior with no warning.

Closes #315 as a duplicate of #314 (same title, body, author, opened 3 seconds apart — already closed on the issue tracker).

## Changes

### `README.md` — Install section
- Replaces the bare install commands with a short table recommending **one** install method per use case (installer script / `cargo` / pre-built binaries).
- Adds a **"Verify which `cora` you're running"** snippet using `which -a cora` (lists every `cora` on `PATH`) and `cora --version`.
- Explains what to do when more than one entry appears (remove the unwanted one, or reorder `PATH`).
- Cross-links issue #314 for background.

### `CHANGELOG.md`
Entry under `## [0.6.1] -> Changed — Docs`.

## Tests
Docs-only change. `cargo build` and `cargo fmt --check` still pass to keep the version bump consistent with the rest of the 0.6.1 patch bundle.

## Versioning

Patch bump `0.6.0` → `0.6.1` (shares the release with #316, #312, #313).

⚠️ **Merge note**: CHANGELOG and `Cargo.toml` will conflict with #317, #318, and #319. Suggested merge order: #317 → #318 → #319 → **this PR** (docs last). Conflicts are confined to the `## [0.6.1]` block of `CHANGELOG.md` and the version line in `Cargo.toml`/`Cargo.lock`.

## Checklist
- [x] `cargo build` passes
- [x] `cargo fmt --check` clean
- [x] CHANGELOG entry under `## [0.6.1]` → `### Changed — Docs`
- [x] Version bumped in `Cargo.toml` + `Cargo.lock`
- [x] Duplicate issue #315 closed as not-planned