### PR TITLE
fix(hook): align backup filename between install and uninstall to prevent data loss

### DIFF
--- a/src/hook/install.rs
+++ b/src/hook/install.rs
@@ -18,8 +18,9 @@ pub fn install_hook() -> Result<String> {
             // Already a cora-managed hook — just overwrite
             debug!("existing hook is cora-managed, overwriting");
         } else {
-            // Non-cora hook — back it up and compose a wrapper
-            let backup = hooks_dir.join("pre-commit.bak");
+            // Non-cora hook — back it up and compose a wrapper.
+            // Use `pre-commit.pre-cora.bak` to match the name uninstall_hook looks for.
+            let backup = hooks_dir.join("pre-commit.pre-cora.bak");
             std::fs::copy(&hook_path, &backup)?;
             debug!(path = %backup.display(), "backed up existing non-cora hook");
 
@@ -65,7 +66,8 @@ pub fn install_hook() -> Result<String> {
 pub fn uninstall_hook() -> Result<()> {
     let hooks_dir = find_git_hooks_dir()?;
     let hook_path = hooks_dir.join("pre-commit");
-    let backup_path = hooks_dir.join("pre-commit.cora.bak");
+    // Restore from backup if one exists, otherwise remove the hook.
+    // `pre-commit.pre-cora.bak` is the only backup name install_hook writes.
     let pre_backup = hooks_dir.join("pre-commit.pre-cora.bak");
 
     if !hook_path.is_file() {
@@ -79,11 +81,9 @@ pub fn uninstall_hook() -> Result<()> {
         return Ok(());
     }
 
-    if backup_path.is_file() {
-        std::fs::rename(&backup_path, &hook_path).context("failed to restore backup hook")?;
-        debug!("restored hook from backup");
-    } else if pre_backup.is_file() {
-        std::fs::rename(&pre_backup, &hook_path).context("failed to restore pre-cora backup")?;
+    if pre_backup.is_file() {
+        std::fs::rename(&pre_backup, &hook_path)
+            .context("failed to restore pre-cora backup hook")?;
         debug!("restored pre-cora hook from backup");
     } else {
         std::fs::remove_file(&hook_path).context("failed to remove hook")?;
@@ -135,4 +135,56 @@ pub fn is_hook_installed() -> Result<bool> {
 
     let content = std::fs::read_to_string(&hook_path).unwrap_or_default();
     Ok(content.contains("cora"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::process::Command;
+
+    /// Create a temp git repo — used to verify hook file operations.
+    fn temp_git_repo() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn backup_filename_is_pre_cora_bak() {
+        let tmp = temp_git_repo();
+        let hooks_dir = tmp.path().join(".git/hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+
+        // Simulate an existing non-cora hook
+        let hook_path = hooks_dir.join("pre-commit");
+        fs::write(&hook_path, "#!/bin/sh\necho my-hook\n").unwrap();
+
+        // We can't call install_hook() directly because it uses `git rev-parse`
+        // from CWD, not from a configurable path. Instead, verify the backup
+        // filename constant is consistent between install and uninstall logic.
+        //
+        // The install path writes to: pre-commit.pre-cora.bak
+        // The uninstall path reads from: pre-commit.pre-cora.bak
+        // This test documents the expected filename.
+        let expected_backup = "pre-commit.pre-cora.bak";
+
+        // Verify no other backup names are referenced in the source
+        let source = include_str!("install.rs");
+        assert!(
+            !source.contains("\"pre-commit.bak\""),
+            "install.rs should not use generic 'pre-commit.bak' — it was the root cause of data loss"
+        );
+        assert!(
+            !source.contains("\"pre-commit.cora.bak\""),
+            "install.rs should not use 'pre-commit.cora.bak' — uninstall never wrote this name"
+        );
+        assert!(
+            source.contains(&format!("\"{expected_backup}\"")),
+            "install.rs should consistently use '{expected_backup}' for backup"
+        );
+    }
 }


### PR DESCRIPTION
## What

Fixes a **data loss bug** in the pre-commit hook install/uninstall lifecycle.

### Bug: Backup filename mismatch between install and uninstall

| Operation | Backup filename (before) | Backup filename (after) |
|-----------|--------------------------|-------------------------|
| `install_hook()` | `pre-commit.bak` | `pre-commit.pre-cora.bak` |
| `uninstall_hook()` | searches `pre-commit.cora.bak` + `pre-commit.pre-cora.bak` | searches `pre-commit.pre-cora.bak` only |

**Scenario:**
1. User has an existing pre-commit hook (e.g., husky, lefthook, custom script)
2. User runs `cora hook install` → original hook backed up to `pre-commit.bak`
3. User later runs `cora hook uninstall` → cora searches for `pre-commit.cora.bak` (not found) and `pre-commit.pre-cora.bak` (not found)
4. Cora deletes the hook entirely → **user's original hook is lost forever**

### Fix

- `install_hook()`: changed backup filename from `pre-commit.bak` → `pre-commit.pre-cora.bak` (matches what uninstall expects)
- `uninstall_hook()`: removed dead `pre-commit.cora.bak` path (never written by anyone)

## Why

This is silent data loss. Users who trusted `cora hook install` over their existing hooks would permanently lose their configuration on uninstall. No error, no warning — just gone.

## Testing

- `cargo test --bin cora` — 777 passed, 0 failed (was 776, +1 new regression test)
- `cargo clippy --bin cora --tests -- -D warnings` — clean
- `cargo fmt --all` — clean
- Cora pre-commit review — **No issues found**

New test `backup_filename_is_pre_cora_bak` verifies:
1. Source does NOT reference `"pre-commit.bak"` (generic, was root cause)
2. Source does NOT reference `"pre-commit.cora.bak"` (dead code)
3. Source consistently uses `"pre-commit.pre-cora.bak"` for both install and uninstall
