### PR TITLE
chore: bump v0.8.2 for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-code"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to cora-code are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.2] - 2026-07-24
 
 ### Added — Code Intelligence
 
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Dart symbol indexing** (#374)
   - Classes, mixins, extensions, methods, top-level functions, and enums.
+
+### Changed — Documentation
+
+- Updated README, changelog (v0.8.0 + v0.8.1 entries), roadmap (v0.8 section), CLI reference, and code intelligence docs.
+
+## [Unreleased]
 
 ## [0.8.1] - 2026-07-24
 
@@ -661,7 +667,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-platform** — Linux (x86_64, ARM64), macOS (Apple Silicon), Windows (x86_64)
 - **MIT License** — fully open source
 
-[Unreleased]: https://github.com/codecoradev/cora-code/compare/v0.8.1...develop
+[Unreleased]: https://github.com/codecoradev/cora-code/compare/v0.8.2...develop
+[0.8.2]: https://github.com/codecoradev/cora-code/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/codecoradev/cora-code/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/codecoradev/cora-code/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/codecoradev/cora-code/compare/v0.6.2...v0.7.0


### PR DESCRIPTION
## v0.8.2 — Patch Release

### Changes since v0.8.1
- Dart symbol indexing (#374)
- Svelte symbol indexing (#375)
- Tree-sitter expansion: 4 → 12 languages (#376)
- Documentation overhaul (README, changelog, roadmap, CLI reference, code-intelligence) (#377)