### PR TITLE
docs: fix README links + add docs landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cora config show --project # .cora.yaml
 | `~/.cora/config.yaml` | Global defaults (provider, model, etc.) |
 | `.cora.yaml` | Per-project overrides |
 
-See **[Configuration →](https://codecora.dev/configuration.html)** for full reference.
+See **[Configuration →](https://codecora.dev/cora/docs/configuration)** for full reference.
 
 ## CI/CD
 
@@ -169,7 +169,7 @@ Required secrets: `CORA_API_KEY`, `CORA_BASE_URL` (optional), `CORA_MODEL` (opti
 
 See [GitHub Marketplace](https://github.com/marketplace/actions/cora-ai-code-review) for full documentation.
 
-Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecora.dev/examples.html#_07-gitea-forgejo-ci)
+Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecora.dev/cora/docs/examples#_07-gitea-forgejo-ci)
 
 ## Commands
 
@@ -207,7 +207,7 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora mcp` | Start MCP server (15 tools) for AI coding agents |
 | `cora hook install` | Install pre-commit hook |
 
-See **[CLI Reference →](https://codecora.dev/cli-reference.html)** for all flags and examples.
+See **[CLI Reference →](https://codecora.dev/cora/docs/cli-reference)** for all flags and examples.
 
 ## Performance
 
@@ -237,13 +237,13 @@ Provider-specific keys are auto-detected: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](https://codecora.dev/getting-started.html) | Install, auth, first review |
-| [Configuration](https://codecora.dev/configuration.html) | Config files, env vars, priority |
-| [CLI Reference](https://codecora.dev/cli-reference.html) | All commands and flags |
-| [Providers](https://codecora.dev/providers.html) | Supported LLM providers |
-| [Examples](https://codecora.dev/examples.html) | Common workflows & CI setup |
-| [Changelog](https://codecora.dev/changelog.html) | Release history |
-| [Roadmap](https://codecora.dev/roadmap.html) | Planned features |
+| [Getting Started](https://codecora.dev/cora/docs/getting-started) | Install, auth, first review |
+| [Configuration](https://codecora.dev/cora/docs/configuration) | Config files, env vars, priority |
+| [CLI Reference](https://codecora.dev/cora/docs/cli-reference) | All commands and flags |
+| [Providers](https://codecora.dev/cora/docs/providers) | Supported LLM providers |
+| [Examples](https://codecora.dev/cora/docs/examples) | Common workflows & CI setup |
+| [Changelog](https://codecora.dev/cora/docs/changelog) | Release history |
+| [Roadmap](https://codecora.dev/cora/docs/roadmap) | Planned features |
 
 ## Star History
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ features:
     details: Index symbols across 15 languages. Call graph, trace, impact analysis. FTS5 + vector KNN + graph hybrid search.
   - icon: 🌳
     title: Tree-sitter
-    details: AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, Svelte.
+    details: "AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, Svelte."
   - icon: 🔌
     title: MCP Server
     details: 15 tools for AI coding agents — review, search, brain, debt, trace. Works with Claude, GPT, and other MCP clients.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,59 @@
 ---
 layout: home
+
+hero:
+  name: Cora
+  text: AI Code Review CLI
+  tagline: BYOK, zero config. Multi-LLM code review, semantic search, and code intelligence — runs in your terminal, CI/CD, or AI coding agents. All local, zero cloud.
+  image:
+    src: /logo.png
+    alt: Cora
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /getting-started
+    - theme: alt
+      text: Installation
+      link: /installation
+    - theme: alt
+      text: GitHub
+      link: https://github.com/codecoradev/cora-code
+
+features:
+  - icon: 🤖
+    title: Multi-LLM
+    details: OpenAI, Anthropic, Groq, Ollama, Z.AI, or any OpenAI-compatible API. Bring your own key, pick any model.
+  - icon: ⚡
+    title: Native Rust
+    details: Fast binary, no runtime dependencies, cross-platform. 10.4 MB single static binary.
+  - icon: 🪝
+    title: Pre-commit Hooks
+    details: Catch issues before they reach CI. Review staged changes, unpushed commits, or any diff.
+  - icon: 📋
+    title: SARIF Output
+    details: Upload findings to GitHub Code Scanning. Native SARIF support for CI integration.
+  - icon: 🛡️
+    title: Deterministic Scanners
+    details: 12 built-in rules + 13 security patterns + 15 secret detection patterns — run without LLM, zero cost.
+  - icon: 🧠
+    title: Code Intelligence
+    details: Index symbols across 15 languages. Call graph, trace, impact analysis. FTS5 + vector KNN + graph hybrid search.
+  - icon: 🌳
+    title: Tree-sitter
+    details: AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, Svelte.
+  - icon: 🔌
+    title: MCP Server
+    details: 15 tools for AI coding agents — review, search, brain, debt, trace. Works with Claude, GPT, and other MCP clients.
+  - icon: 📐
+    title: Quality Profiles
+    details: Strict, balanced, or lax presets. Configurable quality gate with pass/fail thresholds for CI enforcement.
+  - icon: 💾
+    title: Diff-hash Caching
+    details: Skip repeat reviews automatically. Incremental index in ~6ms with mtime:size fingerprint.
+  - icon: 🚧
+    title: Quality Gate
+    details: Configurable pass/fail thresholds for CI enforcement. Max critical, max security findings, per-category actions.
+  - icon: 🔧
+    title: Configurable
+    details: Per-project .cora.yaml, global ~/.cora/config.yaml, or env vars. Custom regex rules in config.
 ---


### PR DESCRIPTION
## What

Fix 10 broken documentation links in README + add missing landing page content for docs site.

**README links:** All `codecora.dev/*.html` links returned 404. Updated to correct VitePress routes under `codecora.dev/cora/docs/`.

**Docs landing page:** `docs/index.md` only had `layout: home` frontmatter — no hero or features. `codecora.dev/cora/docs/` rendered blank. Added hero + 12 feature cards matching README content.

## Why

- README pointed to non-existent URLs (`codecora.dev/getting-started.html` → 404). Users clicking docs links hit dead pages.
- Docs landing page (`/cora/docs/`) was blank — no hero, no features, just empty white space. Looked broken/unmaintained compared to uteke docs which has a proper landing page.

## Testing

- All 9 doc pages verified 200 OK via curl: `codecora.dev/cora/docs/{getting-started,installation,usage,configuration,providers,cli-reference,examples,changelog,roadmap}`
- Old URLs confirmed 404: `codecora.dev/getting-started.html`, `codecora.dev/configuration.html`
- Landing page index.md follows same pattern as uteke docs (hero + features frontmatter)
- 10 links in README now all use `codecora.dev/cora/docs/` base path

### Files changed
- `README.md` — 10 links fixed
- `docs/index.md` — landing page content added