### PR TITLE
fix(findings): use parameterized queries to prevent SQL injection in list

### DIFF
--- a/src/commands/findings.rs
+++ b/src/commands/findings.rs
@@ -120,27 +120,33 @@ fn list_findings(
         JOIN reviews r ON f.review_id = r.id",
     );
 
-    let mut wheres: Vec<String> = Vec::new();
+    // Build WHERE clause with parameterized placeholders to prevent SQL injection.
+    let mut wheres: Vec<&str> = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
     if !all {
-        wheres.push("f.status = 'open'".to_string());
+        wheres.push("f.status = 'open'");
     }
     if let Some(s) = severity {
-        wheres.push(format!("f.severity = '{}'", s.to_uppercase()));
+        wheres.push("f.severity = ?");
+        params.push(Box::new(s.to_uppercase()));
     }
     if let Some(f) = file {
-        wheres.push(format!("f.file_path LIKE '%{}%'", f.replace('"', "'")));
+        wheres.push("f.file_path LIKE ?");
+        params.push(Box::new(format!("%{f}%")));
     }
 
     if !wheres.is_empty() {
         sql.push_str(" WHERE ");
         sql.push_str(&wheres.join(" AND "));
     }
-    sql.push_str(" ORDER BY f.id DESC");
-    sql.push_str(&format!(" LIMIT {}", limit));
+    sql.push_str(" ORDER BY f.id DESC LIMIT ?");
+    params.push(Box::new(limit as i64));
 
+    let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows: Vec<ListRow> = stmt
-        .query([])?
+        .query(param_refs.as_slice())?
         .mapped(|r| {
             Ok(ListRow {
                 id: r.get(0)?,

--- a/src/data_dir.rs
+++ b/src/data_dir.rs
@@ -71,21 +71,37 @@ pub fn ensure_data_dir() -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Ensure tests that mutate CODECORA_HOME don't run concurrently.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_codecora_home_returns_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = codecora_home();
         assert!(path.ends_with(".codecora"));
     }
 
     #[test]
     fn test_product_data_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = product_data_dir("cora-code");
         assert!(path.ends_with(".codecora/cora-code"));
     }
 
     #[test]
     fn test_graph_db_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = graph_db_path();
         assert!(
             path.ends_with(".codecora/cora-code/cora.db")
@@ -96,6 +112,10 @@ mod tests {
 
     #[test]
     fn test_cora_data_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = cora_data_dir();
         assert!(path.ends_with(".codecora/cora-code"));
         // Should not have trailing slash
@@ -105,6 +125,7 @@ mod tests {
 
     #[test]
     fn test_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var(CODECORA_HOME_ENV, "/tmp/test-codecora");
         }


### PR DESCRIPTION
## What

Fixes **SQL injection vulnerabilities** in `cora findings list` command.

### Vulnerable code (before)

Two filters interpolated user input directly into SQL via `format!()`:

```rust
// --severity flag
format!("f.severity = '{}'", s.to_uppercase())

// --file flag
format!("f.file_path LIKE '%{}%'", f.replace('"', "'"))
```

The `f.replace('"', "'")` only escaped double-quotes — **not single-quotes**,
which are the SQL string delimiter. This made it completely ineffective.

### Attack vectors

| Flag | Input | Resulting SQL |
|------|-------|---------------|
| `--severity` | `critical' OR 1=1 --` | `WHERE f.severity = 'CRITICAL' OR 1=1 --'` |
| `--file` | `'; DROP TABLE findings; --` | `LIKE '%'; DROP TABLE findings; --%'` |

### Fix

Use `?` placeholders + `rusqlite::params!` — the same pattern already used
by `dismiss()` and `reopen()` in the same file.

## Why

Cora is a security tool. Shipping SQL injection in its own CLI undermines
credibility. While exploitability requires local access, this is a
**defense-in-depth** issue and a **best-practice violation**.

## Testing

- `cargo test --bin cora` — 782 pass, 0 fail
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --all` — clean
- Manual: `cora findings list --severity "critical' OR 1=1 --"` now returns
  empty results (no matching severity) instead of leaking all findings
