### PR TITLE
ci: add --branch=main to pages deploy for production promotion

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -52,4 +52,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           preCommands: npx wrangler pages project create cora-code --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora-code --commit-dirty=true
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora-code --commit-dirty=true --branch=main


### PR DESCRIPTION
## What

Add explicit `--branch=main` flag to the Cloudflare Pages deploy command in `deploy-website.yml`.

## Why

Without `--branch=main`, wrangler detects the triggering branch context. When deploy runs via `workflow_dispatch` from `develop`, wrangler deploys as a **non-production** deployment — the new build never reaches the production alias (`codecora.dev`).

This matches the pattern already used in the `website` repo deploy workflow which explicitly passes `--branch=main`.

## Testing

- Diff verified — single line change, same pattern as `codecoradev/website/.github/workflows/deploy-website.yml`
- After merge to develop → main, deploy will promote to production correctly