### PR TITLE
chore: bump v0.8.1 for crates.io publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-24
+
+### Fixed
+
+- crates.io publish (503 transient on v0.8.0)
+
+
 ## [0.8.0] - 2026-07-24
 
 ### Highlights

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-code"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"


### PR DESCRIPTION
v0.8.0 crates.io publish failed (503 transient). Bumping to v0.8.1 to retry.