### PR TITLE
fix(rules): narrow sql-concat, debug-enabled, hardcoded-role patterns

### DIFF
--- a/src/engine/rules/builtin.rs
+++ b/src/engine/rules/builtin.rs
@@ -133,6 +133,8 @@ pub fn post_match_filter(rule_id: &str, line: &str) -> bool {
         "sec-hardcoded-secret" | "crypto/hardcoded-secret" => is_false_positive_secret(line),
         "sec-hardcoded-url" => is_false_positive_url(line),
         "config/cors-wildcard" => is_false_positive_cors(line),
+        "injection/sql-concat" => is_false_positive_sql_concat(line),
+        "config/debug-enabled" => is_false_positive_debug(line),
         _ => false,
     }
 }
@@ -243,6 +245,69 @@ fn is_false_positive_secret(line: &str) -> bool {
                 return true;
             }
         }
+    }
+
+    false
+}
+
+/// Check if a `sql-concat` match is a false positive.
+///
+/// Suppresses: comment lines, string literal descriptions, and lines where
+/// the "+" is not actually string concatenation (e.g., arithmetic).
+fn is_false_positive_sql_concat(line: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Comment lines — SQL keywords in comments are not injection
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("--")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+    {
+        return true;
+    }
+
+    // Python/Rust docstrings
+    if trimmed.contains("\"\"\"") || trimmed.contains("'''") {
+        return true;
+    }
+
+    false
+}
+
+/// Check if a `debug-enabled` match is a false positive.
+///
+/// Suppresses: comment lines documenting debug config, argument parser
+/// definitions, and environment variable references.
+fn is_false_positive_debug(line: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Comment lines
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("--")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+    {
+        return true;
+    }
+
+    // Argument parser definitions (Python argparse, JS commander, etc.)
+    let lower = line.to_lowercase();
+    if lower.contains("add_argument")
+        || lower.contains("addoption")
+        || lower.contains("argument(")
+        || lower.contains(".option(")
+        || lower.contains("parser.")
+    {
+        return true;
+    }
+
+    // Environment variable references (DEBUG from env, not hardcoded)
+    if lower.contains("env")
+        && (lower.contains("getenv") || lower.contains("environ") || lower.contains("from_env"))
+    {
+        return true;
     }
 
     false

--- a/src/engine/security_scanner.rs
+++ b/src/engine/security_scanner.rs
@@ -52,7 +52,10 @@ pub static PATTERNS: &[SecurityPattern] = &[
     SecurityPattern {
         id: "injection/sql-concat",
         name: "SQL injection via string concatenation",
-        regex: r"(?i)(?:SELECT|INSERT|UPDATE|DELETE)\s+.*\+",
+        // Require a SQL keyword inside a string literal, followed by concatenation.
+        // This prevents matching comments, prose, and non-SQL code that happens
+        // to contain SQL keywords + "+".
+        regex: r#"(?i)(?:(?:SELECT|INSERT|UPDATE|DELETE)\b[^"\']*["\x27`][^"\']*\+|format!\s*\(\s*["\x27`]\s*(?:SELECT|INSERT|UPDATE|DELETE))"#,
         severity: Severity::Critical,
     },
     SecurityPattern {
@@ -74,14 +77,19 @@ pub static PATTERNS: &[SecurityPattern] = &[
     SecurityPattern {
         id: "auth/hardcoded-role",
         name: "Hardcoded role or permission check",
-        regex: r"(?i)role\s*==\s*(?:admin|super|root)|is_admin\s*==\s*True",
+        // Match both quoted and unquoted role comparisons, property access
+        // (user.role), and strict equality (===) for JS/TS.
+        regex: r#"(?i)(?:\w+\.)*role\s*[=]{2,3}\s*["']?(?:admin|super|root|superuser)["']?|is_admin\s*==\s*True"#,
         severity: Severity::Major,
     },
     // ── Debug config ──
     SecurityPattern {
         id: "config/debug-enabled",
         name: "Debug mode enabled (production risk)",
-        regex: r"(?i)(?:DEBUG\s*=\s*True|debug:\s*true|--debug)",
+        // Only match actual config assignments, not CLI flag references.
+        // `--debug` is removed — it matches dev tooling, argument parsers,
+        // Dockerfiles, and documentation (too many false positives).
+        regex: r#"(?i)(?:DEBUG\s*=\s*True|debug\s*:\s*true|debug\s*=\s*true)"#,
         severity: Severity::Minor,
     },
     SecurityPattern {
@@ -827,5 +835,221 @@ mod tests {
         assert!(!is_doc_file("Dockerfile"));
         assert!(!is_doc_file("docker-compose.yml"));
         assert!(!is_doc_file("Makefile"));
+    }
+
+    // ── #485: sql-concat false positive tests ──
+
+    #[test]
+    fn sql_concat_real_injection_still_detected() {
+        let chunks = vec![make_chunk(
+            "src/db.py",
+            &["query = \"SELECT * FROM users WHERE id = \" + user_input"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "real SQL concat must be detected");
+        assert!(findings[0].rule_id.contains("sql"));
+    }
+
+    #[test]
+    fn sql_concat_format_macro_detected() {
+        let chunks = vec![make_chunk(
+            "src/db.rs",
+            &["let q = format!(\"SELECT * FROM users WHERE id = {}\", id);"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "format! with SELECT must be detected");
+    }
+
+    #[test]
+    fn sql_concat_comment_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/db.py",
+            &["// SELECT all users then concatenate results"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let sql_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("sql"))
+            .collect();
+        assert!(
+            sql_findings.is_empty(),
+            "comment with SQL keyword + '+' should not be flagged"
+        );
+    }
+
+    #[test]
+    fn sql_concat_python_comment_not_flagged() {
+        let chunks = vec![make_chunk("src/db.py", &["# SELECT a + b FROM joined"])];
+        let findings = scan_security(&chunks, 10);
+        let sql_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("sql"))
+            .collect();
+        assert!(sql_findings.is_empty());
+    }
+
+    #[test]
+    fn sql_concat_non_sql_plus_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/calc.rs",
+            &["let total = a + b; // UPDATE: not SQL"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let sql_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("sql"))
+            .collect();
+        assert!(sql_findings.is_empty());
+    }
+
+    // ── #486: debug-enabled false positive tests ──
+
+    #[test]
+    fn debug_real_assignment_still_detected() {
+        let chunks = vec![make_chunk("src/config.py", &["DEBUG = True"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "DEBUG = True must be detected");
+        assert!(findings[0].rule_id.contains("debug"));
+    }
+
+    #[test]
+    fn debug_yaml_true_still_detected() {
+        let chunks = vec![make_chunk("src/config.yml", &["debug: true"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "debug: true must be detected");
+    }
+
+    #[test]
+    fn debug_cli_flag_not_flagged() {
+        let chunks = vec![make_chunk(
+            "Dockerfile",
+            &["RUN cargo test -- --debug 2>/dev/null"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let debug_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("debug"))
+            .collect();
+        assert!(
+            debug_findings.is_empty(),
+            "--debug CLI flag should not be flagged"
+        );
+    }
+
+    #[test]
+    fn debug_argument_parser_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/cli.py",
+            &["parser.add_argument('--debug', help='Enable debug mode')"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let debug_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("debug"))
+            .collect();
+        assert!(
+            debug_findings.is_empty(),
+            "argument parser definition should not be flagged"
+        );
+    }
+
+    #[test]
+    fn debug_comment_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/config.py",
+            &["# Use --debug for verbose output"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let debug_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("debug"))
+            .collect();
+        assert!(debug_findings.is_empty());
+    }
+
+    // ── #490: hardcoded-role quoted pattern tests ──
+
+    #[test]
+    fn hardcoded_role_unquoted_still_detected() {
+        let chunks = vec![make_chunk("src/auth.rb", &["if role == admin"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "unquoted role check must be detected");
+        assert!(findings[0].rule_id.contains("role"));
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_double_quotes_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.js",
+            &["if (role == \"admin\") return true;"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "quoted role == \"admin\" must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_single_quotes_detected() {
+        let chunks = vec![make_chunk("src/auth.py", &["if role == 'admin':"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "quoted role == 'admin' must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_strict_equality_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.ts",
+            &["if (role === \"admin\") return true;"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "strict equality role === must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_property_access_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.js",
+            &["if (user.role == \"admin\") return true;"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "user.role == \"admin\" must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_super_detected() {
+        let chunks = vec![make_chunk("src/auth.py", &["if role == \"super\":"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "role == \"super\" must be detected");
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_root_detected() {
+        let chunks = vec![make_chunk("src/auth.py", &["if role == 'root':"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "role == 'root' must be detected");
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_superuser_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.ts",
+            &["if (user.role === \"superuser\") grant_all();"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "role === \"superuser\" must be detected"
+        );
     }
 }


### PR DESCRIPTION
## What

Three security scanner rules produced false positives or false negatives due to overly broad or overly narrow regex patterns. This PR narrows and adds post-match filters for each, following the same 3-layer defense approach established in #484.

## Why

**#485 — `injection/sql-concat`** flagged comments, prose, and non-SQL concatenation. The old regex `(?i)(?:SELECT|INSERT|UPDATE|DELETE)\s+.*\+` matched any SQL keyword followed by `+` anywhere — including `// SELECT a + b` and `let total = a + b; // UPDATE: not SQL`.

**#486 — `config/debug-enabled`** flagged CLI flags, argument parser definitions, and Dockerfile RUN commands. The old regex included `--debug` which is a CLI convention, not a config assignment.

**#490 — `auth/hardcoded-role`** missed the most common real-world pattern: quoted role comparisons. The old regex only matched bareword `role == admin` (rare outside Ruby/PHP), missing `role == "admin"` (JS, TS, Python, Go), `user.role === "admin"` (property access + strict equality), and `"superuser"`.

Closes #485, closes #486, closes #490.

## How

**`injection/sql-concat` (`security_scanner.rs`):**
- Narrowed regex to require SQL keyword inside a string literal before matching `+`
- Added `format!("SELECT ...")` pattern for Rust format macros
- Added `is_false_positive_sql_concat()` post-match filter: suppresses comment lines (`//`, `#`, `--`, `/*`, `*`) and docstrings

**`config/debug-enabled` (`security_scanner.rs`):**
- Removed `--debug` from regex — too many false positives in dev tooling
- Kept `DEBUG = True`, `debug: true`, added `debug = true`
- Added `is_false_positive_debug()` post-match filter: suppresses comment lines, argument parser definitions (`add_argument`, `.option(`, `parser.`), and env var references

**`auth/hardcoded-role` (`security_scanner.rs`):**
- Rewrote regex to accept optional quotes (`["']?`), strict equality (`[=]{2,3}`), property access (`(?:\w+\.)*role`), and `superuser`
- Now covers: `role == "admin"`, `user.role === 'super'`, `if role === "superuser"`, etc.

## Testing

- [x] `cargo test --features tree-sitter` passes — 854 tests, 0 failures (18 new tests added)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --features tree-sitter -- -D warnings` passes
- [x] `cargo build --release --features tree-sitter` passes
- [x] Manual verification: each false positive example from issues #485, #486, #490 confirmed suppressed; each true positive confirmed still detected

New test coverage:
- 5 sql-concat tests (real injection, format! macro, 3 false positive cases)
- 5 debug-enabled tests (real assignment, YAML config, CLI flag, argument parser, comment)
- 8 hardcoded-role tests (unquoted, double/single quotes, strict equality, property access, super/root/superuser)

## Related Issues

Closes #485, closes #486, closes #490
Part of epic #487

## Checklist

- [x] Branch name follows convention (`fix/`)
- [x] Branch is from `develop`
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials committed
- [x] One logical change per PR (security scanner rule fixes from #485 + #486 + #490)