### PR TITLE
docs: comprehensive documentation audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - 🧠 **Brain Mode** — hybrid semantic search (FTS5 + vector KNN + graph) with RRF fusion
 - 🗄️ **Multi-project database** — one global index, search across all your repos at once
 - 🌳 **Tree-sitter** (opt-in) — AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, **Svelte** (via TypeScript delegation, zero extra dependency)
-- 🔌 **MCP server** — 15 tools for AI coding agents (review, search, brain, debt, trace, ...)
+- 🔌 **MCP server** — 18 tools for AI coding agents (review, search, brain, debt, trace, dead code, graph query, ...)
 - 💾 **Diff-hash caching** — skip repeat reviews automatically
 - 🔧 **Configurable** — per-project `.cora.yaml`, global `~/.cora/config.yaml`, or env vars
 
@@ -195,6 +195,9 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora callers` | Find all callers of a symbol |
 | `cora impact` | Analyze blast radius of changing a symbol |
 | `cora affected` | Find tests impacted by changed files |
+| `cora dead-code` | Detect dead code — functions with zero callers |
+| `cora query` | Query the code graph (e.g. `"main -> *"`) |
+| `cora routes` | List detected HTTP routes (Axum, Actix, Express, FastAPI, Flask, Go) |
 
 ### Config & Setup
 
@@ -203,8 +206,12 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora init` | Create project config + hook |
 | `cora auth login` | Save API key |
 | `cora config show` | Show resolved config |
+| `cora config validate` | Validate configuration |
 | `cora providers` | List available LLM providers |
-| `cora mcp` | Start MCP server (15 tools) for AI coding agents |
+| `cora profile list` | List quality profiles (strict, balanced, lax) |
+| `cora mcp` | Start MCP server (18 tools) for AI coding agents |
+| `cora serve` | Start MCP server + auto-reindex on startup |
+| `cora install` | Auto-detect and configure AI coding agents |
 | `cora hook install` | Install pre-commit hook |
 
 See **[CLI Reference →](https://codecora.dev/cora/docs/cli-reference)** for all flags and examples.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -21,37 +21,134 @@ Complete command reference for the cora CLI.
 
 ## Commands
 
+### Setup & Config
+
 | Command | Description |
 |---------|-------------|
-| `cora init` | Create `.cora.yaml` config file |
-| `cora commit` | Review staged + generate commit message + commit (HITL prompt) |
-| `cora commit --yolo` | Auto-commit without prompts (YOLO mode) |
-| `cora commit --force` | Commit even if quality gate fails |
-| `cora commit --no-review` | Skip review, only generate commit message |
-| `cora commit --edit` | Always open `$EDITOR` to edit message |
-| `cora review` | Review code changes (default: staged files) |
-| `cora review --staged` | Review staged git changes explicitly |
+| `cora init` | Create `.cora.yaml` config file and install pre-commit hook |
+| `cora init --force` | Overwrite existing config file |
+| `cora init --no-hook` | Skip pre-commit hook installation |
+| `cora config show` | Show resolved configuration |
+| `cora config show --global` | Show global config (`~/.cora/config.yaml`) |
+| `cora config show --project` | Show project config (`.cora.yaml`) |
+| `cora config set` `<key>` `<value>` | Set a config value |
+| `cora config set` `<key>` `<value>` `--global` | Write to global config instead of project |
+| `cora config validate` | Validate configuration and report status |
+| `cora auth login` | Save API key interactively |
+| `cora auth login --provider` `<name>` `--api-key` `<key>` | Non-interactive login |
+| `cora auth login --model` `<model>` | Set model with provider |
+| `cora auth login --base-url` `<url>` | Custom API endpoint |
+| `cora auth login --force` | Overwrite existing key without confirmation |
+| `cora auth status` | Check current auth status |
+| `cora auth remove` | Remove stored API key |
+| `cora providers` | List detected AI providers |
+| `cora install` | Auto-detect and configure AI coding agents for Cora MCP |
+| `cora install --list` | List detected agents without installing |
+| `cora install --agents` `"cline,cursor"` | Install specific agents |
+| `cora install --dry-run` | Show what would be changed |
+| `cora install --force` | Overwrite existing cora entry |
+| `cora install --yes` | Install ALL detected agents (non-interactive) |
+| `cora hook install` | Install pre-commit hook |
+| `cora hook uninstall` | Remove pre-commit hook |
+| `cora completion` `<shell>` | Generate shell completions (bash/zsh/fish/powershell) |
+
+### Review & Scan
+
+| Command | Description |
+|---------|-------------|
+| `cora review` | Review code changes (default: tries staged, then unpushed) |
+| `cora review --staged` | Review staged git changes |
 | `cora review --unstaged` | Review unstaged working changes |
 | `cora review --unpushed` | Review unpushed commits |
 | `cora review --base` `<branch>` | Compare current branch against target |
 | `cora review --commit` `<ref>` | Review specific commit or range |
 | `cora review --diff-file` `<path>` | Review from a diff file |
 | `cora review --upload` | Review and upload SARIF to GitHub Code Scanning |
-| `cora scan` `<path>` | Scan files for issues |
-| `cora scan .` `[--incremental]` | Scan only changed files |
-| `cora scan .` `[--batch-files N]` | Max files per LLM batch (default: 20). Lower to work around provider token limits |
-| `cora scan .` `[--no-continue-on-batch-error]` | Abort the scan when a batch fails to parse (default: skip and continue) |
-| `cora config show` | Show resolved configuration |
-| `cora config show --global` | Show global config (`~/.cora/config.yaml`) |
-| `cora config show --project` | Show project config (`.cora.yaml`) |
-| `cora config set` `<key>` `<value>` | Set a config value |
-| `cora hook install` | Install pre-commit hook |
-| `cora hook uninstall` | Remove pre-commit hook |
-| `cora auth login` | Save API key to `~/.cora/auth.toml` |
-| `cora auth status` | Check current auth status |
-| `cora auth remove` | Remove stored API key |
-| `cora providers` | List detected AI providers |
-| `cora upload-sarif` `<file>` | Upload SARIF to GitHub Code Scanning |
+| `cora review --no-auto-chunk` | Disable auto-chunking for large diffs |
+| `cora review --progress` | Output NDJSON progress events to stderr |
+| `cora review --quiet` | Suppress all output except result |
+| `cora review --output-file` `<path>` | Write output to file instead of stdout |
+| `cora review --severity` `<level>` | Filter by min severity (info/minor/major/critical) |
+| `cora review --no-cache` | Disable review caching |
+| `cora review --ci` | CI mode: skip diff size limit, exit 2 if any findings |
+| `cora review --max-diff-size` `<chars>` | Override max diff size |
+| `cora review --memory` | Recall project patterns from Uteke before review |
+| `cora review --learn` | Save findings to Uteke after review (implies `--memory`) |
+| `cora commit` | Review staged + generate commit message + commit (HITL prompt) |
+| `cora commit --yolo` | Auto-commit without prompts |
+| `cora commit --force` | Commit even if quality gate fails |
+| `cora commit --no-review` | Skip review, only generate commit message |
+| `cora commit --edit` | Always open `$EDITOR` to edit message |
+| `cora commit --stream` | Stream LLM response in real-time |
+| `cora commit --quiet` | Suppress all output except result |
+| `cora scan` `[--path <dir>]` | Scan files for issues (default: current directory) |
+| `cora scan --include` `"src/**/*.rs"` | Include glob patterns |
+| `cora scan --exclude` `"vendor/**"` | Exclude glob patterns |
+| `cora scan --extensions` `"ts,js"` | Additional file extensions to scan |
+| `cora scan --incremental` | Scan only files changed since last scan |
+| `cora scan --focus` `security` | Override focus areas |
+| `cora scan --batch-files` `N` | Max files per LLM batch (default: 20) |
+| `cora scan --no-continue-on-batch-error` | Abort on batch failure (default: skip and continue) |
+
+### Code Intelligence
+
+See [Code Intelligence](./code-intelligence) for detailed usage.
+
+| Command | Description |
+|---------|-------------|
+| `cora index` | Index project symbols into SQLite + usearch |
+| `cora index --rebuild` | Rebuild index from scratch |
+| `cora index --watch` | Auto-sync file watcher (2s poll interval) |
+| `cora index --stats` | Show index statistics (symbol count, languages, DB size) |
+| `cora index --prune` | Remove stale entries for deleted files |
+| `cora explore` `<query>` | Keyword search (FTS5) over symbol names |
+| `cora explore --kind` `function` | Filter by symbol kind |
+| `cora explore --file` `"src/"` | Filter by file path prefix |
+| `cora explore --language` `rust` | Filter by language |
+| `cora explore --limit` `N` | Max results (default: 50) |
+| `cora brain` `<query>` | Hybrid search: FTS5 + vector + graph → RRF fusion |
+| `cora brain --limit N` | Max results (default: 20) |
+| `cora callers` `<symbol>` | Find all callers of a symbol (reverse call graph) |
+| `cora callers --limit N` | Max callers to return (default: 50) |
+| `cora impact` `<symbol>` | Analyze blast radius of changing a symbol |
+| `cora impact --depth N` | Traversal depth (default: 3) |
+| `cora trace` `<symbol>` | Trace call chains (depth-limited BFS) |
+| `cora trace --direction incoming` | Trace callers instead of callees |
+| `cora trace --depth N` | Max hops (default: 3) |
+| `cora arch` | Architecture overview — modules, edge types, top connectors |
+| `cora affected` `<files...>` | Find test files affected by source changes |
+| `cora affected --stdin` | Read changed files from stdin (pipe from `git diff --name-only`) |
+| `cora affected --filter` `"*test*"` | Custom test file glob pattern |
+| `cora dead-code` | Detect dead code — functions/methods with zero callers |
+| `cora dead-code --include-tests` | Include test functions in results |
+| `cora dead-code --min-lines N` | Filter out tiny functions |
+| `cora query` `"main -> *"` | Query the code graph with simple patterns |
+| `cora query --limit N` | Max results (default: 50) |
+| `cora routes` | List detected HTTP routes (Axum, Actix, Express, FastAPI, Flask, Go) |
+| `cora routes --method GET` | Filter by HTTP method |
+| `cora routes --prefix /api` | Filter by path prefix |
+
+### Quality Profiles
+
+| Command | Description |
+|---------|-------------|
+| `cora profile list` | List available quality profiles |
+| `cora profile show` `<name>` | Show details of a specific profile |
+| `cora profile validate` `<path>` | Validate a custom profile YAML file |
+
+### Findings & Debt
+
+| Command | Description |
+|---------|-------------|
+| `cora findings list` | Show open findings |
+| `cora findings list --all` | Show all findings including resolved |
+| `cora findings list --severity major` | Filter by severity |
+| `cora findings list --file "src/main.rs"` | Filter by file |
+| `cora findings list --json` | JSON output |
+| `cora findings stats` | Summary counts with resolution rate |
+| `cora findings dismiss <id>` | Mark finding as won't-fix |
+| `cora findings dismiss <id> --reason "..."` | Dismiss with reason |
+| `cora findings reopen <id>` | Reopen a dismissed/resolved finding |
 | `cora debt` | Show tech debt report from review history |
 | `cora debt --json` | Debt report as JSON (for CI/dashboards) |
 | `cora debt --trend` | Quality score trend graph |
@@ -59,27 +156,14 @@ Complete command reference for the cora CLI.
 | `cora debt --estimate` | Show estimated fix time |
 | `cora debt --since v0.4.5` | Filter by git tag or date |
 | `cora debt --branch main` | Filter by branch |
-| `cora findings list` | Show open findings (use `--all`, `--severity`, `--file`, `--json`) |
-| `cora findings stats` | Summary counts with resolution rate (`--json`) |
-| `cora findings dismiss <id>` | Mark finding as won't-fix (optional `--reason`) |
-| `cora findings reopen <id>` | Reopen a dismissed/resolved finding |
-| `cora arch` | Architecture overview — modules, edge types, top connectors |
-| `cora trace` `<symbol>` | Trace call chains from a symbol (depth-limited BFS) |
-| `cora brain` `<query>` | Hybrid search: FTS5 + vector + graph → RRF fusion |
-| `cora brain` `--json` | Brain search as JSON |
-| `cora brain` `--limit N` | Max results (default: 20) |
-| `cora index` | Index project symbols into SQLite + usearch |
-| `cora index --rebuild` | Rebuild index from scratch |
-| `cora index --watch` | Auto-sync file watcher (2s poll interval) |
-| `cora index --stats` | Show index statistics (symbol count, languages, DB size) |
-| `cora index --prune` | Remove stale entries for deleted files |
-| `cora callers` `<symbol>` | Find all callers of a symbol (reverse call graph) |
-| `cora callers` `--limit N` | Max callers to return (default: 50) |
-| `cora impact` `<symbol>` | Analyze blast radius of changing a symbol |
-| `cora impact` `--depth N` | Traversal depth (default: 3) |
-| `cora affected` `<files...>` | Find test files affected by source changes |
-| `cora completion` `<shell>` | Generate shell completions (bash/zsh/fish) |
+| `cora upload-sarif` `<file>` | Upload SARIF to GitHub Code Scanning |
+
+### MCP Server
+
+| Command | Description |
+|---------|-------------|
 | `cora mcp` | Start MCP server for AI coding agents (Claude Code, Cursor, Windsurf) |
+| `cora serve` | Start MCP server with auto-reindex on startup |
 
 ## Quick Examples
 

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -214,6 +214,43 @@ cora arch --json   # JSON output
 
 Shows: module breakdown, edge types (calls, imports), and top connector symbols.
 
+### `cora dead-code` — Dead Code Detection
+
+Find functions and methods that have zero callers — candidates for removal.
+
+```bash
+cora dead-code                     # Find dead functions
+cora dead-code --include-tests     # Include test functions (test_*, *_test)
+cora dead-code --min-lines 10      # Filter out tiny functions
+cora dead-code --json              # JSON output
+```
+
+> **Tip:** Use `analysis.entry_point_patterns` in `.cora.yaml` to mark entry points (e.g. `*Handler`, `main`) so they're not flagged as dead code.
+
+### `cora query` — Code Graph Query
+
+Query the call graph with simple pattern syntax.
+
+```bash
+cora query "main -> *"             # What does main call?
+cora query "* -> authenticate"     # What calls authenticate?
+cora query "MyStruct"              # Find all edges involving MyStruct
+cora query --limit 100 "main -> *"
+```
+
+Pattern syntax: `source -> target`, where each side can be a symbol name or `*` (wildcard).
+
+### `cora routes` — HTTP Route Listing
+
+List detected HTTP routes from framework annotations. Supports Axum, Actix, Express, FastAPI, Flask, and Go (net/http, gin, echo, chi).
+
+```bash
+cora routes                        # All routes
+cora routes --method GET           # Filter by HTTP method
+cora routes --prefix /api          # Filter by path prefix
+cora routes --json                 # JSON output
+```
+
 ## Test Impact Analysis
 
 ### `cora affected`
@@ -223,8 +260,9 @@ Find tests that are impacted by changed files.
 ```bash
 cora affected                              # From git diff
 cora affected src/auth.rs src/api.rs      # Specific files
-cora affected --test-glob "*test*"         # Custom test file pattern
-cora affected --json                     # JSON output
+cora affected --stdin                      # Pipe from git diff --name-only
+cora affected --filter "*test*"            # Custom test file pattern
+cora affected --json                       # JSON output
 ```
 
 ## MCP Integration
@@ -266,11 +304,13 @@ cora index --rebuild
 
 ## Schema Versioning
 
-The database uses automatic migrations. Current schema version: **v4**.
+The database uses automatic migrations. Current schema version: **v6**.
 
 | Version | Changes |
----------|---------|
+|---------|---------|
 | v1 | Initial symbols table + FTS5 |
 | v2 | Added language column |
 | v3 | Added `edges` table for call graph |
 | v4 | Added `embedding_tier`, `embedding_dims`, `embedding_model`, `last_embedded_at` to projects |
+| v5 | Added `reviews`, `findings`, `finding_events` tables for review history and findings tracking |
+| v6 | Added index config hash column for fingerprint invalidation on config changes |

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -110,7 +110,7 @@ FTS5 full-text search over symbol names and signatures.
 ```bash
 cora explore "authenticate"         # Search by name
 cora explore --kind function        # Filter by symbol kind
-cora explore --lang rust             # Filter by language
+cora explore --language rust        # Filter by language
 cora explore --limit 20              # Max results
 cora explore --json                 # JSON output
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ provider:
 llm:
   temperature: 0
   max_tokens: 4096
+  max_tokens_param: auto       # auto | max_tokens | max_output_tokens | max_completion_tokens
   timeout: 120
   cache_ttl: 1440
 
@@ -66,11 +67,17 @@ hook:
   mode: warn
   min_severity: major
   max_diff_size: 51200
+  on_violation: warn           # warn | disallow (blocks commit if violations found)
 
 ignore:
   files:
     - "vendor/**"
-    - "*.min.js"
+    - "*.generated.ts"
+  rules: []                    # rule IDs to skip (e.g. ["no-unwrap", "sql-injection"])
+
+output:
+  format: pretty               # pretty | json | compact | sarif
+  color: true                  # ANSI colors in terminal output
 
 quality_gate:
   enabled: true
@@ -90,7 +97,7 @@ analysis:
     - "*Handler"
     - "resolve_*"
 
-profile: balanced            # strict | balanced | lax
+profile: clean-code        # security-first | performance | clean-code | beginner-friendly | minimal | rust-strict | typescript-strict | go-pragmatic
 ```
 
 ## Environment Variables
@@ -196,6 +203,9 @@ review:
     follow_depth: 1             # outbound resolution depth (1 = direct refs only)
     include_tests: true         # resolve test files via naming convention
     include_callers: true       # resolve callers of changed code (blast radius)
+    use_brain: true             # enrich prompt with symbol-index intelligence
+    impact_depth: 2             # blast-radius traversal depth (2 = callers of callers)
+    prefer_index: true          # prefer symbol index (FTS5 + call graph) over regex
 ```
 
 | Field | Default | Notes |
@@ -205,6 +215,9 @@ review:
 | `follow_depth` | `1` | Outbound recursion depth (`1` = direct references). |
 | `include_tests` | `true` | Map changed source to its test files. |
 | `include_callers` | `true` | Inbound caller resolution. Scans source files (gitignore-aware — `target/`, `node_modules/` are never scanned), bounded to ≤400 files and ≤3 call-sites per symbol. |
+| `use_brain` | `true` | Enrich prompt with symbol-index intelligence (impact analysis, affected tests, semantic search). Only active when `cora index` has been run. |
+| `impact_depth` | `2` | Blast-radius traversal depth (`1` = direct callers, `2` = callers of callers). |
+| `prefer_index` | `true` | Prefer symbol index (FTS5 + call graph) over regex scanning for outbound resolution. |
 
 ## Quality Gate
 
@@ -368,18 +381,25 @@ No configuration needed — language context is auto-detected from file extensio
 
 ## Quality Profiles
 
-cora includes built-in quality profiles for different review strictness:
+cora includes built-in quality profiles for different review focus:
 
 | Profile | Description |
 |---------|------------|
-| `strict` | All categories enabled, low tolerance for issues |
-| `balanced` | *(default)* Security + bugs + performance, moderate thresholds |
-| `lax` | Only critical issues, high tolerance |
+| `security-first` | Strict security focus — zero tolerance for vulnerabilities |
+| `performance` | Focus on speed, memory, and allocation patterns — best for hot-path code |
+| `clean-code` | *(default)* Broad quality — readability, naming, complexity — best for team projects |
+| `beginner-friendly` | Gentle review — focus on common mistakes and learning opportunities |
+| `minimal` | Only critical + security — best for quick PRs and hotfixes |
+| `rust-strict` | Rust-specific: unsafe, unwrap, panic, lifetime, error handling, idiomatic patterns |
+| `typescript-strict` | TypeScript-specific: any types, null safety, proper typing, async patterns |
+| `go-pragmatic` | Go-specific: error handling, goroutine safety, interface design, idiomatic Go |
+
+Run `cora profile list` to see all profiles. Cora auto-detects the best profile based on your project's primary language (Rust → `rust-strict`, Go → `go-pragmatic`, others → `clean-code`).
 
 Set in `.cora.yaml`:
 
 ```yaml
-profile: strict
+profile: security-first
 ```
 
 ## Custom Rule Engine
@@ -411,7 +431,7 @@ Control how index-based scanners (unused imports, dead code, breaking changes) b
 ```yaml
 rules_engine:
   enabled: true
-  max_findings: 50
+  max_findings: 5
   index_skip_files:
     - "*.config.ts"
     - "vite.config.*"
@@ -427,7 +447,7 @@ rules_engine:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `true` | Enable/disable the rule engine |
-| `max_findings` | `int` | `50` | Max findings per scan |
+| `max_findings` | `int` | `5` | Max findings per scan |
 | `index_skip_files` | `[string]` | *(see below)* | Glob patterns for files to skip during index scanning |
 
 Default `index_skip_files` patterns (bundled with cora):
@@ -490,18 +510,18 @@ Control how multiple files are grouped into LLM batches during `cora scan`. Cora
 
 ```yaml
 bundling:
-  max_chars_per_group: 12000   # max source characters per LLM batch
+  max_chars_per_group: 60000  # max source characters per LLM batch
   max_files_per_group: 20      # max files per batch
-  strategy: directory          # grouping strategy: directory | language
+  strategy: smart              # grouping strategy: smart | flat
   coalesce_by_directory: true  # merge small batches from the same directory
   coalesce_by_language: true   # merge small batches with the same language
 ```
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `max_chars_per_group` | `12000` | Soft limit on source characters per batch |
+| `max_chars_per_group` | `60000` | Soft limit on source characters per batch |
 | `max_files_per_group` | `20` | Max files per batch before splitting |
-| `strategy` | `directory` | Grouping strategy: `directory` (proximity-based) or `language` (same-language files together) |
+| `strategy` | `smart` | Grouping strategy: `smart` (coalesce by directory + language within limits) or `flat` (first-fit by character count, legacy) |
 | `coalesce_by_directory` | `true` | Merge small batches from the same directory into one LLM call |
 | `coalesce_by_language` | `true` | Merge small batches with the same primary language |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,9 @@ review:
   system_prompt: "You are a senior code reviewer."
   # system_prompt_file: ./review-prompt.md
   response_format: json_object
+  static_analysis:
+    auto_clippy: false       # auto-run `cargo clippy` (Rust only)
+    clippy_output_file: ""   # or read clippy output from file
 
 focus: security, performance, bugs
 
@@ -68,6 +71,26 @@ ignore:
   files:
     - "vendor/**"
     - "*.min.js"
+
+quality_gate:
+  enabled: true
+  thresholds:
+    max_critical: 0
+    max_security: 0
+
+bundling:
+  max_chars_per_group: 12000
+  max_files_per_group: 20
+  strategy: directory        # directory | language
+  coalesce_by_directory: true
+  coalesce_by_language: true
+
+analysis:
+  entry_point_patterns:
+    - "*Handler"
+    - "resolve_*"
+
+profile: balanced            # strict | balanced | lax
 ```
 
 ## Environment Variables
@@ -418,6 +441,87 @@ Default `index_skip_files` patterns (bundled with cora):
 
 Glob patterns support: exact match (`main.rs`), wildcard suffix (`*.config.ts`), wildcard prefix (`vite.*`), and any-directory (`**/main.ts`).
 
+## Ignore Files
+
+Exclude files or directories from **all** cora operations — review, scan, and indexing. This is the broadest exclusion mechanism.
+
+```yaml
+ignore:
+  files:
+    - "vendor/**"
+    - "*.min.js"
+    - "**/generated/**"
+    - "*.lock"
+```
+
+| Pattern | Matches |
+|---------|---------|
+| `src/main.ts` | Exact path — only `src/main.ts` |
+| `*.config.ts` | Suffix wildcard — any file ending in `.config.ts` |
+| `vite.config.*` | Prefix wildcard — `vite.config.js`, `vite.config.ts` |
+| `**/main.ts` | Any-dir name — `src/main.ts`, `app/main.ts`, `a/b/main.ts` |
+| `**/phaser/**` | Any-dir wildcard — any path containing a `phaser/` directory |
+| `src/engine/**` | Prefix-dir — everything under `src/engine/` |
+| `**/*.test.ts` | Double wildcard ext — any `.test.ts` file anywhere |
+
+**Auto-skipped by default** (gitignore-aware): `node_modules/`, `target/`, `.git/`, `dist/`, `build/`.
+
+> **`ignore.files` vs `rules_engine.index_skip_files`:** `ignore.files` excludes files from **everything** (review, scan, index). `rules_engine.index_skip_files` excludes files from **index scanners only** (dead code, unused imports) — they're still reviewed by the LLM.
+
+## Static Analysis
+
+Run language-specific static analysis tools automatically during review and feed their output to the LLM for better findings.
+
+```yaml
+review:
+  static_analysis:
+    auto_clippy: false       # auto-run `cargo clippy` (Rust only)
+    clippy_output_file: ""   # or read clippy output from a file
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `auto_clippy` | `false` | Auto-run `cargo clippy --message-format=json` and inject warnings into review context (Rust projects only) |
+| `clippy_output_file` | `""` | Read clippy JSON output from a file instead of running clippy (useful for CI where clippy runs separately) |
+
+## Bundling
+
+Control how multiple files are grouped into LLM batches during `cora scan`. Cora automatically chunks large file sets into groups that fit within provider token limits.
+
+```yaml
+bundling:
+  max_chars_per_group: 12000   # max source characters per LLM batch
+  max_files_per_group: 20      # max files per batch
+  strategy: directory          # grouping strategy: directory | language
+  coalesce_by_directory: true  # merge small batches from the same directory
+  coalesce_by_language: true   # merge small batches with the same language
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `max_chars_per_group` | `12000` | Soft limit on source characters per batch |
+| `max_files_per_group` | `20` | Max files per batch before splitting |
+| `strategy` | `directory` | Grouping strategy: `directory` (proximity-based) or `language` (same-language files together) |
+| `coalesce_by_directory` | `true` | Merge small batches from the same directory into one LLM call |
+| `coalesce_by_language` | `true` | Merge small batches with the same primary language |
+
+## Analysis
+
+Configure entry-point symbol patterns for architecture and call-graph analysis. Entry points are treated as roots when tracing execution paths and detecting dead code.
+
+```yaml
+analysis:
+  entry_point_patterns:
+    - "*Handler"
+    - "resolve_*"
+    - "*Middleware"
+    - "main"
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `entry_point_patterns` | `[]` | Glob patterns identifying entry-point symbols (used by `dead-code`, `trace`, and `arch` commands to avoid false positives on intentionally-unreachable functions) |
+
 ## Tech Debt Tracker
 
 cora tracks review history and calculates tech debt metrics over time.
@@ -451,7 +555,8 @@ cora includes a built-in MCP (Model Context Protocol) server that exposes rules 
 ### Start the server
 
 ```bash
-cora mcp
+cora mcp      # Start MCP server
+cora serve    # Start MCP server + auto-reindex on startup (ensures fresh index)
 ```
 
 ### Available tools
@@ -463,6 +568,19 @@ cora mcp
 | `cora.get_quality_gate` | Get quality gate config and thresholds |
 | `cora.get_config` | Get effective project config (no secrets exposed) |
 | `cora.list_profiles` | List all quality profiles |
+| `cora.search_symbols` | Search the symbol index (requires `cora index`) |
+| `cora.find_callers` | Find all callers of a symbol (reverse call graph) |
+| `cora.find_impact` | Analyze blast radius of changing a symbol |
+| `cora.find_affected_tests` | Find test files affected by changed source files |
+| `cora.index_status` | Check if a symbol index exists and get statistics |
+| `cora.review_diff` | Review a git diff using cora's full pipeline (makes LLM call) |
+| `cora.get_debt` | Get tech debt report from review history |
+| `cora.get_project_info` | Get project context (repo, branch, cora version, index status) |
+| `cora.get_memory` | Recall project patterns from Uteke (requires `uteke` CLI) |
+| `cora.brain_search` | Hybrid code search: FTS5 + vector + graph → RRF fusion |
+| `cora.install` | Detect installed AI agents and configure cora as MCP server |
+| `cora.dead_code` | Find potentially dead code (functions with no callers) |
+| `cora.query` | Query the code graph with simple patterns (e.g. `main -> *`) |
 
 ### Configure in Claude Code
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ features:
     details: "AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, Svelte."
   - icon: 🔌
     title: MCP Server
-    details: 15 tools for AI coding agents — review, search, brain, debt, trace. Works with Claude, GPT, and other MCP clients.
+    details: 18 tools for AI coding agents — review, search, brain, debt, trace, dead code, graph query. Works with Claude, Cursor, Windsurf, and other MCP clients.
   - icon: 📐
     title: Quality Profiles
     details: Strict, balanced, or lax presets. Configurable quality gate with pass/fail thresholds for CI enforcement.


### PR DESCRIPTION
## What

Audit menyeluruh dokumentasi cora-code — menambahkan section yang missing (fitur sudah ada di source code tapi belum terdokumentasi) dan memperbaiki info yang outdated/wrong.

## Why

Dokumentasi tertinggal jauh di belakang source code. 6 CLI commands tidak terdokumentasi, 4 config sections missing, profile names salah (`strict/balanced/lax` tidak exist di source), beberapa defaults salah (`max_findings: 50` vs actual `5`), dan schema version outdated (v4 vs actual v6).

## How

Cross-referenced setiap field/command di docs melawan source code:
- `src/main.rs` Command enum (28 commands)
- `src/config/schema.rs` config structs (15 sections)
- `src/profiles/*.yaml` (8 profiles)
- `src/engine/bundling/types.rs`, `src/engine/context/types.rs` (sub-config)
- `src/mcp/` (18 MCP tools)

### Changes per file

**`docs/cli-reference.md`** — Full rewrite
- +6 missing commands: `dead-code`, `query`, `routes`, `serve`, `install`, `profile`
- Missing flags added across all commands

**`docs/configuration.md`** — Major additions
- +4 new sections: Ignore Files, Static Analysis, Bundling, Analysis
- Profile table: `strict/balanced/lax` → 8 actual profiles
- `max_findings` default: `50` → `5`
- `bundling.max_chars_per_group`: `12000` → `60000`
- `bundling.strategy`: `directory` → `smart` (actual enum: `smart | flat`)
- +3 `context_chain` fields: `use_brain`, `impact_depth`, `prefer_index`
- +`hook.on_violation`, `ignore.rules`, `output.color`, `llm.max_tokens_param`
- MCP tools table: 5 → 18

**`docs/code-intelligence.md`**
- Schema version: v4 → v6 (v5: reviews/findings/finding_events, v6: index config hash)
- +3 command sections: `dead-code`, `query`, `routes`
- Fixed: `--lang` → `--language`, `--test-glob` → `--filter`

**`README.md`** — Command tables: +7 missing commands, MCP count 15 → 18
**`docs/index.md`** — MCP count 15 → 18

## Testing

- [x] `cargo test --features tree-sitter` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --features tree-sitter -- -D warnings` passes
- [x] `cargo build --release --features tree-sitter` passes
- [x] Manual verification: all config fields cross-referenced against `src/config/schema.rs` structs, all CLI commands against `src/main.rs` Command enum, profile names against `src/profiles/*.yaml`, MCP tools against `src/mcp/` source files

## Related Issues

Closes #476

## Checklist

- [x] Branch name follows convention (`docs/comprehensive-audit`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR (no mixed concerns)