### PR TITLE
fix(cli): forward --config flag to all load_config call sites

### DIFF
--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -11,7 +11,11 @@ use crate::config::schema::{CoraFile, HookSection, OutputSection, ProviderSectio
 /// `--global` shows only ~/.cora/config.yaml
 /// `--project` shows only .cora.yaml
 /// (default) shows the fully merged effective config
-pub fn execute_config_show(global_only: bool, project_only: bool) -> Result<()> {
+pub fn execute_config_show(
+    global_only: bool,
+    project_only: bool,
+    config_path: Option<&str>,
+) -> Result<()> {
     // Clap conflicts_with handles the --global + --project case,
     // but add a defensive check in case of programmatic invocation.
     if global_only {
@@ -20,12 +24,12 @@ pub fn execute_config_show(global_only: bool, project_only: bool) -> Result<()> 
     if project_only {
         return show_project_config();
     }
-    show_effective_config()
+    show_effective_config(config_path)
 }
 
 /// Show the fully merged effective config (default behavior).
-fn show_effective_config() -> Result<()> {
-    let config = loader::load_config(None, None, None, None, None, false)?;
+fn show_effective_config(config_path: Option<&str>) -> Result<()> {
+    let config = loader::load_config(config_path, None, None, None, None, false)?;
 
     // Resolve effective values (env vars can override config file)
     let eff_provider = std::env::var("CORA_PROVIDER")
@@ -438,20 +442,28 @@ pub fn execute_config_set(key: &str, value: &str, global: bool) -> Result<()> {
 /// Execute `cora config validate` — load config and report validity.
 ///
 /// Returns exit code: 0 if valid, 2 if issues found.
-pub fn execute_config_validate() -> Result<i32> {
+pub fn execute_config_validate(config_path: Option<&str>) -> Result<i32> {
     // 1. Load resolved config (same as other commands)
-    let config = loader::load_config(None, None, None, None, None, false)?;
+    let config = loader::load_config(config_path, None, None, None, None, false)?;
 
-    // 2. Find the raw config file to check which fields were explicitly set
-    let cora_file = loader::find_cora_file(&std::env::current_dir().unwrap_or_default())
-        .unwrap_or_else(|e| {
+    // 2. Find the raw config file to check which fields were explicitly set.
+    //    Prefer --config path, then fall back to auto-discovery.
+    let cora_file = if let Some(path) = config_path {
+        std::fs::read_to_string(path).ok().and_then(|content| {
+            CoraFile::from_str(&content)
+                .ok()
+                .map(|cf| (std::path::PathBuf::from(path), cf))
+        })
+    } else {
+        loader::find_cora_file(&std::env::current_dir().unwrap_or_default()).unwrap_or_else(|e| {
             eprintln!(
                 "{} Warning: could not search for config file: {}",
                 "⚠️".yellow(),
                 e
             );
             None
-        });
+        })
+    };
 
     // Also check global config for fields set there
     let global_cora = load_global_cora_file();

--- a/src/commands/debt.rs
+++ b/src/commands/debt.rs
@@ -25,11 +25,20 @@ pub struct DebtOptions {
     pub badge: bool,
     /// Show estimated debt fix time.
     pub estimate: bool,
+    /// Config file path (from --config global flag).
+    pub config_path: Option<String>,
 }
 
 /// Execute the `cora debt` subcommand.
 pub fn execute_debt(opts: &DebtOptions) -> Result<i32> {
-    let config = crate::config::loader::load_config(None, None, None, None, None, false)?;
+    let config = crate::config::loader::load_config(
+        opts.config_path.as_deref(),
+        None,
+        None,
+        None,
+        None,
+        false,
+    )?;
 
     if !config.debt.enabled {
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,10 +721,16 @@ async fn main() -> Result<()> {
                 }
             } else {
                 // Load config for config-hash invalidation
-                let skip_patterns =
-                    crate::config::loader::load_config(None, None, None, None, None, false)
-                        .ok()
-                        .map(|c| c.rules_config.index_skip_files);
+                let skip_patterns = crate::config::loader::load_config(
+                    cli.global.config.as_deref(),
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .ok()
+                .map(|c| c.rules_config.index_skip_files);
 
                 eprintln!("{}", "🔍 Indexing project...".cyan());
                 let stats = index::index_project_with_skip(
@@ -1438,14 +1444,16 @@ async fn main() -> Result<()> {
         }
         Command::Config { action } => match action {
             ConfigAction::Show { global, project } => {
-                config_cmd::execute_config_show(global, project)?;
+                config_cmd::execute_config_show(global, project, cli.global.config.as_deref())?;
                 0
             }
             ConfigAction::Set { key, value, global } => {
                 config_cmd::execute_config_set(&key, &value, global)?;
                 0
             }
-            ConfigAction::Validate => config_cmd::execute_config_validate()?,
+            ConfigAction::Validate => {
+                config_cmd::execute_config_validate(cli.global.config.as_deref())?
+            }
         },
         Command::Providers => {
             providers::execute_providers();
@@ -1475,6 +1483,7 @@ async fn main() -> Result<()> {
                 branch,
                 badge,
                 estimate,
+                config_path: cli.global.config.clone(),
             };
             debt::execute_debt(&opts)?
         }
@@ -1509,8 +1518,15 @@ async fn main() -> Result<()> {
             )?;
 
             // Load config for entry_point_patterns
-            let config = crate::config::loader::load_config(None, None, None, None, None, false)
-                .unwrap_or_default();
+            let config = crate::config::loader::load_config(
+                cli.global.config.as_deref(),
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .unwrap_or_default();
             let entry_point_patterns = config.analysis.entry_point_patterns.clone();
 
             let opts = index::graph::DeadCodeOptions {


### PR DESCRIPTION
## What

The global `--config` flag (`CORA_CONFIG` env) was silently ignored by 5 commands because they called `load_config(None, ...)` instead of forwarding the user-provided config path.

## Why

Users running `cora config show --config /path/to/custom.yaml` would get default config instead of their specified file — a silent failure with no error message. Same for `config validate`, `debt`, `index`, and `dead-code`.

Root cause: `GlobalOptions.config` was defined as a `global = true` clap flag (main.rs:54), but multiple match arms in `main()` and helper functions in `config_cmd.rs`/`debt.rs` hardcoded `None` for the `cli_config_path` parameter.

## Changes

- `config_cmd.rs`: `execute_config_show()` and `execute_config_validate()` now accept `config_path: Option<&str>`. Validate also uses `--config` path for raw file inspection (fixes cora review finding).
- `debt.rs`: `DebtOptions` gains `config_path` field. `execute_debt()` forwards it to `load_config`.
- `main.rs`: All 5 call sites now forward `cli.global.config.as_deref()`:
  1. `cora config show`
  2. `cora config validate`
  3. `cora debt`
  4. `cora index` (skip pattern loading)
  5. `cora dead-code` (entry_point_patterns)

## Testing

- `cargo test --bin cora` — 776 passed, 0 failed
- `cargo test --test *` — 22 passed, 0 failed
- `cargo clippy -- -D warnings` — clean
- `cora review` (pre-commit) — No issues found
- Manual: `cora config validate --config /tmp/test.yaml` correctly reads custom config (Model: test-model-from-config vs default glm-5.2)