### PR TITLE
chore: sync v0.9.0 release prep to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.4] - 2026-07-28
+## [0.9.0] - 2026-07-28
+
+### Highlights
+
+- **Single source of truth.** Review findings, scan findings, and tech debt snapshots now persist to `cora.db` — one global database, no more scattered file snapshots.
+- **Massive indexing speedup.** Rayon-parallel extraction + embedding, batch SQLite writes, PRAGMA tuning, and mtime:size fingerprinting deliver **52× faster incremental indexing** (414ms → 6ms) and **1.3× faster cold rebuild** (1,260ms → 936ms).
+- **`cora findings` CLI.** Track, filter, dismiss, and reopen findings across all your reviews.
 
 ### Added
 
-- **Persist review & scan findings to `cora.db`** (#397, #398). `cora review` and `cora scan` now save findings (severity, file, line, title, fingerprint) to the global database. Uses best-effort logging — never blocks the review pipeline on DB errors.
+- **Persist review & scan findings to `cora.db`** (#397, #398). `cora review` and `cora scan` now save findings (severity, file, line, title, fingerprint) to the global database. Best-effort logging — never blocks the review pipeline on DB errors.
 - **Auto-resolve stale findings** (#399). When a new review/scan completes, findings from prior reviews that no longer appear are automatically marked `resolved` with an `auto_resolved` event. Findings that reappear stay `open`.
 - **`cora findings` CLI command** (#400). New subcommand with four actions:
   - `cora findings list` — show open findings (use `--all`, `--severity`, `--file`, `--json` for filtering)
   - `cora findings stats` — summary counts with resolution rate (`--json` supported)
   - `cora findings dismiss <id>` — mark as won't-fix with optional `--reason`
   - `cora findings reopen <id>` — reopen a dismissed/resolved finding
-- **Read-only DB access for `cora findings list/stats`** via `open_db_for_read()` — no migrations, no WAL, safe for concurrent reads.
+- **Migration v5 schema** (#396). New tables: `reviews`, `findings`, `finding_events`. Auto-migrates on first run.
+- **`cora index --rebuild` flag.** Drop and re-index from scratch — useful for schema upgrades or corrupted indices.
+- **Rayon parallel processing** (#409, #422). File extraction and embedding computation now run in parallel across CPU cores via Rayon.
+- **Cache vector index in memory** (#407). `VECTOR_CACHE` (LazyLock) keeps the usearch HNSW index hot in memory — eliminates file I/O on every brain search.
+- **Batch symbol lookup in RRF fusion** (#410). Brain search now batches DB lookups instead of per-result queries.
+- **SQLite PRAGMA tuning** (#406). `journal_mode=WAL`, `synchronous=NORMAL`, `mmap_size=256MB`, `cache_size=-64MB` for faster writes.
+- **Batch INSERT via multi-row VALUES** (#405). Symbol insertion now uses multi-row `INSERT ... VALUES (?,?,?),(?,?,?),...` instead of per-row inserts.
+- **Batch transaction for `index_project`** (#404). All symbol/edge insertions wrapped in a single `BEGIN IMMEDIATE ... COMMIT`.
+- **Disable FTS5 triggers during bulk indexing** (#411). Triggers re-enabled after commit — avoids redundant index updates mid-batch.
+- **Mtime:size fingerprinting.** Replaces SHA256 content hashing for change detection. Trade-off: `--rebuild` available for full re-validation.
 
 ### Changed
 
+- **`cora debt` reads from `cora.db` as primary source** (#403). File snapshots are now fallback only. DB is the single source of truth for tech debt reports.
+- **`graph.db` renamed to `cora.db`** (#395). Auto-migrates existing `graph.db` on first run.
 - `db_writer` module now exposes `open_db_for_read()`, `open_db_for_write()`, and `compute_fingerprint_pub()` for use by the findings CLI.
+
+### Performance
+
+Benchmarked on the cora-code repository (1,864 symbols, 115 Rust files, x86_64):
+
+| Operation | Before (v0.8.3) | After (v0.9.0) | Speedup |
+|-----------|-----------------|-----------------|---------|
+| Cold index (full rebuild) | ~1,260ms | ~936ms | 1.3× |
+| Incremental (no changes) | ~414ms | ~6ms | **52×** |
+| Brain search (hybrid) | ~250ms | ~5ms | **40×** |
+
+### Fixed
+
+- **`cora brain` vector search filtered by project_id** (#382). Over-fetches from global usearch index, filters at DB layer — prevents cross-project noise.
+- **Project root detection** (#380). Walks up from CWD to find `.cora.yaml` / `Cargo.toml` / `.git` instead of always using CWD.
 
 ## [0.8.3] - 2026-07-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "cora-code"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [
     "docs/",
     ".github/",
     "tests/",
+    "bench/",
     "target/",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-code"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora scan` | Scan files for issues |
 | `cora commit` | Review + generate commit message + commit |
 | `cora debt` | Show tech debt report from review history |
+| `cora findings` | Track, dismiss, and reopen review/scan findings |
 
 ### Code Intelligence
 
@@ -207,6 +208,19 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora hook install` | Install pre-commit hook |
 
 See **[CLI Reference →](https://codecora.dev/cli-reference.html)** for all flags and examples.
+
+## Performance
+
+Benchmarked on the cora-code repository (1,864 symbols, 115 Rust files, x86_64, single-thread baseline → Rayon parallel).
+
+| Operation | Time | Notes |
+|-----------|------|-------|
+| Cold index (full rebuild) | **~936ms** | Walk + parse + embed + HNSW insert (Rayon parallel) |
+| Incremental (no changes) | **~6ms** | mtime:size fingerprint — skips unchanged files |
+| Brain search (hybrid) | **~5ms** | FTS5 + vector KNN + graph BFS → RRF fusion |
+| Binary size | **10.4 MB** | Single static binary, zero runtime dependencies |
+
+> Measurements are indicative, not contractual. Your numbers will vary with codebase size, CPU cores, and disk I/O.
 
 ## Environment Variables
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-28
+
+### Highlights
+
+- **Single source of truth.** Findings, debt, and reviews persist to `cora.db` — one global database.
+- **52× faster incremental indexing** (414ms → 6ms) and **40× faster brain search** (250ms → 5ms).
+- **`cora findings` CLI.** Track, dismiss, and reopen findings across all reviews.
+
+### Added
+
+- **Persist review & scan findings to `cora.db`** (#397, #398). Best-effort logging — never blocks the pipeline.
+- **Auto-resolve stale findings** (#399). Prior findings auto-marked `resolved` when they no longer appear.
+- **`cora findings` CLI** (#400). `list`, `stats`, `dismiss`, `reopen` actions with `--json` support.
+- **Migration v5 schema** (#396). `reviews`, `findings`, `finding_events` tables. Auto-migrates.
+- **`cora index --rebuild`**. Drop and re-index from scratch.
+- **Rayon parallel processing** (#409, #422). File extraction and embedding in parallel.
+- **Vector index cached in memory** (#407). Eliminates file I/O on every brain search.
+- **Batch symbol lookup in RRF fusion** (#410). DB lookups batched instead of per-result.
+- **SQLite PRAGMA tuning** (#406). WAL, `synchronous=NORMAL`, mmap/cache sizing.
+- **Batch INSERT + transaction** (#404, #405, #411). Multi-row values, single transaction, FTS5 triggers disabled during bulk indexing.
+- **Mtime:size fingerprinting.** Replaces SHA256 for change detection.
+
+### Changed
+
+- **`cora debt` reads from `cora.db` as primary source** (#403). File snapshots are now fallback only.
+- **`graph.db` renamed to `cora.db`** (#395). Auto-migrates on first run.
+
+### Performance
+
+| Operation | Before (v0.8.3) | After (v0.9.0) | Speedup |
+|-----------|-----------------|-----------------|---------|
+| Cold index (full rebuild) | ~1,260ms | ~936ms | 1.3× |
+| Incremental (no changes) | ~414ms | ~6ms | **52×** |
+| Brain search (hybrid) | ~250ms | ~5ms | **40×** |
+
+### Fixed
+
+- **`cora brain` vector search filtered by project_id** (#382). Prevents cross-project noise.
+- **Project root detection** (#380). Walks up from CWD to find project config.
+
 ## [0.8.1] - 2026-07-24
 
 ### Changed

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -59,6 +59,10 @@ Complete command reference for the cora CLI.
 | `cora debt --estimate` | Show estimated fix time |
 | `cora debt --since v0.4.5` | Filter by git tag or date |
 | `cora debt --branch main` | Filter by branch |
+| `cora findings list` | Show open findings (use `--all`, `--severity`, `--file`, `--json`) |
+| `cora findings stats` | Summary counts with resolution rate (`--json`) |
+| `cora findings dismiss <id>` | Mark finding as won't-fix (optional `--reason`) |
+| `cora findings reopen <id>` | Reopen a dismissed/resolved finding |
 | `cora arch` | Architecture overview — modules, edge types, top connectors |
 | `cora trace` `<symbol>` | Trace call chains from a symbol (depth-limited BFS) |
 | `cora brain` `<query>` | Hybrid search: FTS5 + vector + graph → RRF fusion |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,6 +117,25 @@ Hybrid semantic search and deep language support via AST parsing.
 - [#369](https://github.com/codecoradev/cora-code/pull/369) Security scanner false positive suppression — ✓ Done
 - [#355](https://github.com/codecoradev/cora-code/pull/355) Global index database (`~/.codecora/cora-code/graph.db`) — ✓ Done
 
+## v0.9 — Findings SoT & Performance
+
+Unified data layer and massive performance improvements.
+
+- [#396](https://github.com/codecoradev/cora-code/issues/396) DB migration v5 — `reviews`, `findings`, `finding_events` tables — ✓ Done
+- [#397](https://github.com/codecoradev/cora-code/issues/397) Persist review findings to `cora.db` — ✓ Done
+- [#398](https://github.com/codecoradev/cora-code/issues/398) Persist scan findings to `cora.db` — ✓ Done
+- [#399](https://github.com/codecoradev/cora-code/issues/399) Auto-resolve stale findings — ✓ Done
+- [#400](https://github.com/codecoradev/cora-code/issues/400) `cora findings` CLI command — ✓ Done
+- [#395](https://github.com/codecoradev/cora-code/issues/395) Rename `graph.db` → `cora.db` — ✓ Done
+- [#404](https://github.com/codecoradev/cora-code/issues/404) Batch transaction for index_project — ✓ Done
+- [#405](https://github.com/codecoradev/cora-code/issues/405) Batch INSERT multi-row VALUES — ✓ Done
+- [#406](https://github.com/codecoradev/cora-code/issues/406) SQLite PRAGMA tuning — ✓ Done
+- [#407](https://github.com/codecoradev/cora-code/issues/407) Cache vector index in memory — ✓ Done
+- [#408](https://github.com/codecoradev/cora-code/issues/408) Incremental index via mtime:size — ✓ Done
+- [#409](https://github.com/codecoradev/cora-code/issues/409) Rayon parallel file processing — ✓ Done
+- [#410](https://github.com/codecoradev/cora-code/issues/410) Batch symbol lookup in RRF — ✓ Done
+- [#422](https://github.com/codecoradev/cora-code/pull/422) Rayon parallel embedding — ✓ Done
+
 ## Future — What's Next
 
 ### Other


### PR DESCRIPTION
Cherry-pick release prep changes (version bump, docs, benchmark) that were previously merged only to main into develop.

### Changes
- Bump version 0.8.4 → 0.9.0
- CHANGELOG v0.9.0 entry
- Add `cora findings` to README + docs/cli-reference
- Performance benchmark table
- Sync docs/changelog.md
- Roadmap v0.9 section