### PR TITLE
fix: exclude vendored embeddings from crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ readme = "README.md"
 keywords = ["cli", "code-review", "ai", "git", "pre-commit"]
 categories = ["command-line-utilities", "development-tools"]
 rust-version = "1.85"
+exclude = [
+    "vendored/",
+    "docs/",
+    ".github/",
+    "tests/",
+    "target/",
+]
 
 [dependencies]
 # CLI
@@ -80,6 +87,7 @@ tree-sitter-javascript = { version = "0.25", optional = true }
 
 [features]
 default = []
+pretrained-embed = []
 tree-sitter = [
     "dep:tree-sitter",
     "dep:tree-sitter-rust",

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -15,5 +15,9 @@
 
 // Embedding engine — consumed by brain module (Phase 3).
 
-pub mod token_vocab;
 pub mod tokens;
+
+// Pre-trained nomic-embed-code module — only compiled when vendored data
+// exists. Excluded from crates.io package (too large for 10 MB upload limit).
+#[cfg(feature = "pretrained-embed")]
+pub mod token_vocab;


### PR DESCRIPTION
## Problem
crates.io publish fails with 413 Payload Too Large because `vendored/nomic/code_vectors.bin` (31MB) is included in the package. crates.io max upload is 10MB.

## Fix
- Add `exclude` field to `[package]` in Cargo.toml for vendored/, docs/, .github/, tests/
- Gate `token_vocab` module behind `pretrained-embed` feature flag (non-default)
- Package size: 31.9MB → 300KB (well under 10MB limit)

## Trade-off
`token_vocab` (pre-trained nomic-embed-code) is now behind `--features pretrained-embed`. This is acceptable because:
- The module is currently dead code (no callers outside itself)
- Pre-trained embeddings were reserved for Phase 5
- Local builds can still use `--features pretrained-embed` when vendored data exists