### PR TITLE
docs: fix README links + add docs landing page

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,13 +17,13 @@ jobs:
           echo "Checking branch: $HEAD_REF"
 
           # Allowed prefixes (kebab-case)
-          ALLOWED="^(feat|fix|docs|chore|perf|security|refactor|test|build|ci)/"
+          ALLOWED="^(feat|fix|docs|chore|perf|security|refactor|test|build|ci|release)/"
 
           if echo "$HEAD_REF" | grep -qE "$ALLOWED"; then
             echo "✅ Branch name follows convention"
           else
-            echo "::error::Branch name must start with one of: feat/, fix/, docs/, chore/, perf/, security/, refactor/, test/, build/, ci/"
-            echo "Example: fix/fts5-camelcase, feat/mcp-find-callers"
+            echo "::error::Branch name must start with one of: feat/, fix/, docs/, chore/, perf/, security/, refactor/, test/, build/, ci/, release/"
+            echo "Example: fix/fts5-camelcase, feat/mcp-find-callers, release/v0.12.0"
             echo "Current: $HEAD_REF"
             exit 1
           fi
@@ -67,7 +67,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Check PR title format
@@ -77,16 +77,16 @@ jobs:
           echo "Checking PR title: $PR_TITLE"
 
           # Conventional Commits: type(scope): description
-          # Types: feat, fix, docs, chore, perf, refactor, test, build, ci, security
-          PATTERN="^(feat|fix|docs|chore|perf|refactor|test|build|ci|security)(\(.+\))?!?: .+"
+          # Types: feat, fix, docs, chore, perf, refactor, test, build, ci, security, release
+          PATTERN="^(feat|fix|docs|chore|perf|refactor|test|build|ci|security|release)(\\(.+\\))?!?: .+"
 
           if echo "$PR_TITLE" | grep -qE "$PATTERN"; then
             echo "✅ PR title follows Conventional Commits"
           else
             echo "::error::PR title must follow Conventional Commits format"
             echo "Expected: type(scope): short description"
-            echo "Example: fix(review): handle empty diff"
-            echo "Types: feat, fix, docs, chore, perf, refactor, test, build, ci, security"
+            echo "Example: fix(review): handle empty diff, release: v0.12.0"
+            echo "Types: feat, fix, docs, chore, perf, refactor, test, build, ci, security, release"
             echo "Current: $PR_TITLE"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cora config show --project # .cora.yaml
 | `~/.cora/config.yaml` | Global defaults (provider, model, etc.) |
 | `.cora.yaml` | Per-project overrides |
 
-See **[Configuration →](https://codecora.dev/configuration.html)** for full reference.
+See **[Configuration →](https://codecora.dev/cora/docs/configuration)** for full reference.
 
 ## CI/CD
 
@@ -169,7 +169,7 @@ Required secrets: `CORA_API_KEY`, `CORA_BASE_URL` (optional), `CORA_MODEL` (opti
 
 See [GitHub Marketplace](https://github.com/marketplace/actions/cora-ai-code-review) for full documentation.
 
-Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecora.dev/examples.html#_07-gitea-forgejo-ci)
+Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecora.dev/cora/docs/examples#_07-gitea-forgejo-ci)
 
 ## Commands
 
@@ -207,7 +207,7 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora mcp` | Start MCP server (15 tools) for AI coding agents |
 | `cora hook install` | Install pre-commit hook |
 
-See **[CLI Reference →](https://codecora.dev/cli-reference.html)** for all flags and examples.
+See **[CLI Reference →](https://codecora.dev/cora/docs/cli-reference)** for all flags and examples.
 
 ## Performance
 
@@ -237,13 +237,13 @@ Provider-specific keys are auto-detected: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](https://codecora.dev/getting-started.html) | Install, auth, first review |
-| [Configuration](https://codecora.dev/configuration.html) | Config files, env vars, priority |
-| [CLI Reference](https://codecora.dev/cli-reference.html) | All commands and flags |
-| [Providers](https://codecora.dev/providers.html) | Supported LLM providers |
-| [Examples](https://codecora.dev/examples.html) | Common workflows & CI setup |
-| [Changelog](https://codecora.dev/changelog.html) | Release history |
-| [Roadmap](https://codecora.dev/roadmap.html) | Planned features |
+| [Getting Started](https://codecora.dev/cora/docs/getting-started) | Install, auth, first review |
+| [Configuration](https://codecora.dev/cora/docs/configuration) | Config files, env vars, priority |
+| [CLI Reference](https://codecora.dev/cora/docs/cli-reference) | All commands and flags |
+| [Providers](https://codecora.dev/cora/docs/providers) | Supported LLM providers |
+| [Examples](https://codecora.dev/cora/docs/examples) | Common workflows & CI setup |
+| [Changelog](https://codecora.dev/cora/docs/changelog) | Release history |
+| [Roadmap](https://codecora.dev/cora/docs/roadmap) | Planned features |
 
 ## Star History
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,59 @@
 ---
 layout: home
+
+hero:
+  name: Cora
+  text: AI Code Review CLI
+  tagline: BYOK, zero config. Multi-LLM code review, semantic search, and code intelligence — runs in your terminal, CI/CD, or AI coding agents. All local, zero cloud.
+  image:
+    src: /logo.png
+    alt: Cora
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /getting-started
+    - theme: alt
+      text: Installation
+      link: /installation
+    - theme: alt
+      text: GitHub
+      link: https://github.com/codecoradev/cora-code
+
+features:
+  - icon: 🤖
+    title: Multi-LLM
+    details: OpenAI, Anthropic, Groq, Ollama, Z.AI, or any OpenAI-compatible API. Bring your own key, pick any model.
+  - icon: ⚡
+    title: Native Rust
+    details: Fast binary, no runtime dependencies, cross-platform. 10.4 MB single static binary.
+  - icon: 🪝
+    title: Pre-commit Hooks
+    details: Catch issues before they reach CI. Review staged changes, unpushed commits, or any diff.
+  - icon: 📋
+    title: SARIF Output
+    details: Upload findings to GitHub Code Scanning. Native SARIF support for CI integration.
+  - icon: 🛡️
+    title: Deterministic Scanners
+    details: 12 built-in rules + 13 security patterns + 15 secret detection patterns — run without LLM, zero cost.
+  - icon: 🧠
+    title: Code Intelligence
+    details: Index symbols across 15 languages. Call graph, trace, impact analysis. FTS5 + vector KNN + graph hybrid search.
+  - icon: 🌳
+    title: Tree-sitter
+    details: "AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, Svelte."
+  - icon: 🔌
+    title: MCP Server
+    details: 15 tools for AI coding agents — review, search, brain, debt, trace. Works with Claude, GPT, and other MCP clients.
+  - icon: 📐
+    title: Quality Profiles
+    details: Strict, balanced, or lax presets. Configurable quality gate with pass/fail thresholds for CI enforcement.
+  - icon: 💾
+    title: Diff-hash Caching
+    details: Skip repeat reviews automatically. Incremental index in ~6ms with mtime:size fingerprint.
+  - icon: 🚧
+    title: Quality Gate
+    details: Configurable pass/fail thresholds for CI enforcement. Max critical, max security findings, per-category actions.
+  - icon: 🔧
+    title: Configurable
+    details: Per-project .cora.yaml, global ~/.cora/config.yaml, or env vars. Custom regex rules in config.
 ---


### PR DESCRIPTION
## What

Merge docs fixes from develop to main for production deploy.

- Fix 10 broken documentation links in README (404 → 200)
- Add missing landing page content for docs site (`docs/index.md`)
- VitePress build passes

## Why

- README links pointed to non-existent `codecora.dev/*.html` URLs
- `codecora.dev/cora/docs/` rendered blank — no hero or features

## Testing

- All 9 doc pages verified 200 OK
- Website Build CI passes
- Deploy workflow tested via workflow_dispatch — builds successfully