### PR TITLE
ci: add --branch=main to pages deploy

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -52,4 +52,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           preCommands: npx wrangler pages project create cora-code --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora-code --commit-dirty=true
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora-code --commit-dirty=true --branch=main


### PR DESCRIPTION
## What

Merge deploy fix from develop to main for production deploy.

## Why

Deploy workflow was missing `--branch=main` flag, causing wrangler to deploy as non-production when triggered from non-main branches.

## Testing

- All 13 CI checks pass on PR #472