### PR TITLE
ci: deploy to cora-cli pages project (not cora-code)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: npx wrangler pages project create cora-code --production-branch=main || true
-          command: pages deploy docs/.vitepress/dist/ --project-name=cora-code --commit-dirty=true --branch=main
+          preCommands: npx wrangler pages project create cora-cli --production-branch=main || true
+          command: pages deploy docs/.vitepress/dist/ --project-name=cora-cli --commit-dirty=true --branch=main


### PR DESCRIPTION
## What

Merge to main for production deploy. Fixes CF Pages project name.

## Why

Deploy was targeting wrong project (`cora-code` instead of `cora-cli`).

## Testing

- All CI checks pass on PR #474