### PR TITLE
fix(ci): project-sync should not fail when merged PR has no closing keyword

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -121,8 +121,10 @@ jobs:
               | python3 -c "
                   import sys, json
                   data = json.load(sys.stdin)
+                  node = (data.get('data') or {}).get('node') or {}
+                  items = (node.get('items') or {}).get('nodes') or []
                   target = '$content_node_id'
-                  for n in data['data']['node']['items']['nodes']:
+                  for n in items:
                       c = n.get('content') or {}
                       if c.get('id') == target:
                           print(n['id'])
@@ -176,17 +178,21 @@ jobs:
                 | python3 -c "
                     import sys, json
                     data = json.load(sys.stdin)
-                    nodes = data['data']['node']['closingIssuesReferences']['nodes']
+                    node = (data.get('data') or {}).get('node') or {}
+                    nodes = (node.get('closingIssuesReferences') or {}).get('nodes') or []
                     for n in nodes:
                         print(n['id'] + ' ' + str(n['number']))
                   " 2>/dev/null || true)
 
               if [ -z "$LINKED" ]; then
                 echo "No linked closing issues found for PR #$PR_NUMBER."
-                # If the PR content itself is on the board, mark it Done.
-                item_id=$(get_item_id "$PR_NODE_ID")
+                # A merged PR that references issues via "Refs #N" (rather than
+                # a closing keyword) legitimately has no closing references —
+                # this is not an error. Best-effort: mark the PR itself Done if
+                # it happens to be on the board.
+                item_id=$(get_item_id "$PR_NODE_ID" || true)
                 if [ -n "$item_id" ]; then
-                  set_done "$item_id"
+                  set_done "$item_id" || true
                 fi
               else
                 echo "$LINKED" | while read -r issue_node issue_num; do


### PR DESCRIPTION
## Problem

When PR #338 was merged, the `sync` (project-board) workflow failed with exit 1 — visible as a red check on an otherwise all-green PR.

## Root cause

PR #338 referenced its issue via `Refs #335` (not `Closes #335`), so its `closingIssuesReferences` were empty. That empty case then called `get_item_id()` under `set -e`. When the GraphQL response had an unexpected shape (e.g. `node: null` from a token/permission quirk), the inline python raised `TypeError`, the function returned non-zero, and `set -e` aborted the script **before** the intended `exit 0`.

A merged PR with no closing keyword is a legitimate, non-error outcome — the script treated it as a hard failure.

## Fix

1. **Defensive python** in `get_item_id()` and the LINKED query — use `.get()` chains and fall back to `[]` so null/unexpected shapes never raise.
2. **Guarded call sites** in the empty-LINKED branch with `|| true` so a missing board item can never abort the job.

The job is already `continue-on-error: true` (non-critical), but this eliminates the spurious red check entirely.

## Testing

- YAML structure preserved (only inline-script python changed).
- Logic trace: merged PR with `Refs #N` → empty LINKED → `get_item_id` returns "" (no throw) → no `set_done` → `exit 0`. ✅
- Merged PR with `Closes #N` → LINKED populated → unchanged happy path. ✅

Refs #338