### PR TITLE
ci: deploy to cora-cli pages project (not cora-code)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: npx wrangler pages project create cora-code --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora-code --commit-dirty=true --branch=main
+          preCommands: npx wrangler pages project create cora-cli --production-branch=main || true
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora-cli --commit-dirty=true --branch=main


### PR DESCRIPTION
## What

Fix CF Pages project name from `cora-code` → `cora-cli` in deploy workflow.

## Why

Production `codecora.dev/cora/docs/` is served from **`cora-cli.pages.dev`**, not `cora-code.pages.dev`. The worker router in `codecoradev/website` also proxies `/docs/cora/*` to `cora-cli.pages.dev`.

Evidence:
- `cora-cli.pages.dev` hash: `BP_l2CHe` (matches `codecora.dev/cora/docs/`)
- `cora-code.pages.dev` hash: `ahCvLnqw` (NEW build, but NOT what production serves)

Previous deploys went to the wrong project — builds completed successfully but never reached production.

## Testing

- Same VitePress build, same `--branch=main` flag
- Only project name changed: `cora-code` → `cora-cli`
- After merge → main, deploy will target the correct production project