### PR TITLE
chore: rename cora-cli → cora-code

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -1,4 +1,4 @@
-# Agent Context — cora-cli
+# Agent Context — cora-code
 
 ## Pre-Release Checklist
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: npx wrangler pages project create cora-cli --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora-cli --commit-dirty=true
+          preCommands: npx wrangler pages project create cora-code --production-branch=main || true
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora-code --commit-dirty=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
             printf '### 🚀 Quick Start\n\n'
             printf '```bash\n'
             printf '# Quick install (Linux / macOS)\n'
-            printf 'curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh\n\n'
+            printf 'curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh\n\n'
             printf '# Or via cargo\n'
             printf 'cargo install cora\n\n'
             printf '# Init project\n'
@@ -194,7 +194,7 @@ jobs:
             printf '# Review staged changes\n'
             printf 'CORA_API_KEY=your-key cora review --staged\n'
             printf '```\n\n'
-            printf '**Full changelog:** https://github.com/codecoradev/cora-cli/blob/main/CHANGELOG.md\n'
+            printf '**Full changelog:** https://github.com/codecoradev/cora-code/blob/main/CHANGELOG.md\n'
           } > release-notes.md
 
       - name: Create GitHub Release

--- a/AGENT.md
+++ b/AGENT.md
@@ -2,12 +2,12 @@
 
 ## Project Overview
 
-**cora-cli** is a Rust CLI tool for AI-powered code review. Bring Your Own Keys (BYOK) —
+**cora-code** is a Rust CLI tool for AI-powered code review. Bring Your Own Keys (BYOK) —
 no managed API, no cloud service. Runs locally against diffs, scans, or branches.
 
 - **License:** MIT
 - **Edition:** Rust 2024 (MSRV 1.85)
-- **Repo:** `codecoradev/cora-cli`
+- **Repo:** `codecoradev/cora-code`
 - **Default branch:** `develop`
 - **Marketplace:** https://github.com/marketplace/actions/cora-ai-code-review
 - **Website:** https://codecora.dev
@@ -275,7 +275,7 @@ reality BEFORE version bump.
 - [ ] **Consistent terminology**: Same name for features across all files (e.g. "Quality Gate" not "quality gate" or "gate check")
 - [ ] **No broken links**: All `codecora.dev` links resolve. All internal doc links work
 - [ ] **Version numbers**: README install example, docs/installation.md pin example, AGENT.md test count — all match current version
-- [ ] **Star History chart**: Repository list includes all relevant repos (e.g. `cora-cli,uteke`)
+- [ ] **Star History chart**: Repository list includes all relevant repos (e.g. `cora-code,uteke`)
 
 ### 4. CI & Scanning
 
@@ -311,7 +311,7 @@ Generate a comprehensive pre-release report covering:
 ║           LAPORAN PRE-RELEASE vX.Y.Z — FINAL               ║
 ╚══════════════════════════════════════════════════════════════╝
 
-📦 REPOSITORY: codecoradev/cora-cli
+📦 REPOSITORY: codecoradev/cora-code
 🌿 BRANCH:     develop (N commits ahead of main)
 🏷️  TAG:       Next → vX.Y.Z
 📋 CARGO:      version = "0.X.Y" (needs bump)
@@ -384,7 +384,7 @@ After release completes, verify:
 - [ ] GitHub Release page shows vX.Y.Z with correct changelog
 - [ ] 4 platform binaries attached to release
 - [ ] SHA256 checksums file included
-- [ ] `crates.io` shows new version: `cargo search cora-cli`
+- [ ] `crates.io` shows new version: `cargo search cora-code`
 - [ ] `codecora.dev` reflects new docs
 - [ ] Marketplace action still works (test on a test PR)
 - [ ] Close the released milestone/issues
@@ -396,7 +396,7 @@ If release fails or has critical bugs:
 
 1. Delete the tag: `git push origin --delete vX.Y.Z`
 2. Delete the GitHub Release
-3. Yank from crates.io: `cargo yank cora-cli@X.Y.Z`
+3. Yank from crates.io: `cargo yank cora-code@X.Y.Z`
 4. Fix on develop, re-tag when ready
 
 ### Version Numbering Convention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to cora-cli are documented in this file.
+All notable changes to cora-code are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -242,7 +242,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Profiles bugs** — path resolution with project root, fail-fast on invalid config, dedup merge by `id` (#238)
 - **Code Scanning alert #79** — eliminated redundant `parse_diff()` call in language context injection
-- **Download hardening** — 5x retry with exponential backoff, gzip validation, checksum verification for cora-cli binary download in CI (#221)
+- **Download hardening** — 5x retry with exponential backoff, gzip validation, checksum verification for cora-code binary download in CI (#221)
 - **curl hardening** — `--fail --show-error` + `set -e` guard prevents silent HTML downloads
 - **Checksum enforcement** — hard fail on missing/invalid checksums (was warning-only)
 - **Exact checksum match** — `awk` exact filename lookup replaces `grep` substring match
@@ -374,7 +374,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`BundlingConfig`** — `strategy`, `max_chars_per_group`, `max_files_per_group`, `coalesce_by_directory`, `coalesce_by_language` in `.cora.yaml`
 - **`ContextConfig`** — `enabled`, `max_context_tokens`, `follow_depth`, `max_symbols` in `.cora.yaml` review section
 - **Default SARIF upload to GitHub Code Scanning ON** — opt-out with `upload-sarif: false` (#148)
-- **SARIF tool branding** — `CodeCora` driver name (`codecoradev/cora-cli`) in SARIF output (#148)
+- **SARIF tool branding** — `CodeCora` driver name (`codecoradev/cora-code`) in SARIF output (#148)
 
 ### Changed
 
@@ -395,7 +395,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Engine layer migrated from `anyhow` to `thiserror`** — structured error handling in engine, `anyhow` retained in CLI layer (#86)
 - **All clippy pedantic warnings resolved** — 175 → 0 warnings across entire codebase (#84)
-- **Repo URLs updated** to `codecoradev/cora-cli` org (#137)
+- **Repo URLs updated** to `codecoradev/cora-code` org (#137)
 - **CI actions bumped** — `upload-artifact@v7`, Node 24 strict mode (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`) (#142)
 
 ### Fixed
@@ -576,7 +576,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced ASCII art banner with eye icon in README
-- Updated README branding to cora-cli
+- Updated README branding to cora-code
 
 ### Fixed
 
@@ -600,25 +600,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.6.1...develop
-[0.6.1]: https://github.com/codecoradev/cora-cli/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/codecoradev/cora-cli/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/codecoradev/cora-cli/compare/v0.4.6...v0.5.0
-[0.4.6]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...v0.4.6
-[0.4.5]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...v0.4.5
-[0.4.4]: https://github.com/codecoradev/cora-cli/compare/v0.4.3...v0.4.4
-[0.4.3]: https://github.com/codecoradev/cora-cli/compare/v0.4.2...v0.4.3
-[0.4.2]: https://github.com/codecoradev/cora-cli/compare/v0.4.1...v0.4.2
-[0.4.1]: https://github.com/codecoradev/cora-cli/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/codecoradev/cora-cli/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/codecoradev/cora-cli/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/codecoradev/cora-cli/compare/v0.1.8...v0.2.0
-[0.1.8]: https://github.com/codecoradev/cora-cli/compare/v0.1.7...v0.1.8
-[0.1.7]: https://github.com/codecoradev/cora-cli/compare/v0.1.6...v0.1.7
-[0.1.6]: https://github.com/codecoradev/cora-cli/compare/v0.1.5...v0.1.6
-[0.1.5]: https://github.com/codecoradev/cora-cli/compare/v0.1.4...v0.1.5
-[0.1.4]: https://github.com/codecoradev/cora-cli/compare/v0.1.3...v0.1.4
-[0.1.3]: https://github.com/codecoradev/cora-cli/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/codecoradev/cora-cli/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/codecoradev/cora-cli/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/codecoradev/cora-cli/releases/tag/v0.1.0
+[Unreleased]: https://github.com/codecoradev/cora-code/compare/v0.6.1...develop
+[0.6.1]: https://github.com/codecoradev/cora-code/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/codecoradev/cora-code/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/codecoradev/cora-code/compare/v0.4.6...v0.5.0
+[0.4.6]: https://github.com/codecoradev/cora-code/compare/v0.4.5...v0.4.6
+[0.4.5]: https://github.com/codecoradev/cora-code/compare/v0.4.4...v0.4.5
+[0.4.4]: https://github.com/codecoradev/cora-code/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/codecoradev/cora-code/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/codecoradev/cora-code/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/codecoradev/cora-code/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/codecoradev/cora-code/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/codecoradev/cora-code/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/codecoradev/cora-code/compare/v0.1.8...v0.2.0
+[0.1.8]: https://github.com/codecoradev/cora-code/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/codecoradev/cora-code/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/codecoradev/cora-code/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/codecoradev/cora-code/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/codecoradev/cora-code/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/codecoradev/cora-code/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/codecoradev/cora-code/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/codecoradev/cora-code/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/codecoradev/cora-code/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to cora-cli
+# Contributing to cora-code
 
-First off — thank you for considering contributing to **cora-cli**! 🎉
+First off — thank you for considering contributing to **cora-code**! 🎉
 This guide will help you get started.
 
 ## Table of Contents
@@ -29,8 +29,8 @@ Be respectful, constructive, and inclusive. We follow the [Rust Code of Conduct]
 
 ```bash
 # Clone the repository
-git clone https://github.com/codecoradev/cora-cli.git
-cd cora-cli
+git clone https://github.com/codecoradev/cora-code.git
+cd cora-code
 
 # Build in debug mode
 cargo build
@@ -45,7 +45,7 @@ cargo clippy -- -D warnings
 ### Project Structure
 
 ```
-cora-cli/
+cora-code/
 ├── src/
 │   ├── main.rs              # CLI entry point + clap args
 │   ├── cli.rs               # Argument parsing (clap)
@@ -135,11 +135,11 @@ mod tests {
 
 ## Reporting Bugs
 
-Please open a [GitHub Issue](https://github.com/codecoradev/cora-cli/issues/new) with:
+Please open a [GitHub Issue](https://github.com/codecoradev/cora-code/issues/new) with:
 
 - **Description** — What happened vs. what you expected
 - **Steps to reproduce** — Minimal reproduction steps
-- **Environment** — OS, Rust version, cora-cli version
+- **Environment** — OS, Rust version, cora-code version
 - **Logs** — Output with `RUST_LOG=debug cora review`
 
 ## Feature Requests
@@ -156,4 +156,4 @@ Feel free to open an issue tagged with `question` or reach out on GitHub Discuss
 
 ---
 
-Thank you for helping make cora-cli better! 🦀
+Thank you for helping make cora-code better! 🦀

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "assert_cmd"
@@ -123,9 +123,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -138,13 +138,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -155,15 +155,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -179,15 +179,26 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -199,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -209,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -221,23 +232,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -263,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -274,7 +285,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "cora-cli"
+name = "cora-code"
 version = "0.7.0"
 dependencies = [
  "anyhow",
@@ -323,10 +334,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -343,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -402,7 +422,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -453,9 +473,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -473,12 +493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,53 +503,53 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -572,29 +586,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
+ "r-efi",
+ "rand_core",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -617,9 +618,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -635,15 +636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -669,9 +661,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -679,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -689,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -708,9 +700,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -871,12 +863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -921,15 +907,13 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -958,23 +942,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -985,16 +968,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libgit2-sys"
@@ -1010,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1030,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -1054,9 +1031,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1075,15 +1052,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1152,9 +1129,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -1163,15 +1140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -1205,29 +1173,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1245,14 +1203,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1266,32 +1225,26 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1301,31 +1254,28 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1341,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1353,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1364,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1439,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1458,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "once_cell",
  "ring",
@@ -1472,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1493,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1513,16 +1463,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1530,29 +1474,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1602,7 +1546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1629,15 +1573,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1663,9 +1607,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1689,7 +1644,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1699,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1713,29 +1668,29 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -1752,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1767,9 +1722,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1782,13 +1737,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1941,7 +1896,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2006,12 +1961,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -2108,28 +2057,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2140,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2150,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2160,46 +2091,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -2216,22 +2125,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2249,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2298,7 +2195,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2309,7 +2206,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2342,16 +2239,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2369,31 +2257,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2403,22 +2274,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2427,22 +2286,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2451,22 +2298,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2475,22 +2310,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2508,100 +2331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,9 +2338,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2626,28 +2355,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2667,15 +2396,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -2707,11 +2436,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "cora-cli"
+name = "cora-code"
 version = "0.7.0"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"
-repository = "https://github.com/codecoradev/cora-cli"
+repository = "https://github.com/codecoradev/cora-code"
 readme = "README.md"
 keywords = ["cli", "code-review", "ai", "git", "pre-commit"]
 categories = ["command-line-utilities", "development-tools"]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **AI-Powered Code Review CLI — BYOK**
 
-[![GitHub stars](https://img.shields.io/github/stars/codecoradev/cora-cli?style=social)](https://github.com/codecoradev/cora-cli/stargazers)
-[![CI](https://github.com/codecoradev/cora-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/codecoradev/cora-cli/actions/workflows/ci.yml)
-[![Crates.io](https://img.shields.io/crates/v/cora-cli.svg)](https://crates.io/crates/cora-cli)
+[![GitHub stars](https://img.shields.io/github/stars/codecoradev/cora-code?style=social)](https://github.com/codecoradev/cora-code/stargazers)
+[![CI](https://github.com/codecoradev/cora-code/actions/workflows/ci.yml/badge.svg)](https://github.com/codecoradev/cora-code/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/cora-code.svg)](https://crates.io/crates/cora-code)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/Rust-1.85+-orange.svg)](https://www.rust-lang.org/)
 
@@ -42,17 +42,17 @@ Pick **one** install method — mixing channels can leave stale binaries on your
 |---|---|
 | **`curl … install.sh`** (recommended) | Quick standalone install; fetches the latest GitHub release binary |
 | **`cargo install --git …`** | You already have a Rust toolchain; builds from source |
-| **Pre-built binaries** | Manual download from [Releases](https://github.com/codecoradev/cora-cli/releases) |
+| **Pre-built binaries** | Manual download from [Releases](https://github.com/codecoradev/cora-code/releases) |
 
 ```bash
 # Recommended: Cora only (standalone)
-curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh
 
 # Or install both Cora + Uteke (code review with memory)
-curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install-bundle.sh | sh
 
 # Or build from source with cargo
-cargo install --git https://github.com/codecoradev/cora-cli
+cargo install --git https://github.com/codecoradev/cora-code
 ```
 
 > Pin a version: `CORA_VERSION=v0.6.1 curl -fsSL ... | sh`
@@ -64,7 +64,7 @@ which -a cora            # list every `cora` on your PATH (one entry = healthy)
 cora --version           # should match the latest release
 ```
 
-If `which -a cora` shows more than one path (e.g. `~/.local/bin/cora` and `~/.cargo/bin/cora`), remove the one you don't want or reorder your `PATH`. See [Issue #314](https://github.com/codecoradev/cora-cli/issues/314) for background.
+If `which -a cora` shows more than one path (e.g. `~/.local/bin/cora` and `~/.cargo/bin/cora`), remove the one you don't want or reorder your `PATH`. See [Issue #314](https://github.com/codecoradev/cora-code/issues/314) for background.
 
 <details>
 <summary><b>macOS note — binary killed on launch (<code>Killed: 9</code>)?</b></summary>
@@ -204,7 +204,7 @@ Cora works 100% standalone. Install [Uteke](https://github.com/codecoradev/uteke
 curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh
 
 # Or install both at once
-curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install-bundle.sh | sh
 
 # Enable memory
 export PATH="$HOME/.local/bin:$PATH"
@@ -238,11 +238,11 @@ Provider-specific keys are auto-detected: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=codecoradev%2Fcora-cli%2Ccodecoradev%2Futeke&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=codecoradev%2Fcora-code%2Ccodecoradev%2Futeke&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=codecoradev/cora-cli%2Ccodecoradev/uteke&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=codecoradev/cora-cli%2Ccodecoradev/uteke&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=codecoradev/cora-cli%2Ccodecoradev/uteke&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=codecoradev/cora-code%2Ccodecoradev/uteke&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=codecoradev/cora-code%2Ccodecoradev/uteke&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=codecoradev/cora-code%2Ccodecoradev/uteke&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,7 +5,7 @@ export default createConfig({
   title: 'Cora',
   description: 'AI-Powered Code Review CLI — BYOK, zero config, runs in your terminal',
   accent: 'green',
-  repo: 'cora-cli',
+  repo: 'cora-code',
   head: [
     ['meta', { property: 'og:title', content: 'Cora — AI Code Review CLI' }],
     ['meta', { property: 'og:description', content: 'BYOK, zero config, runs in your terminal' }],

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to cora-cli are documented in this file.
+All notable changes to cora-code are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -238,7 +238,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Profiles bugs** — path resolution with project root, fail-fast on invalid config, dedup merge by `id` (#238)
 - **Code Scanning alert #79** — eliminated redundant `parse_diff()` call in language context injection
-- **Download hardening** — 5x retry with exponential backoff, gzip validation, checksum verification for cora-cli binary download in CI (#221)
+- **Download hardening** — 5x retry with exponential backoff, gzip validation, checksum verification for cora-code binary download in CI (#221)
 - **curl hardening** — `--fail --show-error` + `set -e` guard prevents silent HTML downloads
 - **Checksum enforcement** — hard fail on missing/invalid checksums (was warning-only)
 - **Exact checksum match** — `awk` exact filename lookup replaces `grep` substring match
@@ -370,7 +370,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`BundlingConfig`** — `strategy`, `max_chars_per_group`, `max_files_per_group`, `coalesce_by_directory`, `coalesce_by_language` in `.cora.yaml`
 - **`ContextConfig`** — `enabled`, `max_context_tokens`, `follow_depth`, `max_symbols` in `.cora.yaml` review section
 - **Default SARIF upload to GitHub Code Scanning ON** — opt-out with `upload-sarif: false` (#148)
-- **SARIF tool branding** — `CodeCora` driver name (`codecoradev/cora-cli`) in SARIF output (#148)
+- **SARIF tool branding** — `CodeCora` driver name (`codecoradev/cora-code`) in SARIF output (#148)
 
 ### Changed
 
@@ -391,7 +391,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Engine layer migrated from `anyhow` to `thiserror`** — structured error handling in engine, `anyhow` retained in CLI layer (#86)
 - **All clippy pedantic warnings resolved** — 175 → 0 warnings across entire codebase (#84)
-- **Repo URLs updated** to `codecoradev/cora-cli` org (#137)
+- **Repo URLs updated** to `codecoradev/cora-code` org (#137)
 - **CI actions bumped** — `upload-artifact@v7`, Node 24 strict mode (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`) (#142)
 
 ### Fixed
@@ -572,7 +572,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced ASCII art banner with eye icon in README
-- Updated README branding to cora-cli
+- Updated README branding to cora-code
 
 ### Fixed
 
@@ -596,25 +596,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-cli/compare/v0.6.1...develop
-[0.6.1]: https://github.com/codecoradev/cora-cli/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/codecoradev/cora-cli/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/codecoradev/cora-cli/compare/v0.4.6...v0.5.0
-[0.4.6]: https://github.com/codecoradev/cora-cli/compare/v0.4.5...v0.4.6
-[0.4.5]: https://github.com/codecoradev/cora-cli/compare/v0.4.4...v0.4.5
-[0.4.4]: https://github.com/codecoradev/cora-cli/compare/v0.4.3...v0.4.4
-[0.4.3]: https://github.com/codecoradev/cora-cli/compare/v0.4.2...v0.4.3
-[0.4.2]: https://github.com/codecoradev/cora-cli/compare/v0.4.1...v0.4.2
-[0.4.1]: https://github.com/codecoradev/cora-cli/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/codecoradev/cora-cli/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/codecoradev/cora-cli/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/codecoradev/cora-cli/compare/v0.1.8...v0.2.0
-[0.1.8]: https://github.com/codecoradev/cora-cli/compare/v0.1.7...v0.1.8
-[0.1.7]: https://github.com/codecoradev/cora-cli/compare/v0.1.6...v0.1.7
-[0.1.6]: https://github.com/codecoradev/cora-cli/compare/v0.1.5...v0.1.6
-[0.1.5]: https://github.com/codecoradev/cora-cli/compare/v0.1.4...v0.1.5
-[0.1.4]: https://github.com/codecoradev/cora-cli/compare/v0.1.3...v0.1.4
-[0.1.3]: https://github.com/codecoradev/cora-cli/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/codecoradev/cora-cli/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/codecoradev/cora-cli/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/codecoradev/cora-cli/releases/tag/v0.1.0
+[Unreleased]: https://github.com/codecoradev/cora-code/compare/v0.6.1...develop
+[0.6.1]: https://github.com/codecoradev/cora-code/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/codecoradev/cora-code/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/codecoradev/cora-code/compare/v0.4.6...v0.5.0
+[0.4.6]: https://github.com/codecoradev/cora-code/compare/v0.4.5...v0.4.6
+[0.4.5]: https://github.com/codecoradev/cora-code/compare/v0.4.4...v0.4.5
+[0.4.4]: https://github.com/codecoradev/cora-code/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/codecoradev/cora-code/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/codecoradev/cora-code/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/codecoradev/cora-code/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/codecoradev/cora-code/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/codecoradev/cora-code/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/codecoradev/cora-code/compare/v0.1.8...v0.2.0
+[0.1.8]: https://github.com/codecoradev/cora-code/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/codecoradev/cora-code/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/codecoradev/cora-code/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/codecoradev/cora-code/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/codecoradev/cora-code/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/codecoradev/cora-code/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/codecoradev/cora-code/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/codecoradev/cora-code/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/codecoradev/cora-code/releases/tag/v0.1.0

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -101,7 +101,7 @@ $ cora commit --yolo
 
 ```bash
 # Install both Cora + Uteke (code review with memory)
-$ curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+$ curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install-bundle.sh | sh
 
 # Then review with memory:
 $ cora review --staged --memory --learn

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -179,7 +179,7 @@ ignore:
 
 The action automatically:
 
-1. **Resolves** the latest cora-cli version from GitHub releases
+1. **Resolves** the latest cora-code version from GitHub releases
 2. **Downloads** the binary with retry + checksum verification
 3. **Runs** `cora review` on the PR diff
 4. **Posts** a formatted comment on the PR with findings
@@ -209,7 +209,7 @@ jobs:
         env:
           CORA_API_KEY: ${{ secrets.CORA_API_KEY }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+          curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh
           cora review --base origin/main --format sarif
 ```
 
@@ -233,10 +233,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install cora-cli
+      - name: Install cora-code
         run: |
-          VERSION=$(curl -sf https://api.github.com/repos/codecoradev/cora-cli/releases/latest | jq -r '.tag_name')
-          curl -sfL "https://github.com/codecoradev/cora-cli/releases/download/${VERSION}/cora-cli-x86_64-unknown-linux-gnu.tar.gz" | tar xz
+          VERSION=$(curl -sf https://api.github.com/repos/codecoradev/cora-code/releases/latest | jq -r '.tag_name')
+          curl -sfL "https://github.com/codecoradev/cora-code/releases/download/${VERSION}/cora-code-x86_64-unknown-linux-gnu.tar.gz" | tar xz
           sudo mv cora /usr/local/bin/
 
       - name: Run review
@@ -285,8 +285,8 @@ cora-review:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
   before_script:
-    - VERSION=$(curl -sf https://api.github.com/repos/codecoradev/cora-cli/releases/latest | jq -r '.tag_name')
-    - curl -sfL "https://github.com/codecoradev/cora-cli/releases/download/${VERSION}/cora-cli-x86_64-unknown-linux-gnu.tar.gz" | tar xz
+    - VERSION=$(curl -sf https://api.github.com/repos/codecoradev/cora-code/releases/latest | jq -r '.tag_name')
+    - curl -sfL "https://github.com/codecoradev/cora-code/releases/download/${VERSION}/cora-code-x86_64-unknown-linux-gnu.tar.gz" | tar xz
     - mv cora /usr/local/bin/
   script:
     - git fetch origin $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
@@ -329,8 +329,8 @@ pipelines:
           script:
             - apt-get update && apt-get install -y jq
             - |
-              VERSION=$(curl -sf https://api.github.com/repos/codecoradev/cora-cli/releases/latest | jq -r '.tag_name')
-              curl -sfL "https://github.com/codecoradev/cora-cli/releases/download/${VERSION}/cora-cli-x86_64-unknown-linux-gnu.tar.gz" | tar xz
+              VERSION=$(curl -sf https://api.github.com/repos/codecoradev/cora-code/releases/latest | jq -r '.tag_name')
+              curl -sfL "https://github.com/codecoradev/cora-code/releases/download/${VERSION}/cora-code-x86_64-unknown-linux-gnu.tar.gz" | tar xz
               mv cora /usr/local/bin/
             - git fetch origin $BITBUCKET_PR_DESTINATION_BRANCH
             - cora review --base origin/$BITBUCKET_PR_DESTINATION_BRANCH --format markdown > review.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ title: Getting Started
 Get up and running with cora in three simple steps.
 
 1. **Install cora** — Single binary, no runtime dependencies:
-   `curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh`
+   `curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh`
 
 2. **Authenticate** — Run `cora auth login` to pick your provider and enter your API key.
    Cora stores the API key in `~/.cora/auth.toml` (never committed to git) and provider settings in `~/.cora/config.yaml`.
@@ -156,7 +156,7 @@ Install [Uteke](https://github.com/codecoradev/uteke) to give Cora a memory:
 
 ```bash
 # Install both tools
-curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install-bundle.sh | sh
 ```
 
 Then enable memory in reviews:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ title: Installation
 The fastest way to get cora — single command, no Rust required:
 
 ```bash
-$ curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+$ curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh
 ```
 
 Installs to `~/.local/bin`. Add to PATH if needed:
@@ -21,7 +21,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 Pin a specific version:
 
 ```bash
-$ CORA_VERSION=v0.6.1 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+$ CORA_VERSION=v0.6.1 curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh
 ```
 
 ## Install via Cargo
@@ -29,14 +29,14 @@ $ CORA_VERSION=v0.6.1 curl -fsSL https://raw.githubusercontent.com/codecoradev/c
 If you have Rust 1.85+ installed:
 
 ```bash
-$ cargo install cora-cli
+$ cargo install cora-code
 ```
 
 This compiles cora from source and installs it to Cargo's binary directory (typically `~/.cargo/bin/`).
 
 ## Download Binary
 
-Pre-built binaries are available from the [GitHub Releases](https://github.com/codecoradev/cora-cli/releases) page.
+Pre-built binaries are available from the [GitHub Releases](https://github.com/codecoradev/cora-code/releases) page.
 
 Supported platforms:
 
@@ -47,7 +47,7 @@ Supported platforms:
 
 ```bash
 # Download and extract
-$ curl -sL https://github.com/codecoradev/cora-cli/releases/latest/download/cora-linux-x86_64.tar.gz | tar xz
+$ curl -sL https://github.com/codecoradev/cora-code/releases/latest/download/cora-linux-x86_64.tar.gz | tar xz
 $ mv cora ~/.local/bin/cora
 ```
 
@@ -56,8 +56,8 @@ $ mv cora ~/.local/bin/cora
 If you prefer to build from the latest source:
 
 ```bash
-$ git clone https://github.com/codecoradev/cora-cli.git
-$ cd cora-cli
+$ git clone https://github.com/codecoradev/cora-code.git
+$ cd cora-code
 $ cargo build --release
 # Binary at target/release/cora
 ```
@@ -106,7 +106,7 @@ $ cora --version
 cora 0.6.1
 ```
 
-If `which -a cora` shows more than one path (e.g. `~/.local/bin/cora` and `~/.cargo/bin/cora`), remove the one you don't want or reorder your `PATH`. See [Issue #314](https://github.com/codecoradev/cora-cli/issues/314) for background.
+If `which -a cora` shows more than one path (e.g. `~/.local/bin/cora` and `~/.cargo/bin/cora`), remove the one you don't want or reorder your `PATH`. See [Issue #314](https://github.com/codecoradev/cora-code/issues/314) for background.
 
 ## macOS: `Killed: 9` on launch?
 
@@ -127,5 +127,5 @@ To update cora to the latest version:
 
 | Method | Command |
 |--------|---------|
-| Via Cargo | `cargo install cora-cli --force` |
+| Via Cargo | `cargo install cora-code --force` |
 | Via Binary | Download the latest release from GitHub and replace the existing binary |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,105 +4,105 @@ title: Roadmap
 
 # Roadmap
 
-Demand-gated — we build what people actually need. Track progress on [GitHub Issues](https://github.com/codecoradev/cora-cli/issues).
+Demand-gated — we build what people actually need. Track progress on [GitHub Issues](https://github.com/codecoradev/cora-code/issues).
 
 ## v0.1.5 — Initial Release
 
-- [#90](https://github.com/codecoradev/cora-cli/issues/90) Basic diff review with OpenAI — ✓ Done
-- [#89](https://github.com/codecoradev/cora-cli/issues/89) JSON response repair & unicode handling — ✓ Done
-- [#90](https://github.com/codecoradev/cora-cli/issues/90) CLI interface with review command — ✓ Done
+- [#90](https://github.com/codecoradev/cora-code/issues/90) Basic diff review with OpenAI — ✓ Done
+- [#89](https://github.com/codecoradev/cora-code/issues/89) JSON response repair & unicode handling — ✓ Done
+- [#90](https://github.com/codecoradev/cora-code/issues/90) CLI interface with review command — ✓ Done
 
 ## v0.1.6 — Custom Prompts & Path Injection
 
-- [#95](https://github.com/codecoradev/cora-cli/issues/95) Enhanced default system prompts — ✓ Done
-- [#94](https://github.com/codecoradev/cora-cli/issues/94) Custom system prompt via .cora.yaml config — ✓ Done
-- [#93](https://github.com/codecoradev/cora-cli/issues/93) Inject valid file paths into system prompt — ✓ Done
-- [#92](https://github.com/codecoradev/cora-cli/issues/92) JSON object response format (opt-in) — ✓ Done
+- [#95](https://github.com/codecoradev/cora-code/issues/95) Enhanced default system prompts — ✓ Done
+- [#94](https://github.com/codecoradev/cora-code/issues/94) Custom system prompt via .cora.yaml config — ✓ Done
+- [#93](https://github.com/codecoradev/cora-code/issues/93) Inject valid file paths into system prompt — ✓ Done
+- [#92](https://github.com/codecoradev/cora-code/issues/92) JSON object response format (opt-in) — ✓ Done
 
 ## v0.1.7 — Deterministic & Reliable
 
-- [#98](https://github.com/codecoradev/cora-cli/issues/98) Deterministic reviews — temperature=0 — ✓ Done
-- [#97](https://github.com/codecoradev/cora-cli/issues/97) Non-deterministic output bug fix — ✓ Done
-- [#99](https://github.com/codecoradev/cora-cli/issues/99) HTTP timeout + connection pooling — ✓ Done
-- [#100](https://github.com/codecoradev/cora-cli/issues/100) Diff-hash caching for repeat reviews — ✓ Done
-- [#101](https://github.com/codecoradev/cora-cli/issues/101) Configurable max_tokens — ✓ Done
+- [#98](https://github.com/codecoradev/cora-code/issues/98) Deterministic reviews — temperature=0 — ✓ Done
+- [#97](https://github.com/codecoradev/cora-code/issues/97) Non-deterministic output bug fix — ✓ Done
+- [#99](https://github.com/codecoradev/cora-code/issues/99) HTTP timeout + connection pooling — ✓ Done
+- [#100](https://github.com/codecoradev/cora-code/issues/100) Diff-hash caching for repeat reviews — ✓ Done
+- [#101](https://github.com/codecoradev/cora-code/issues/101) Configurable max_tokens — ✓ Done
 
 ## v0.2.0 — Multi-Provider & SARIF
 
-- [#106](https://github.com/codecoradev/cora-cli/issues/106) BYOK — Anthropic, Groq, Ollama support — ✓ Done
-- [#106](https://github.com/codecoradev/cora-cli/issues/106) SARIF output format — ✓ Done
-- [#106](https://github.com/codecoradev/cora-cli/issues/106) Branch review mode — ✓ Done
-- [#106](https://github.com/codecoradev/cora-cli/issues/106) Output footer watermark — ✓ Done
+- [#106](https://github.com/codecoradev/cora-code/issues/106) BYOK — Anthropic, Groq, Ollama support — ✓ Done
+- [#106](https://github.com/codecoradev/cora-code/issues/106) SARIF output format — ✓ Done
+- [#106](https://github.com/codecoradev/cora-code/issues/106) Branch review mode — ✓ Done
+- [#106](https://github.com/codecoradev/cora-code/issues/106) Output footer watermark — ✓ Done
 
 ## v0.3 — Progress & CI Hardening
 
-- [#140](https://github.com/codecoradev/cora-cli/issues/140) Static analysis context injection (reduce false positives) — ✓ Done
-- [#108](https://github.com/codecoradev/cora-cli/issues/108) --progress flag for machine-readable output — ✓ Done
-- [#102](https://github.com/codecoradev/cora-cli/issues/102) Composite action crash fix (KeyError) — ✓ Done
-- [#88](https://github.com/codecoradev/cora-cli/issues/88) Config validate command — ✓ Done
+- [#140](https://github.com/codecoradev/cora-code/issues/140) Static analysis context injection (reduce false positives) — ✓ Done
+- [#108](https://github.com/codecoradev/cora-code/issues/108) --progress flag for machine-readable output — ✓ Done
+- [#102](https://github.com/codecoradev/cora-code/issues/102) Composite action crash fix (KeyError) — ✓ Done
+- [#88](https://github.com/codecoradev/cora-code/issues/88) Config validate command — ✓ Done
 
 ## v0.4 — Deterministic Engine Pipeline
 
-- [#116](https://github.com/codecoradev/cora-cli/issues/116) Deterministic rule engine — 12 built-in rules — ✓ Done
-- [#115](https://github.com/codecoradev/cora-cli/issues/115) File bundling — parallel per-bundle review — ✓ Done
-- [#114](https://github.com/codecoradev/cora-cli/issues/114) AST-based cross-file dependency extraction — ✓ Done
-- [#159](https://github.com/codecoradev/cora-cli/issues/159) Hunk header regex panic fix + 5MB diff support — ✓ Done
+- [#116](https://github.com/codecoradev/cora-code/issues/116) Deterministic rule engine — 12 built-in rules — ✓ Done
+- [#115](https://github.com/codecoradev/cora-code/issues/115) File bundling — parallel per-bundle review — ✓ Done
+- [#114](https://github.com/codecoradev/cora-code/issues/114) AST-based cross-file dependency extraction — ✓ Done
+- [#159](https://github.com/codecoradev/cora-code/issues/159) Hunk header regex panic fix + 5MB diff support — ✓ Done
 
 ## v0.4.5 — Config Architecture
 
-- [#209](https://github.com/codecoradev/cora-cli/issues/209) Config redesign — auth.toml for secrets, config.yaml for settings — ✓ Done
-- [#203](https://github.com/codecoradev/cora-cli/issues/203) Auth login auto-detect provider env vars — ✓ Done
-- [#189](https://github.com/codecoradev/cora-cli/issues/189) `cora config show` effective resolved config — ✓ Done
-- [#182](https://github.com/codecoradev/cora-cli/issues/182) Env var override visibility — ✓ Done
-- [#185](https://github.com/codecoradev/cora-cli/issues/185) Deterministic rules exclude `rules/` — ✓ Done
-- [#186](https://github.com/codecoradev/cora-cli/issues/186) Truncated JSON repair tests — ✓ Done
+- [#209](https://github.com/codecoradev/cora-code/issues/209) Config redesign — auth.toml for secrets, config.yaml for settings — ✓ Done
+- [#203](https://github.com/codecoradev/cora-code/issues/203) Auth login auto-detect provider env vars — ✓ Done
+- [#189](https://github.com/codecoradev/cora-code/issues/189) `cora config show` effective resolved config — ✓ Done
+- [#182](https://github.com/codecoradev/cora-code/issues/182) Env var override visibility — ✓ Done
+- [#185](https://github.com/codecoradev/cora-code/issues/185) Deterministic rules exclude `rules/` — ✓ Done
+- [#186](https://github.com/codecoradev/cora-code/issues/186) Truncated JSON repair tests — ✓ Done
 
 ## v0.4.6 — Polish & Docs
 
-- [#162](https://github.com/codecoradev/cora-cli/issues/162) README overhaul — market-facing copy — ✓ Done
-- [#204](https://github.com/codecoradev/cora-cli/issues/204) Deterministic secrets pre-scan — ✓ Done
-- [#195](https://github.com/codecoradev/cora-cli/issues/195) Diff parser hardening Phase 1 — ✓ Done
+- [#162](https://github.com/codecoradev/cora-code/issues/162) README overhaul — market-facing copy — ✓ Done
+- [#204](https://github.com/codecoradev/cora-code/issues/204) Deterministic secrets pre-scan — ✓ Done
+- [#195](https://github.com/codecoradev/cora-code/issues/195) Diff parser hardening Phase 1 — ✓ Done
 
 ## v0.5 — Agent & Quality
 
-- [#205](https://github.com/codecoradev/cora-cli/issues/205) Quality gate — CI pass/fail thresholds — ✓ Done
-- [#234](https://github.com/codecoradev/cora-cli/issues/234) Static security scanner — 11 patterns — ✓ Done
-- [#233](https://github.com/codecoradev/cora-cli/issues/233) Language-specific analyzers (Dart, Svelte, TS, Go, Rust, Python) — ✓ Done
-- [#207](https://github.com/codecoradev/cora-cli/issues/207) MCP server — expose rules to AI agents — ✓ Done
-- [#238](https://github.com/codecoradev/cora-cli/issues/238) Quality profiles bug fix — path resolution, fail-fast, dedup — ✓ Done
-- [#188](https://github.com/codecoradev/cora-cli/issues/188) Auto-chunking for large diffs — ✓ Done
-- [#206](https://github.com/codecoradev/cora-cli/issues/206) Tech debt metrics — review history — ✓ Done
-- [#232](https://github.com/codecoradev/cora-cli/issues/232) Uteke memory integration — recall + learn — ✓ Done
-- [#262](https://github.com/codecoradev/cora-cli/issues/262) `cora commit` — review + auto commit message + quality gate — ✓ Done
+- [#205](https://github.com/codecoradev/cora-code/issues/205) Quality gate — CI pass/fail thresholds — ✓ Done
+- [#234](https://github.com/codecoradev/cora-code/issues/234) Static security scanner — 11 patterns — ✓ Done
+- [#233](https://github.com/codecoradev/cora-code/issues/233) Language-specific analyzers (Dart, Svelte, TS, Go, Rust, Python) — ✓ Done
+- [#207](https://github.com/codecoradev/cora-code/issues/207) MCP server — expose rules to AI agents — ✓ Done
+- [#238](https://github.com/codecoradev/cora-code/issues/238) Quality profiles bug fix — path resolution, fail-fast, dedup — ✓ Done
+- [#188](https://github.com/codecoradev/cora-code/issues/188) Auto-chunking for large diffs — ✓ Done
+- [#206](https://github.com/codecoradev/cora-code/issues/206) Tech debt metrics — review history — ✓ Done
+- [#232](https://github.com/codecoradev/cora-code/issues/232) Uteke memory integration — recall + learn — ✓ Done
+- [#262](https://github.com/codecoradev/cora-code/issues/262) `cora commit` — review + auto commit message + quality gate — ✓ Done
 
 ## v0.6 — Code Intelligence
 
 The foundation layer for structural code understanding — persistent symbol index, semantic search, and deep Uteke integration.
 
-- [#264](https://github.com/codecoradev/cora-cli/issues/264) `cora index` — Symbol index & SQLite persistence — ✓ Done
-- [#265](https://github.com/codecoradev/cora-cli/issues/265) `cora explore` — Structural + semantic code search — ✓ Done
-- [#235](https://github.com/codecoradev/cora-cli/issues/235) Cora + Uteke cross-product integration bundle — ✓ Done
-- [#284](https://github.com/codecoradev/cora-cli/issues/284) MCP Phase 1 — Code Intelligence tools (5 tools) — ✓ Done
-- [#285](https://github.com/codecoradev/cora-cli/issues/285) MCP Phase 2 — Review + Debt tools (2 tools) — ✓ Done
-- [#286](https://github.com/codecoradev/cora-cli/issues/286) MCP Phase 3 — Context enrichment tools (2 tools) — ✓ Done
+- [#264](https://github.com/codecoradev/cora-code/issues/264) `cora index` — Symbol index & SQLite persistence — ✓ Done
+- [#265](https://github.com/codecoradev/cora-code/issues/265) `cora explore` — Structural + semantic code search — ✓ Done
+- [#235](https://github.com/codecoradev/cora-code/issues/235) Cora + Uteke cross-product integration bundle — ✓ Done
+- [#284](https://github.com/codecoradev/cora-code/issues/284) MCP Phase 1 — Code Intelligence tools (5 tools) — ✓ Done
+- [#285](https://github.com/codecoradev/cora-code/issues/285) MCP Phase 2 — Review + Debt tools (2 tools) — ✓ Done
+- [#286](https://github.com/codecoradev/cora-code/issues/286) MCP Phase 3 — Context enrichment tools (2 tools) — ✓ Done
 
 ### Also in v0.6
 
-- [#47](https://github.com/codecoradev/cora-cli/issues/47) GitHub Marketplace action — ✓ Done
-- [#196](https://github.com/codecoradev/cora-cli/issues/196) VitePress docs site — ✓ Done
-- [#161](https://github.com/codecoradev/cora-cli/issues/161) `cora gain` — local stats + viral sharing — ✓ Done
-- [#160](https://github.com/codecoradev/cora-cli/issues/160) Landing page redesign — ✓ Done
+- [#47](https://github.com/codecoradev/cora-code/issues/47) GitHub Marketplace action — ✓ Done
+- [#196](https://github.com/codecoradev/cora-code/issues/196) VitePress docs site — ✓ Done
+- [#161](https://github.com/codecoradev/cora-code/issues/161) `cora gain` — local stats + viral sharing — ✓ Done
+- [#160](https://github.com/codecoradev/cora-code/issues/160) Landing page redesign — ✓ Done
 
 ## v0.7 — Multi-Language & Code Graph
 
 Query layer built on top of the v0.6 index — call graph traversal, test impact analysis, broader language support, and real-time sync.
 
-- [#266](https://github.com/codecoradev/cora-cli/issues/266) `cora callers` / `cora impact` — Call graph query commands — ✓ Done
-- [#267](https://github.com/codecoradev/cora-cli/issues/267) `cora affected` — Find tests affected by changes — ✓ Done
-- [#268](https://github.com/codecoradev/cora-cli/issues/268) Language expansion — 6 → 15+ language support — ✓ Done
-- [#269](https://github.com/codecoradev/cora-cli/issues/269) Auto-sync file watcher daemon — ✓ Done
+- [#266](https://github.com/codecoradev/cora-code/issues/266) `cora callers` / `cora impact` — Call graph query commands — ✓ Done
+- [#267](https://github.com/codecoradev/cora-code/issues/267) `cora affected` — Find tests affected by changes — ✓ Done
+- [#268](https://github.com/codecoradev/cora-code/issues/268) Language expansion — 6 → 15+ language support — ✓ Done
+- [#269](https://github.com/codecoradev/cora-code/issues/269) Auto-sync file watcher daemon — ✓ Done
 
 ## Future — What's Next
 
-- [#117](https://github.com/codecoradev/cora-cli/issues/117) Lightweight agent follow-up — 1 capped tool-call — → Planned
-- [#132](https://github.com/codecoradev/cora-cli/issues/132) GitHub App backend MVP in Rust (Axum) — → Planned
+- [#117](https://github.com/codecoradev/cora-code/issues/117) Lightweight agent follow-up — 1 capped tool-call — → Planned
+- [#132](https://github.com/codecoradev/cora-code/issues/132) GitHub App backend MVP in Rust (Axum) — → Planned

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -190,7 +190,7 @@ Cora works standalone. Install [Uteke](https://github.com/codecoradev/uteke) to 
 ### Install Both
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install-bundle.sh | sh
 ```
 
 ### Usage

--- a/install-bundle.sh
+++ b/install-bundle.sh
@@ -4,7 +4,7 @@
 # Installs both Cora (AI code review) and Uteke (AI memory) in one command.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install-bundle.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install-bundle.sh | sh
 #
 # With version pinning:
 #   CORA_VERSION=v0.5.1 UTEKE_VERSION=v0.1.0 curl -fsSL ... | sh
@@ -47,7 +47,7 @@ install_cora() {
         fi
     fi
 
-    curl -fsSL "https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh" | sh
+    curl -fsSL "https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh" | sh
     ok "Cora installed: $(cora --version 2>/dev/null | head -1)"
 }
 
@@ -113,7 +113,7 @@ verify() {
         echo "    curl -fsSL https://raw.githubusercontent.com/codecoradev/uteke/main/install.sh | sh"
     elif [ "$UTEKE_OK" = "yes" ]; then
         printf "${YELLOW}Uteke installed.${NC} Install Cora separately for code review:\n"
-        echo "    curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh"
+        echo "    curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh"
     else
         error "Neither tool was installed successfully."
     fi

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env sh
-# cora installer — https://github.com/codecoradev/cora-cli
-# Usage: curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-cli/main/install.sh | sh
+# cora installer — https://github.com/codecoradev/cora-code
+# Usage: curl -fsSL https://raw.githubusercontent.com/codecoradev/cora-code/main/install.sh | sh
 
 set -e
 
-REPO="codecoradev/cora-cli"
+REPO="codecoradev/cora-code"
 BINARY_NAME="cora"
 INSTALL_DIR="${CORA_INSTALL_DIR:-$HOME/.local/bin}"
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -6,7 +6,7 @@ use crate::hook;
 
 /// Example .cora.yaml template content.
 const CONFIG_TEMPLATE: &str = r#"# Cora Code Review Configuration
-# See: https://github.com/codecoradev/cora-cli
+# See: https://github.com/codecoradev/cora-code
 
 # Provider settings
 provider:

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -235,7 +235,7 @@ pub async fn execute_review(
                         "tool": {
                             "driver": {
                                 "name": "cora",
-                                "informationUri": "https://github.com/codecoradev/cora-cli",
+                                "informationUri": "https://github.com/codecoradev/cora-code",
                                 "version": env!("CARGO_PKG_VERSION")
                             }
                         },

--- a/src/formatters/sarif.rs
+++ b/src/formatters/sarif.rs
@@ -123,7 +123,7 @@ fn build_sarif(issues: &[ReviewIssue]) -> Value {
             "tool": {
                 "driver": {
                     "name": "CodeCora",
-                    "fullName": "codecoradev/cora-cli",
+                    "fullName": "codecoradev/cora-code",
                     "version": env!("CARGO_PKG_VERSION"),
                     "informationUri": env!("CARGO_PKG_REPOSITORY"),
                     "rules": rules
@@ -234,7 +234,7 @@ mod tests {
             parsed["runs"][0]["tool"]["driver"]["fullName"]
                 .as_str()
                 .unwrap(),
-            "codecoradev/cora-cli"
+            "codecoradev/cora-code"
         );
     }
 


### PR DESCRIPTION
## Summary

Rename cora-cli → cora-code across the entire codebase.

| Component | Before | After |
|---|---|---|
| GitHub repo | `codecoradev/cora-cli` | `codecoradev/cora-code` |
| Crate name | `cora-cli` | `cora-code` |
| Binary name | `cora` | `cora` (unchanged) |

### Changes
- **22 files** updated: Cargo.toml, Cargo.lock, README, CONTRIBUTING, docs (8 files), CI workflows, install scripts, SARIF branding, VitePress config
- Historical changelog `compare/` URLs preserved (GitHub auto-redirects `cora-cli` → `cora-code`)
- Release artifact names unchanged (`cora-x86_64-unknown-linux-gnu` etc — matches binary name)

### Verification
- `cargo check` — clean ✅
- No remaining `cora-cli` references in source files (excluding historical changelog URLs)