### PR TITLE
fix(watch): use global index DB with schema migrations

### DIFF
--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -33,12 +33,7 @@ pub fn run_watch(
     filter: Option<&str>,
     verbose: bool,
 ) -> Result<()> {
-    let db_path = project_root.join(".cora/index.db");
-    if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-    let conn = rusqlite::Connection::open(&db_path)
-        .with_context(|| format!("Failed to open index database at {}", db_path.display()))?;
+    let conn = crate::index::open_global_index()?;
     // Load skip patterns from config
     let skip_patterns: Option<Vec<String>> =
         crate::config::loader::load_config(config_path, None, None, None, None, false)
@@ -131,7 +126,10 @@ fn detect_changes(
     glob_matcher: Option<&glob::Pattern>,
 ) -> Result<Vec<PathBuf>> {
     let mut changed = Vec::new();
-    let extensions: &[&str] = &["rs", "py", "js", "ts", "go", "java", "c", "cpp", "h", "rb"];
+    let extensions: &[&str] = &[
+        "rs", "py", "js", "ts", "go", "java", "c", "cpp", "h", "rb", "php", "scala", "cs", "kt",
+        "svelte", "jsx", "tsx",
+    ];
 
     let mut walker = |path: &Path| {
         // Skip files inside hidden directories (relative to project root)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1511,6 +1511,7 @@ async fn main() -> Result<()> {
             filter,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let config_path = cli.global.config.as_deref();
             commands::watch::run_watch(
                 &project_root,


### PR DESCRIPTION
## What

Fix `cora watch` crash on projects without prior index (`no such table: projects`).

## Why

`cora watch` opened a **project-local** SQLite database at `.cora/index.db` instead of the **global** database at `~/.codecora/cora-code/cora.db`. The project-local DB never had `run_migrations()` called, so the `projects` table (and all other schema) was missing.

Every other command (`index`, `explore`, `callers`, `dead-code`, etc.) uses `index::open_global_index()` which calls `schema::run_migrations()`. `cora watch` was the only command that bypassed this.

## How

1. **Replace project-local DB with global DB**: `Connection::open(project_root.join(".cora/index.db"))` → `index::open_global_index()`
2. **Resolve project root**: Add `index::resolve_project_root()` in `main.rs` for consistency with `cora index` and other commands
3. **Expand extension filter**: Add `php`, `scala`, `cs`, `kt`, `svelte`, `jsx`, `tsx` to `detect_changes()` extension list to match all tree-sitter supported languages

## Testing

- [x] `cargo test --features tree-sitter` — 903 tests, 0 failures
- [x] `cargo clippy --all-targets --features tree-sitter -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] Manual test: `cora watch` on Uteke (Rust, 410 symbols/34 files) — no crash
- [x] Manual test: `cora watch` on Corin (Tauri/Svelte/TS) — no crash

## Related Issues

Discovered during pre-release validation of v0.13.0.

## Checklist

- [x] Code follows project conventions (CONTRIBUTING.md)
- [x] No emojis in commit messages
- [x] Conventional Commits format
- [x] Tests pass locally
- [x] Clippy + fmt clean