### PR TITLE
docs: update all documentation for v0.8.0-v0.8.1 and Unreleased

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - ⚡ **Native Rust** — fast binary, no runtime dependencies, cross-platform
 - 🪝 **Pre-commit hooks** — catch issues before they reach CI
 - 📋 **SARIF output** — upload to GitHub Code Scanning
-- 🛡️ **Deterministic scanners** — 11 security patterns + 12 secret detection patterns that run without LLM
+- 🛡️ **Deterministic scanners** — 12 built-in rules + 13 security patterns + 15 secret detection patterns that run without LLM
 - 🧠 **Language-specific analysis** — tailored review guidance for Dart/Flutter, Svelte, TypeScript, Go, Rust, Python
 - 🚧 **Quality gate** — configurable pass/fail thresholds for CI enforcement
 - 📐 **Quality profiles** — strict, balanced, or lax presets for different project needs
@@ -31,8 +31,9 @@
 - 🔍 **Code Intelligence** — index symbols across 15 languages, call graph, trace, impact analysis
 - 🧠 **Brain Mode** — hybrid semantic search (FTS5 + vector KNN + graph) with RRF fusion
 - 🗄️ **Multi-project database** — one global index, search across all your repos at once
-- 🌳 **tree-sitter** (opt-in) — AST-based call graph extraction for Rust, Go, Python, TypeScript
-- 🔌 **MCP server** — 15 tools for AI agents (review, search, brain, debt, trace, ...)
+- 🌳 **Tree-sitter** (opt-in) — AST-based symbol extraction for 12 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript
+- 📄 **Svelte support** — review Svelte components with specialized analysis
+- 🔌 **MCP server** — 15 tools for AI coding agents (review, search, brain, debt, trace, ...)
 - 💾 **Diff-hash caching** — skip repeat reviews automatically
 - 🔧 **Configurable** — per-project `.cora.yaml`, global `~/.cora/config.yaml`, or env vars
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Code Intelligence
+
+- **Tree-sitter AST extraction for 8 additional languages** (#376)
+  - Java, C, C++, C#, Ruby, PHP, Scala, JavaScript — full AST-based symbol extraction.
+  - Tree-sitter now covers **12 languages** total (previously: Rust, Go, Python, TypeScript/TSX).
+  - AST path takes priority when tree-sitter is compiled; regex extractors remain as fallback.
+
+- **Svelte symbol indexing** (#375)
+  - Svelte components are now indexed (scripts, props, stores, imports).
+  - Uses TypeScript tree-sitter parser for script blocks.
+
+- **Dart symbol indexing** (#374)
+  - Classes, mixins, extensions, methods, top-level functions, and enums.
+
+## [0.8.1] - 2026-07-24
+
+### Changed
+
+- **Version bump for crates.io publish** — no functional changes.
+
+## [0.8.0] - 2026-07-16
+
+### Highlights
+
+- **Brain Mode** — hybrid semantic search combining FTS5, vector KNN (usearch), and call-graph BFS with Reciprocal Rank Fusion (RRF). All local, no model download.
+- **Tree-sitter AST extraction** — opt-in `--features tree-sitter` builds get accurate symbol extraction and call graph edges for Rust, Go, Python, TypeScript/TSX.
+- **Architecture commands** — `cora trace` for call chain tracing, `cora arch` for module/edge overview.
+- **VitePress documentation** — migrated from SvelteKit to VitePress at `codecora.dev`.
+
+### Added
+
+- **Brain Mode** — hybrid semantic search (#362)
+  - Three search signals fused via RRF (k=60): FTS5 keyword, usearch HNSW vector KNN, call-graph BFS.
+  - `cora brain <query>` command with `--json` and `--limit` flags.
+  - `cora.brain_search` MCP tool.
+
+- **Static token embedding engine** (#354)
+  - Zero-dependency bag-of-tokens hashing producing 256d vectors.
+  - No model download, no GPU, no external service.
+  - Integrated into `cora index` for vector index population.
+
+- **Tree-sitter AST extraction** (#356)
+  - Opt-in via `--features tree-sitter` at build time.
+  - Initial 4 languages: Rust, Go, Python, TypeScript/TSX.
+  - Schema v3 `edges` table for AST-derived call graph relationships.
+
+- **`cora trace` and `cora arch`** (#358)
+  - `cora trace <symbol>` — depth-limited BFS call chain tracing (outgoing/incoming).
+  - `cora arch` — architecture overview showing modules, edge types, and top connectors.
+
+- **Global index database** (#355)
+  - Migrated from `.cora/index.db` (per-project) to `~/.codecora/cora-code/graph.db` (global).
+  - Multi-project search: index multiple repos, search across all of them.
+
+- **Code Intelligence documentation** (#365)
+  - New `docs/code-intelligence.md` covering indexing, search, call graph, and MCP tools.
+
+### Changed
+
+- **Renamed `cora-cli` → `cora-code`** (#338) — crate name, repo description, all references.
+- **Security scanner false positives suppressed** (#369) — `sec-hardcoded-url` and `sec-hardcoded-secret/crypto` patterns refined to reduce noise (#357, #364).
+- **Uteke memory integration hidden from user-facing docs** (#367) — still functional, just not advertised externally.
+- **VitePress docs** — adopted `@codecora-theme`, retired SvelteKit `website/` directory.
+- **CI** — decoupled GitHub Release from crates.io publish (#371).
+
 ## [0.7.0] - 2026-07-16
 
 ### Highlights
@@ -596,9 +661,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-code/compare/v0.6.1...develop
+[Unreleased]: https://github.com/codecoradev/cora-code/compare/v0.8.1...develop
+[0.8.1]: https://github.com/codecoradev/cora-code/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/codecoradev/cora-code/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/codecoradev/cora-code/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/codecoradev/cora-code/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/codecoradev/cora-code/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/codecoradev/cora-code/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/codecoradev/cora-code/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/codecoradev/cora-code/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/codecoradev/cora-code/compare/v0.4.4...v0.4.5

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -66,6 +66,14 @@ Complete command reference for the cora CLI.
 | `cora brain` `--limit N` | Max results (default: 20) |
 | `cora index` | Index project symbols into SQLite + usearch |
 | `cora index --rebuild` | Rebuild index from scratch |
+| `cora index --watch` | Auto-sync file watcher (2s poll interval) |
+| `cora index --stats` | Show index statistics (symbol count, languages, DB size) |
+| `cora index --prune` | Remove stale entries for deleted files |
+| `cora callers` `<symbol>` | Find all callers of a symbol (reverse call graph) |
+| `cora callers` `--limit N` | Max callers to return (default: 50) |
+| `cora impact` `<symbol>` | Analyze blast radius of changing a symbol |
+| `cora impact` `--depth N` | Traversal depth (default: 3) |
+| `cora affected` `<files...>` | Find test files affected by source changes |
 | `cora completion` `<shell>` | Generate shell completions (bash/zsh/fish) |
 | `cora mcp` | Start MCP server for AI coding agents (Claude Code, Cursor, Windsurf) |
 
@@ -110,4 +118,11 @@ $ cora brain "TokenEmbedding" --json --limit 5
 # Trace call chains and view architecture
 $ cora trace main
 $ cora arch
+```
+
+```bash
+# Find callers and analyze impact
+$ cora callers handle_request
+$ cora impact process_order --depth 5
+$ cora affected src/order.rs src/payment.rs
 ```

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -32,10 +32,11 @@ cora arch
 Scans your project, extracts symbol definitions (functions, structs, enums, traits, etc.), and builds:
 
 | Component | Technology | Storage |
------------|-----------|---------|
-| Symbol table | Regex extractors (15 languages) | SQLite FTS5 |
+|-----------|-----------|---------|
+| Symbol table (regex) | Regex extractors (15 languages) | SQLite FTS5 |
+| Symbol table (AST) | Tree-sitter grammars (12 languages, opt-in) | SQLite FTS5 |
 | Vector embeddings | Static token hashing (256d) | usearch HNSW index |
-| Call graph | Regex scope tracking (+ tree-sitter opt-in) | SQLite `edges` table |
+| Call graph | Regex scope tracking + tree-sitter AST edges | SQLite `edges` table |
 
 ```bash
 cora index              # Index current project (incremental)
@@ -47,7 +48,34 @@ cora index --prune     # Remove symbols from deleted files
 
 ### Supported Languages
 
-15 language extractors: Rust, Python, TypeScript/TSX, Go, Java, C, Ruby, PHP, Swift, Scala, Lua, Zig, Dart, Kotlin, JavaScript.
+Cora extracts symbols using two strategies — **regex** (always available) and **tree-sitter AST** (opt-in via `--features tree-sitter` at build time):
+
+| | Regex Extraction | AST (Tree-sitter) |
+|--|-----------------|-------------------|
+| **Rust** | ✅ | ✅ |
+| **Go** | ✅ | ✅ |
+| **Python** | ✅ | ✅ |
+| **TypeScript/TSX** | ✅ | ✅ |
+| **Svelte** | ✅ | ✅ (via TypeScript) |
+| **Java** | ✅ | ✅ |
+| **C** | ✅ | ✅ |
+| **C++** | ✅ | ✅ |
+| **C#** | ✅ | ✅ |
+| **Ruby** | ✅ | ✅ |
+| **PHP** | ✅ | ✅ |
+| **Scala** | ✅ | ✅ |
+| **JavaScript** | ✅ | ✅ |
+| **Swift** | ✅ | — |
+| **Kotlin** | ✅ | — |
+| **Dart** | ✅ | — |
+| **Lua** | ✅ | — |
+| **Zig** | ✅ | — |
+
+**Regex-only** languages work out of the box. For **AST-accurate** extraction (full call graph, precise imports/exports), build with tree-sitter:
+
+```bash
+cargo install --git https://github.com/codecoradev/cora-code --features tree-sitter
+```
 
 ### Multi-Project Index
 
@@ -167,10 +195,12 @@ cora trace "process" --depth 4         # Limit traversal depth
 cora trace --json                     # JSON output
 ```
 
-Requires schema v3 edges table. Enable tree-sitter for AST-based edge extraction:
+Requires schema v3 edges table. When built with `--features tree-sitter`, Cora uses AST-based edge extraction for more accurate call graphs. Regex-only builds still generate edges via scope tracking.
 
 ```bash
-cora index --rebuild  # With tree-sitter feature compiled
+# Build with tree-sitter for best call graph accuracy
+cargo install --git https://github.com/codecoradev/cora-code --features tree-sitter
+cora index --rebuild  # Re-index to get AST edges
 ```
 
 ### `cora arch` — Architecture Overview
@@ -202,13 +232,15 @@ cora affected --json                     # JSON output
 All code intelligence features are available as MCP tools for AI coding agents:
 
 | Tool | Description |
-------|-------------|
+|------|-------------|
 | `cora.search_symbols` | FTS5 symbol search |
 | `cora.find_callers` | Find callers of a symbol |
 | `cora.find_impact` | Impact analysis |
 | `cora.find_affected_tests` | Test impact analysis |
 | `cora.index_status` | Index statistics |
 | `cora.brain_search` | Hybrid semantic search |
+| `cora.get_project_info` | Project metadata & config |
+| `cora.get_memory` | Review memory recall |
 
 ## Data Directory
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,16 +102,22 @@ Query layer built on top of the v0.6 index — call graph traversal, test impact
 - [#268](https://github.com/codecoradev/cora-code/issues/268) Language expansion — 6 → 15+ language support — ✓ Done
 - [#269](https://github.com/codecoradev/cora-code/issues/269) Auto-sync file watcher daemon — ✓ Done
 
-## Future — What's Next
+## v0.8 — Brain Mode & Tree-sitter Expansion
 
-### Brain Mode Roadmap
+Hybrid semantic search and deep language support via AST parsing.
 
 - [Phase 1](https://github.com/codecoradev/cora-code/pull/354) — Static token embedding engine (256d) — ✓ Done
-- [Phase 2](https://github.com/codecoradev/cora-code/pull/356) — tree-sitter AST + schema v3 edges table — ✓ Done
+- [Phase 2](https://github.com/codecoradev/cora-code/pull/356) — Tree-sitter AST + schema v3 edges table — ✓ Done
 - [Phase 2C](https://github.com/codecoradev/cora-code/pull/358) — `cora trace` + `cora arch` — ✓ Done
 - [Phase 3](https://github.com/codecoradev/cora-code/pull/362) — Brain Mode hybrid search (usearch + RRF) — ✓ Done
-- [Phase 4](https://github.com/codecoradev/cora-code/issues/360) — Uteke integration upgrade → Planned
-- [Phase 5](https://github.com/codecoradev/cora-code/issues/361) — Voyage-4-Nano ONNX (opt-in, 1024d) → Deferred
+- [#374](https://github.com/codecoradev/cora-code/pull/374) Dart symbol indexing — ✓ Done
+- [#375](https://github.com/codecoradev/cora-code/pull/375) Svelte symbol indexing — ✓ Done
+- [#376](https://github.com/codecoradev/cora-code/pull/376) Tree-sitter expansion: 4 → 12 languages (Java, C, C++, C#, Ruby, PHP, Scala, JS) — ✓ Done
+- [#338](https://github.com/codecoradev/cora-code/pull/338) Renamed `cora-cli` → `cora-code` — ✓ Done
+- [#369](https://github.com/codecoradev/cora-code/pull/369) Security scanner false positive suppression — ✓ Done
+- [#355](https://github.com/codecoradev/cora-code/pull/355) Global index database (`~/.codecora/cora-code/graph.db`) — ✓ Done
+
+## Future — What's Next
 
 ### Other
 


### PR DESCRIPTION
## Changes

**5 files updated (139 insertions, 17 deletions):**

### README.md
- Fix deterministic scanner counts (12 built-in + 13 security + 15 secret patterns)

### docs/changelog.md
- Add **v0.8.0** entry (Brain Mode, tree-sitter AST, cora trace/arch, VitePress, rename)
- Add **v0.8.1** entry (crates.io bump)
- Add **Unreleased** section (PR #374-376: Dart, Svelte, 8 tree-sitter languages)
- Fix version comparison links

### docs/roadmap.md
- Add **v0.8** section with 11 completed items
- Remove completed Brain Mode phases from Future section

### docs/cli-reference.md
- Add `index --watch/--stats/--prune`, `callers`, `impact`, `affected` commands
- Add usage examples

### docs/code-intelligence.md
- Rewrite Supported Languages table (18 languages, regex vs AST tiers)
- Add MCP tools `get_project_info` and `get_memory`
- Improve tree-sitter build instructions