### PR TITLE
ci: decouple GitHub Release from crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [build-release, publish-crates]
+    needs: [build-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

GitHub Release job depends on `publish-crates`. When crates.io returns 503 (transient), the release is blocked — even though all builds succeeded.

## Fix

Remove `publish-crates` from `release` job needs. GitHub Release now only depends on `build-release` succeeding.

crates.io publish can be retried independently.