### PR TITLE
fix(index): detect project root for scoped queries (#380, #382)

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -45,6 +45,46 @@ pub fn ensure_project(conn: &Connection, root: &Path) -> anyhow::Result<i64> {
     schema::get_or_create_project(conn, &root_str)
 }
 
+/// Detect the project root by walking up from `start` looking for marker files.
+///
+/// Search order: `.cora.yaml` → `Cargo.toml` → `package.json` → `.git` (dir or file).
+/// Returns the directory containing the first marker found, or `None` if none is found.
+pub fn resolve_project_root(start: &Path) -> Option<std::path::PathBuf> {
+    let dir = if start.is_file() {
+        start.parent()?
+    } else {
+        start
+    };
+
+    const MARKERS: &[&str] = &[".cora.yaml", "Cargo.toml", "package.json", ".git"];
+
+    let mut current = dir.to_path_buf();
+    loop {
+        for marker in MARKERS {
+            let candidate = current.join(marker);
+            if candidate.exists() {
+                debug!(root = %current.display(), marker, "detected project root");
+                return Some(current);
+            }
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => return None,
+        }
+    }
+}
+
+/// Resolve `project_id` from the current directory, using project root detection.
+///
+/// Walks up from CWD to find a project root (`.cora.yaml`, `Cargo.toml`, etc.).
+/// Falls back to CWD if no marker is found.
+pub fn resolve_project_id(conn: &Connection) -> anyhow::Result<(i64, std::path::PathBuf)> {
+    let cwd = std::env::current_dir()?;
+    let root = resolve_project_root(&cwd).unwrap_or_else(|| cwd.clone());
+    let project_id = ensure_project(conn, &root)?;
+    Ok((project_id, root))
+}
+
 /// Index a single file: extract symbols and store in the database.
 ///
 /// `project_id` is written to every row so data is scoped per-project
@@ -510,5 +550,65 @@ pub struct AuthService {
         let stats = index_stats(&conn, project_id).unwrap();
         // Should have 1 symbol (replaced, not 2)
         assert_eq!(stats.total_symbols, 1);
+    }
+
+    #[test]
+    fn test_resolve_project_root_finds_cargo_toml() {
+        // CWD of the test process is the crate root — Cargo.toml exists here.
+        let cwd = std::env::current_dir().unwrap();
+        let root = resolve_project_root(&cwd);
+        assert!(root.is_some(), "should find project root from CWD");
+        let root = root.unwrap();
+        assert!(
+            root.join("Cargo.toml").exists(),
+            "resolved root should contain Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn test_resolve_project_root_finds_cora_yaml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        std::fs::write(root.join(".cora.yaml"), "version: 1\n").unwrap();
+        let subdir = root.join("src").join("deep").join("nested");
+        std::fs::create_dir_all(&subdir).unwrap();
+        let resolved = resolve_project_root(&subdir);
+        assert_eq!(resolved, Some(root));
+    }
+
+    #[test]
+    fn test_resolve_project_root_returns_none_in_tmp() {
+        // /tmp itself should have no markers (or at least a very deep /tmp subdirectory
+        // that we create and then check).
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Create a deep directory with no markers.
+        let deep = tmp.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&deep).unwrap();
+        // Walk up from `deep` — tempfile dirs are under /tmp which typically has no
+        // Cargo.toml/.cora.yaml/.git. If it does find one we just skip this assertion.
+        let resolved = resolve_project_root(&deep);
+        // /tmp should not have project markers, but if the test machine has a git
+        // repo at /tmp, we can't guarantee this. Only assert if /tmp is clean.
+        if !std::path::Path::new("/tmp/.git").exists()
+            && !std::path::Path::new("/tmp/Cargo.toml").exists()
+            && !std::path::Path::new("/tmp/.cora.yaml").exists()
+        {
+            assert!(
+                resolved.is_none(),
+                "should not find project root in empty tmp dir, got {resolved:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolve_project_id_uses_project_root() {
+        let conn = mem_conn();
+        // resolve_project_id uses CWD — which is the cora-code crate root.
+        let (pid, root) = resolve_project_id(&conn).unwrap();
+        assert!(pid > 0);
+        assert!(
+            root.join("Cargo.toml").exists(),
+            "resolved root should contain Cargo.toml"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -588,6 +588,7 @@ async fn main() -> Result<()> {
             verbose,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let conn = index::open_global_index()?;
             let project_id = index::ensure_project(&conn, &project_root)?;
 
@@ -688,6 +689,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let db_path = crate::data_dir::graph_db_path();
 
             if !db_path.exists() {
@@ -760,6 +762,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let db_path = crate::data_dir::graph_db_path();
             if !db_path.exists() {
                 eprintln!("{}", "No index found. Run `cora index` first.".yellow());
@@ -840,6 +843,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let db_path = crate::data_dir::graph_db_path();
             if !db_path.exists() {
                 eprintln!("{}", "No index found. Run 'cora index' first.".yellow());
@@ -888,6 +892,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let db_path = crate::data_dir::graph_db_path();
             if !db_path.exists() {
                 eprintln!("{}", "No index found. Run `cora index` first.".yellow());
@@ -946,6 +951,7 @@ async fn main() -> Result<()> {
 
         Command::Arch { json } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let db_path = crate::data_dir::graph_db_path();
             if !db_path.exists() {
                 eprintln!("{}", "No index found. Run `cora index` first.".yellow());
@@ -995,6 +1001,7 @@ async fn main() -> Result<()> {
             }
 
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let db_path = crate::data_dir::graph_db_path();
             if !db_path.exists() {
                 eprintln!("{}", "No index found. Run `cora index` first.".yellow());
@@ -1041,6 +1048,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let db_path = crate::data_dir::graph_db_path();
             if !db_path.exists() {
                 eprintln!("{}", "No index found. Run `cora index` first.".yellow());

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -389,16 +389,16 @@ fn handle_list_profiles() -> ToolResult {
 
 // ─── Code Intelligence Handlers ───
 
-/// Open the global index database and resolve project_id for the current directory.
+/// Open the global index database and resolve project_id for the project root.
+/// Uses project root detection (walks up from CWD looking for markers).
 /// Returns helpful error if not found.
 fn open_index_db() -> anyhow::Result<(rusqlite::Connection, i64)> {
-    let cwd = std::env::current_dir()?;
     let db_path = crate::data_dir::graph_db_path();
     if !db_path.exists() {
         anyhow::bail!("No symbol index found. Run 'cora index' first to build the index.");
     }
     let conn = crate::index::open_global_index()?;
-    let project_id = crate::index::ensure_project(&conn, &cwd)?;
+    let (project_id, _root) = crate::index::resolve_project_id(&conn)?;
     Ok((conn, project_id))
 }
 


### PR DESCRIPTION
## Problem

When `cora` commands or the MCP server are invoked from a subdirectory of the project root (e.g., CWD = `~/repos` when the project is `~/repos/my-project`), `ensure_project()` registers the **wrong directory** as the project. This causes:

- `cora search_symbols` (MCP `cora.search_symbols`) → returns 0 results or cross-project noise (#380)
- `cora brain_search` (MCP `cora.brain_search`) → returns irrelevant symbols from wrong project (#382)
- All 8 CLI commands (`index`, `search`, `callers`, `impact`, `trace`, `brain`, `arch`, `find_callers`) affected

## Root Cause

`open_index_db()` in `src/mcp/tools.rs` and all CLI command handlers in `src/main.rs` used `std::env::current_dir()` directly as the project root. When CWD is not the project root (common with MCP servers, editor integrations, and terminal sessions in subdirectories), the project_id resolved to the wrong project or a newly-created empty project entry.

## Fix

Added `resolve_project_root()` in `src/index/mod.rs` — walks up from CWD looking for project markers in priority order:

1. `.cora.yaml` (cora project config)
2. `Cargo.toml` (Rust workspace/crate)
3. `package.json` (Node.js project)
4. `.git` (git repository root)

If no marker is found, falls back to CWD (existing behavior).

### Changed files

| File | Change |
|------|--------|
| `src/index/mod.rs` | +`resolve_project_root()`, +`resolve_project_id()`, +4 unit tests |
| `src/mcp/tools.rs` | `open_index_db()` uses `resolve_project_id()` instead of raw CWD |
| `src/main.rs` | All 8 command handlers use `resolve_project_root()` before `ensure_project()` |

## Test plan

- [x] `cargo test resolve_project` — 4 new tests pass
  - `test_resolve_project_root_finds_cargo_toml` — finds Cargo.toml from CWD
  - `test_resolve_project_root_finds_cora_yaml` — walks up from deep subdir to find .cora.yaml
  - `test_resolve_project_root_returns_none_in_tmp` — returns None when no markers
  - `test_resolve_project_id_uses_project_root` — resolve_project_id returns correct (pid, root)
- [x] `cargo test` — 746 tests, 0 failures
- [x] `cargo build` — clean
- [x] `cargo fmt` — clean

Fixes #380
Fixes #382
