### PR TITLE
docs(governance): add CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, PR template, issue templates, PR checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,110 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in the fields below — it makes triage much faster.
+
+        For **security issues**, do NOT open an issue. See [SECURITY.md](https://github.com/codecoradev/cora-code/blob/develop/SECURITY.md).
+
+  - type: input
+    id: version
+    attributes:
+      label: Cora version
+      description: Run `cora --version` or check the release you're on.
+      placeholder: "0.13.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      placeholder: "Ubuntu 24.04 / macOS 15.2 / Windows 11 23H2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: command
+    attributes:
+      label: Which command?
+      options:
+        - cora review
+        - cora scan
+        - cora index
+        - cora dead-code
+        - cora rules
+        - cora config
+        - cora install (pre-commit hook)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of exact steps. Include the exact command.
+      placeholder: |
+        1. Run `cora review --base origin/develop`
+        2. Observe error output
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: |
+        Paste relevant terminal output. Use `RUST_LOG=debug cora review` for more detail.
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Config (if relevant)
+      description: Paste your `.cora.yaml` or `cora config show` output, redacting API keys.
+      placeholder: |
+        # rules_engine:
+        #   index_skip_files:
+        #     - "vite.config.ts"
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true
+        - label: I am running the latest version
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! A short conversation here saves everyone time before any code is written.
+
+        Cora is intentionally focused — not every idea will make it in. A "no" is not a judgment of the idea.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        The **why**, not the **what**. What were you trying to do when you wished this existed?
+        placeholder: "When I'm reviewing PRs in a monorepo, I want per-directory rules so the review adapts to each package's conventions."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you imagine using this? CLI flag, config option, MCP tool — anything that helps picture it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds have you tried? What other tools handle this well?
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you willing to contribute the implementation?
+      options:
+        - "Yes, with guidance"
+        - "Yes, I can do it"
+        - "No, just suggesting"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+PR title must follow Conventional Commits — it becomes the squash commit message.
+Format: type(scope): short description
+Examples: fix(review): handle empty diff / feat(index): add camelCase split / docs(readme): update install instructions
+-->
+
+## What
+<!-- One or two sentences describing the change. -->
+
+## Why
+<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
+
+## How
+<!-- Brief notes on the approach, only if non-obvious. -->
+
+## Testing
+
+- [ ] `cargo test --features tree-sitter` passes
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --all-targets --features tree-sitter -- -D warnings` passes
+- [ ] `cargo build --release --features tree-sitter` passes
+- [ ] Manual smoke-test of the affected feature <!-- describe what you tested -->
+
+<!-- If you touched a load-bearing subsystem (indexing, FTS5, code graph, schema migration, embedding, config merge), add specific test details here. -->
+
+## Related Issues
+<!-- Link to related issues, e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Branch name follows convention (`fix/`, `feat/`, `docs/`, `chore/`, `refactor/`, `test/`, `perf/`, `security/`)
+- [ ] Branch is from `develop`
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No secrets or credentials committed
+- [ ] One logical change per PR (no mixed concerns)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,92 @@
+name: PR Checks
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [develop, main]
+
+jobs:
+  branch-naming:
+    name: Branch Naming
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "Checking branch: $HEAD_REF"
+
+          # Allowed prefixes (kebab-case)
+          ALLOWED="^(feat|fix|docs|chore|perf|security|refactor|test|build|ci)/"
+
+          if echo "$HEAD_REF" | grep -qE "$ALLOWED"; then
+            echo "✅ Branch name follows convention"
+          else
+            echo "::error::Branch name must start with one of: feat/, fix/, docs/, chore/, perf/, security/, refactor/, test/, build/, ci/"
+            echo "Example: fix/fts5-camelcase, feat/mcp-find-callers"
+            echo "Current: $HEAD_REF"
+            exit 1
+          fi
+
+  pr-template:
+    name: PR Description
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "Checking PR description..."
+
+          # Check for required sections
+          MISSING=""
+
+          if ! echo "$PR_BODY" | grep -qi "## What"; then
+            MISSING="$MISSING\n  - ## What (description of the change)"
+          fi
+
+          if ! echo "$PR_BODY" | grep -qi "## Why"; then
+            MISSING="$MISSING\n  - ## Why (the problem you're solving)"
+          fi
+
+          if ! echo "$PR_BODY" | grep -qi "## Testing"; then
+            MISSING="$MISSING\n  - ## Testing (how you verified this works)"
+          fi
+
+          if [ -n "$MISSING" ]; then
+            echo "::error::PR description is missing required sections:$MISSING"
+            echo ""
+            echo "Please fill out the PR template. Copy it from:"
+            echo "https://github.com/codecoradev/cora-code/blob/develop/.github/PULL_REQUEST_TEMPLATE.md"
+            exit 1
+          fi
+
+          echo "✅ PR description has required sections"
+
+  commit-conventional:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Checking PR title: $PR_TITLE"
+
+          # Conventional Commits: type(scope): description
+          # Types: feat, fix, docs, chore, perf, refactor, test, build, ci, security
+          PATTERN="^(feat|fix|docs|chore|perf|refactor|test|build|ci|security)(\(.+\))?!?: .+"
+
+          if echo "$PR_TITLE" | grep -qE "$PATTERN"; then
+            echo "✅ PR title follows Conventional Commits"
+          else
+            echo "::error::PR title must follow Conventional Commits format"
+            echo "Expected: type(scope): short description"
+            echo "Example: fix(review): handle empty diff"
+            echo "Types: feat, fix, docs, chore, perf, refactor, test, build, ci, security"
+            echo "Current: $PR_TITLE"
+            exit 1
+          fi

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+Cora is a small open-source project and we want it to stay a place people enjoy contributing to.
+
+## The rules, briefly
+
+- **Be respectful.** Disagreement is fine; rudeness, condescension, and personal attacks are not.
+- **Assume good faith.** Most miscommunication isn't malicious — clarify before escalating.
+- **Stay on topic.** Issues, PRs, and discussions are about Cora. Take off-topic conversations elsewhere.
+- **No harassment.** Targeted insults, slurs, sustained disruption, sexualized comments, doxxing, or threats are not tolerated — anywhere, against anyone.
+- **No spam.** That includes promotional links, irrelevant cross-posting, and AI-generated noise that doesn't engage with the actual conversation.
+
+This applies to everything inside the project: issues, PRs, discussions, commits, and any community space we create later (Discord, etc.).
+
+## Enforcement
+
+If you see a violation — or experience one — email **hello@codecora.dev** with subject `[Cora conduct]`. Include links and context.
+
+Maintainers may, at their discretion:
+
+1. Edit or delete the offending content
+2. Issue a private warning
+3. Lock the thread
+4. Block the account from the project
+
+We default to the lightest action that resolves the situation. Severe or repeat violations skip steps.
+
+## Scope
+
+Maintainers act in this project's spaces. We don't police behavior outside the project, but we do consider patterns of behavior elsewhere when deciding on enforcement here.
+
+---
+
+*This document is intentionally short. It is inspired by the [Contributor Covenant](https://www.contributor-covenant.org/) but kept compact for a small project.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,159 +1,283 @@
-# Contributing to cora-code
+# Contributing to Cora
 
-First off — thank you for considering contributing to **cora-code**! 🎉
-This guide will help you get started.
+Cora is a solo-maintained project with a strong product direction. Contributions are welcome, but **alignment matters more than volume**.
 
-## Table of Contents
+This document helps you decide *whether* and *how* to contribute in a way that's likely to get merged, so neither of us wastes time.
 
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Workflow](#development-workflow)
-- [Pull Request Process](#pull-request-process)
-- [Coding Standards](#coding-standards)
-- [Reporting Bugs](#reporting-bugs)
-- [Feature Requests](#feature-requests)
+## How this project is run
+
+- Cora has one active maintainer ([@ajianaz](https://github.com/ajianaz)).
+- Review bandwidth is limited.
+- Not every contribution can be accepted, even if it's technically correct. Alignment with project direction matters as much as code quality.
+- For scope and direction, check open issues and [ROADMAP.md](ROADMAP.md) if available. Read them before opening anything non-trivial.
+
+This is normal for a solo project. A "no" on a PR is not personal.
+
+## Quick start
+
+```bash
+# Prerequisites: Rust 1.85+ (via https://rustup.rs), Git
+git clone https://github.com/codecoradev/cora-code.git
+cd cora-code
+cargo build
+cargo test
+```
+
+> **Note:** Cora uses the `tree-sitter` feature for intelligent code analysis. Some tests require this feature: `cargo test --features tree-sitter`.
+
+## Where to discuss
+
+Use GitHub Issues for tracking concrete bugs and features. For design discussions or "should I work on X?", open an issue first.
+
+## What makes a good contribution
+
+These get merged fast:
+
+- **Bug fixes** with clear reproduction steps and tests.
+- **Docs / typos / small UX fixes** — open a PR directly.
+- **Pre-discussed features** — alignment in an issue first.
+- **Small, focused changes** — easy to review, low risk.
+
+If your change is small and obvious (typo, narrow bugfix, small docs change), open a PR directly. No issue required.
+
+## Keep changes focused
+
+**Only change what's needed to accomplish your stated goal.**
+
+If you're fixing a bug in `index/symbols.rs`, don't also:
+
+- Reformat other files
+- Clean up unrelated code
+- Fix lint issues in files you didn't need to touch
+- Combine multiple unrelated fixes in one PR
+
+**One PR = one logical change.** Multi-concern PRs will be asked to split.
+
+## Discuss first (required for larger changes)
+
+For anything beyond a small fix, **discussion is required before opening a PR**. This includes:
+
+- New features
+- API changes or new MCP tools
+- Refactors or "cleanup" work
+- Performance rewrites
+- Architectural changes
+- Anything touching many files or subsystems
+- Changes to the index engine, code graph, embedding, or schema migration subsystems
+
+Pull requests with significant unsolicited changes will be closed without detailed review. This isn't meant to discourage contribution. It ensures alignment before significant work goes in.
+
+A 10-minute conversation saves a 500-line PR that doesn't fit the roadmap.
+
+## Quality bar
+
+Every PR is reviewed against:
+
+- `cargo fmt --all -- --check` — must be clean
+- `cargo clippy --all-targets --features tree-sitter -- -D warnings` — must be clean
+- `cargo test --features tree-sitter` — must pass
+- `cargo build --release --features tree-sitter` — must compile
+- No new heavy dependencies without justification
+- No perf regressions in hot paths: indexing, FTS5 search, symbol extraction, embedding
+
+If you're not sure how to measure perf or what counts as a hot path, ask in an issue. Better to confirm than get bounced.
+
+## Changes to core subsystems require a test
+
+The most common way a PR breaks Cora is a **local fix with global blast radius**: the diff solves one case, reads fine, passes clippy, and silently breaks the same subsystem in other cases. Review alone does not catch these. A test does.
+
+If your change touches behavior in any of these load-bearing paths, the PR must add or extend a test:
+
+- **Index engine (src/index/)**: SQLite writes, schema migrations, FTS5, symbol extraction
+- **Code graph (src/index/graph.rs)**: call graph construction, dead-code detection
+- **Embedding (src/embed/)**: ONNX inference, tokenizer, dimension handling
+- **Schema migration (src/index/schema.rs)**: version upgrades, data migration
+- **Config (src/config/)**: YAML resolution chain, merge logic
+- **MCP tools (src/mcp/)**: tool registration, parameter handling
+- **Engine (src/engine/)**: review pipeline, scan pipeline, LLM abstraction
+- **Pre-commit hook (src/hook/)**: git integration, diff generation
+
+The bar for the test is real coverage of the contract, not a placeholder. Test the edge case that would actually break. If you can't see how to test it, ask in an issue before opening the PR.
+
+## What Cora is not
+
+To set expectations:
+
+- Not trying to be a full IDE plugin or language server (though it could integrate with them).
+- Not building: web UI, multi-user collaboration, enterprise SSO.
+- Not a curated "first open-source contribution" project. Beginners are welcome but expect normal review.
+- Mechanical refactors, broad style changes, drive-by rewrites are not helpful.
+- AI-assisted contributions are welcome, but the PR must reflect understanding of the existing patterns. Low-effort AI-generated code that wasn't read by the author will be closed.
+
+## Branches
+
+Branch off `develop`. Use these prefixes (kebab-case):
+
+| Prefix        | Use for                                  |
+| ------------- | ---------------------------------------- |
+| `feat/`       | New feature                              |
+| `fix/`        | Bug fix                                  |
+| `chore/`      | Refactor, tooling, config, dependencies  |
+| `docs/`       | Docs-only changes                        |
+| `perf/`       | Performance work                         |
+| `security/`   | Security fix or hardening                |
+| `refactor/`   | Code restructuring                       |
+| `test/`       | Test additions/changes                   |
+
+Examples: `feat/mcp-find-callers`, `fix/fts5-camelcase`, `security/path-guard`.
+
+Don't open PRs from your fork's `develop` or `main` branch. Work on a feature branch.
+
+## Commits & PRs
+
+The **PR title becomes the squash commit** for most PRs. Title must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(index): add camelCase split for FTS5 queries
+fix(review): handle empty diff without panic
+chore(deps): bump tree-sitter to 0.24.0
+security(rules): tighten secret pattern regex
+docs(readme): update installation instructions
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `perf`, `refactor`, `test`, `build`, `ci`, `security`.
+
+Common scopes: `index`, `graph`, `embed`, `schema`, `config`, `mcp`, `engine`, `review`, `scan`, `hook`, `rules`, `profiles`.
+
+**Fill out the PR template.** Include: what changed, why, how you tested. The more specific, the faster the review.
+
+**Open a draft PR early** if you want feedback mid-flight. Mark "Ready for review" when done.
+
+### What gets merged faster
+
+- Clear problem statement
+- Small, focused diff
+- Follows existing patterns (read 2–3 nearby files before writing yours)
+- All checks pass (fmt, clippy, tests)
+- Manual testing notes describing the steps you took
+
+### What gets bounced back
+
+- Mixed-concern PRs
+- Large architectural PRs without prior discussion
+- New dependencies without justification
+- Breaking changes without migration notes
+- Incidental reformatting unrelated to the change
+- AI-generated code that obviously wasn't read by the author
+
+## Code Style
+
+- Follow existing patterns. Read 2–3 adjacent files before adding new ones.
+- Rust: `cargo fmt` + `cargo clippy` clean. Clippy warnings are errors in CI.
+- Comments: only for *why*, not *what*. Code should explain itself.
+- No emojis in code or commit messages.
+
+## Architecture
+
+Cora is a single crate with modular source layout:
+
+| Module | Purpose |
+| ------ | ------- |
+| `src/main.rs` | CLI entry point + clap args |
+| `src/commands/` | CLI subcommands (review, scan, index, config, etc.) |
+| `src/engine/` | Review + scan pipeline, LLM abstraction, types |
+| `src/index/` | Symbol indexing, FTS5, code graph, schema migration |
+| `src/embed/` | ONNX embedding (nomic-embed-code, vendored) |
+| `src/config/` | YAML config resolution chain + merge logic |
+| `src/mcp/` | MCP server — tool registration + handlers |
+| `src/formatters/` | Output formatting (pretty, json, compact, sarif) |
+| `src/profiles/` | Quality profiles + rules engine |
+| `src/hook/` | Pre-commit hook integration |
+| `src/git/` | Git operations (diff, blame, log) |
+
+```
+src/
+├── main.rs                  # CLI entry point
+├── commands/                # CLI subcommands
+│   ├── review.rs           # cora review
+│   ├── scan.rs             # cora scan
+│   ├── index_cmd.rs        # cora index
+│   └── ...
+├── engine/                  # Core engine
+│   ├── review.rs           # LLM review pipeline
+│   ├── scanner.rs          # File scanning
+│   ├── types.rs            # Issue, Severity, etc.
+│   ├── llm.rs              # LLM API abstraction
+│   ├── context/            # Context building for review
+│   └── rules/              # Rule definitions
+├── index/                   # Code intelligence
+│   ├── schema.rs           # SQLite schema + migrations
+│   ├── symbols.rs          # Symbol extraction + FTS5
+│   ├── graph.rs            # Call graph + dead-code detection
+│   └── mod.rs              # Index orchestration
+├── embed/                   # Embedding engine
+│   └── onnx.rs             # ONNX runtime wrapper
+├── config/                  # Configuration
+│   ├── schema.rs           # YAML structs + merge
+│   ├── loader.rs           # Resolution chain
+│   └── providers.rs        # LLM provider presets
+├── mcp/                     # MCP server
+│   └── tools.rs            # Tool handlers
+├── formatters/              # Output formatting
+├── profiles/                # Quality profiles
+├── hook/                    # Pre-commit hooks
+└── git/                     # Git operations
+```
+
+### Key Design Decisions
+
+- **SQLite-first indexing** — Symbol data, FTS5, and code graph all live in a single `cora.db` per project
+- **Tree-sitter for parsing** — Language-agnostic AST extraction for symbol indexing
+- **Vendored nomic-embed-code** — No external embedding API dependency; ONNX runtime bundled
+- **Schema versioning** — Integer counter; auto-migration on upgrade (current: v6)
+- **Config merge chain** — Global → project `.cora.yaml` → CLI flags, with profile overlay
+- **Pre-commit hook** — Cora runs as a git pre-commit hook reviewing staged diff via LLM
+
+## Release flow
+
+Cora follows a simplified GitFlow:
+
+```
+develop (default) → PR → main → tag vX.Y.Z → release workflow
+```
+
+- Tags must be on `main`, not `develop`.
+- The release workflow verifies tag ancestry to `origin/main` before building.
+- Version bumps happen on `develop` before syncing to `main`.
+
+## Reporting Issues
+
+- **Bugs:** Use the [Bug Report](https://github.com/codecoradev/cora-code/issues/new?template=bug_report.yml) template
+- **Features:** Use the [Feature Request](https://github.com/codecoradev/cora-code/issues/new?template=feature_request.yml) template
+
+## FAQ
+
+**Q: Should I ask before fixing a typo or obvious bug?**
+A: No, open a PR directly.
+
+**Q: I have an idea for a new feature.**
+A: Open a GitHub issue. Don't open a PR without prior discussion.
+
+**Q: My PR was closed without detailed feedback.**
+A: Usually means it didn't align with project direction, or scope was too large to review responsibly. This is normal for a solo project.
+
+**Q: Can I work on an open issue?**
+A: Comment first to confirm it's still relevant. For anything non-trivial, discuss approach before implementing.
+
+**Q: My PR conflicts after develop moved. Should I rebase?**
+A: If the change is still relevant and reasonably small, yes. Large stale PRs may be closed with an offer to reopen after rebase.
+
+**Q: I don't have an LLM API key. Can I still contribute?**
+A: Yes. Code changes to non-LLM paths (index, graph, config, formatting) don't require an API key. Tests run without one. Only `cora review` needs a provider configured.
+
+## Security issues
+
+Don't file them as public issues. See [SECURITY.md](SECURITY.md).
 
 ## Code of Conduct
 
-Be respectful, constructive, and inclusive. We follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
-## Getting Started
+## License
 
-### Prerequisites
-
-- **Rust** 1.85+ (stable toolchain recommended)
-- **Git** for version control
-- An **LLM API key** (OpenAI, Anthropic, etc.) for testing review features
-
-### Setup
-
-```bash
-# Clone the repository
-git clone https://github.com/codecoradev/cora-code.git
-cd cora-code
-
-# Build in debug mode
-cargo build
-
-# Run tests
-cargo test
-
-# Run linter
-cargo clippy -- -D warnings
-```
-
-### Project Structure
-
-```
-cora-code/
-├── src/
-│   ├── main.rs              # CLI entry point + clap args
-│   ├── cli.rs               # Argument parsing (clap)
-│   ├── commands/            # CLI subcommands
-│   │   ├── review.rs       # cora review
-│   │   ├── scan.rs         # cora scan
-│   │   ├── config_cmd.rs   # cora config show/set
-│   │   ├── auth.rs         # cora auth login/logout
-│   │   └── init.rs         # cora init
-│   ├── config/
-│   │   ├── loader.rs       # Config resolution chain (global → project → env → CLI)
-│   │   ├── schema.rs       # YAML config structs + merge logic
-│   │   └── providers.rs    # Provider presets (OpenAI, Anthropic, etc.)
-│   ├── engine/
-│   │   ├── review.rs       # LLM review + SARIF generation
-│   │   ├── scanner.rs      # File scanning and diff generation
-│   │   ├── types.rs        # Issue, Severity, ScanResponse types
-│   │   └── llm.rs          # LLM API abstraction
-│   └── formatter/
-│       └── mod.rs          # Output formatting (pretty, compact, json, sarif)
-├── .github/
-│   └── workflows/          # CI, release, deploy workflows
-├── tests/                   # Integration tests
-├── Cargo.toml
-└── README.md
-```
-
-## Development Workflow
-
-1. **Fork** the repository on GitHub
-2. **Create a branch** for your change:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-3. **Make your changes** and commit with meaningful messages:
-   ```bash
-   git commit -m "feat: add support for SARIF output format"
-   ```
-4. **Push** to your fork and open a **Pull Request**
-
-### Commit Messages
-
-We follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-| Prefix     | Purpose                          |
-|------------|----------------------------------|
-| `feat:`    | New feature                      |
-| `fix:`     | Bug fix                          |
-| `docs:`    | Documentation changes            |
-| `test:`    | Adding or updating tests         |
-| `refactor:`| Code changes without feature/fix |
-| `chore:`   | Maintenance tasks                |
-| `ci:`      | CI/CD changes                    |
-
-## Pull Request Process
-
-1. Update documentation if your change affects user-facing behavior
-2. Add tests for any new functionality
-3. Ensure `cargo test` passes
-4. Ensure `cargo clippy -- -D warnings` is clean
-5. Ensure `cargo fmt` has been applied
-6. Keep PRs focused — one logical change per PR
-
-## Coding Standards
-
-- **Formatting**: Run `cargo fmt` before committing
-- **Linting**: Run `cargo clippy -- -D warnings` — no warnings allowed
-- **Errors**: Use `anyhow` for application errors, define custom error types for library code
-- **Testing**: Write unit tests for core logic, integration tests for CLI commands
-- **Documentation**: Add doc comments to all public items (`///`)
-
-### Example Test
-
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_severity_from_str() {
-        use crate::engine::types::Severity;
-        assert_eq!(Severity::from_str_lossy("critical"), Severity::Critical);
-        assert_eq!(Severity::from_str_lossy("info"), Severity::Info);
-    }
-}
-```
-
-## Reporting Bugs
-
-Please open a [GitHub Issue](https://github.com/codecoradev/cora-code/issues/new) with:
-
-- **Description** — What happened vs. what you expected
-- **Steps to reproduce** — Minimal reproduction steps
-- **Environment** — OS, Rust version, cora-code version
-- **Logs** — Output with `RUST_LOG=debug cora review`
-
-## Feature Requests
-
-We love hearing your ideas! Open an issue with:
-
-- **Problem** — What problem does this solve?
-- **Proposed solution** — How should it work?
-- **Alternatives considered** — Other approaches you thought about
-
-## Questions?
-
-Feel free to open an issue tagged with `question` or reach out on GitHub Discussions.
-
----
-
-Thank you for helping make cora-code better! 🦀
+By contributing you agree your work is licensed under [MIT](LICENSE). No CLA required.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.13.x  | :white_check_mark: |
+| 0.12.x  | :white_check_mark: |
+| < 0.12  | :x:                |
+
+## Reporting a Vulnerability
+
+Cora processes source code and diffs — security vulnerabilities could expose user code, secrets in config files, or the LLM API keys used for review.
+
+**Do NOT open a public issue for security vulnerabilities.**
+
+Instead, email **hello@codecora.dev** with subject `[Cora security]`. Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fix (optional)
+
+You can expect:
+
+- **Acknowledgment within 48 hours**
+- **Assessment within 7 days**
+- **Fix or workaround communicated to you before public disclosure**
+
+If the vulnerability is accepted, we will coordinate disclosure timing with you. Credit is given unless you prefer anonymity.
+
+## Security Considerations in Cora
+
+Cora handles security-sensitive data:
+
+- **API keys** — LLM provider keys stored in config files and environment variables
+- **Source code** — Full access to indexed project files
+- **Git history** — Reads diffs, blame data, and commit metadata
+- **Pre-commit hooks** — Runs automatically on `git commit`, processes staged content
+
+Security-related areas of the codebase:
+
+- `src/engine/rules/` — Secret detection patterns
+- `src/config/providers.rs` — API key handling
+- `src/hook/` — Pre-commit hook integration
+- `src/index/` — File access and SQLite storage
+
+## Responsible Disclosure
+
+We follow responsible disclosure principles:
+
+1. Report privately first
+2. Allow reasonable time to fix (typically 90 days, shorter for critical)
+3. Coordinate public disclosure
+4. Credit researchers (opt-in)


### PR DESCRIPTION
## What

Add governance and contributor documentation modeled after [uteke PR #834](https://github.com/codecoradev/uteke/pull/834).

## Why

Cora is increasingly getting external contributions (PR #461, etc.) but has:
- Outdated CONTRIBUTING.md (wrong project structure, no external contributor policy)
- No CODE_OF_CONDUCT.md or SECURITY.md
- No PR template or issue templates
- No PR checks workflow (branch naming, conventional commits, description validation)

## How

Created/updated 7 files:
- **CONTRIBUTING.md** — Full rewrite: accurate project structure, quality bar, branch/commit conventions, architecture diagram, release flow, FAQ
- **CODE_OF_CONDUCT.md** — Compact CoC inspired by Contributor Covenant
- **SECURITY.md** — Vulnerability reporting, supported versions, security-sensitive code areas
- **.github/PULL_REQUEST_TEMPLATE.md** — What/Why/How/Testing/Checklist
- **.github/ISSUE_TEMPLATE/bug_report.yml** — Structured bug report with cora-specific fields (which command, config)
- **.github/ISSUE_TEMPLATE/feature_request.yml** — Feature request template
- **.github/workflows/pr-checks.yml** — 3 jobs: branch naming, PR description, conventional commit title

## Testing

- [x] YAML issue templates validated (GitHub accepts them)
- [x] PR checks workflow uses `actions/checkout@v4` (matching cora's existing CI)
- [x] All content adapted from uteke with cora-specific details (tree-sitter feature, cora-specific commands, accurate module layout)

## Related Issues

Related to external contributor onboarding improvements.

## Checklist

- [x] Branch name follows convention (`docs/`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR