### PR TITLE
release: sync develop → main for v0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ dist/
 *.zip
 .cora/history/
 .cora/index.db
+.commit-msg.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+
+### Added
+
+- **Runtime embedding backend selection.** Brain Mode now reads `brain.embedding` from `.cora.yaml` to select the embedding backend at runtime instead of compile time. Supported values: `auto` (best available — default), `hashing` (force 256d zero-dependency), `pretrained` (force 768d nomic). No recompilation needed to switch.
+- **Incremental per-symbol embedding.** `embed_project()` now tracks an `embed_fingerprint` (hash of symbol name + signature) and skips re-embedding symbols that have not changed since the last index. On large projects, re-indexing after touching one file embeds only the changed symbols instead of all.
+- **Schema migration v7.** Adds `embed_fingerprint TEXT` column to the `symbols` table for incremental embedding tracking. Auto-migrates on first run; existing indexes are upgraded transparently.
+- **`Backend` enum + `resolve_backend()` in `embed` module.** Clean runtime dispatch with `OnceLock` caching, graceful fallback when a requested backend is not compiled, and `active_dims()` / `active_provider_name()` helpers.
+- **`BrainConfig` + `BrainEmbeddingMode` in config schema.** New `brain` section in `.cora.yaml` with `embedding` field. Includes `Display`, `FromStr`, and `serde` impls for CLI and YAML ergonomics.
+
+### Changed
+
+- **`embed_code_dispatch()` now checks `ACTIVE_BACKEND` at runtime.** Previously selected via `#[cfg]` at compile time only. Falls back to compile-time default if `resolve_backend()` was never called (lazy resolution).
+- **`cora index`, `cora brain`, `cora watch` all resolve embedding backend on startup.** Each command loads `.cora.yaml`, reads `brain.embedding`, and calls `resolve_backend()` before touching the vector index.
+- **Embedding doc comments updated.** Module-level docs now describe runtime selection and the three-tier architecture (hashing → pretrained → ONNX future).
+
 ## [0.12.0]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "cora-code"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-code"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - 🧠 **Brain Mode** — hybrid semantic search (FTS5 + vector KNN + graph) with RRF fusion
 - 🗄️ **Multi-project database** — one global index, search across all your repos at once
 - 🌳 **Tree-sitter** (opt-in) — AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, **Svelte** (via TypeScript delegation, zero extra dependency)
-- 🔌 **MCP server** — 15 tools for AI coding agents (review, search, brain, debt, trace, ...)
+- 🔌 **MCP server** — 18 tools for AI coding agents (review, search, brain, debt, trace, dead code, graph query, ...)
 - 💾 **Diff-hash caching** — skip repeat reviews automatically
 - 🔧 **Configurable** — per-project `.cora.yaml`, global `~/.cora/config.yaml`, or env vars
 
@@ -195,6 +195,9 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora callers` | Find all callers of a symbol |
 | `cora impact` | Analyze blast radius of changing a symbol |
 | `cora affected` | Find tests impacted by changed files |
+| `cora dead-code` | Detect dead code — functions with zero callers |
+| `cora query` | Query the code graph (e.g. `"main -> *"`) |
+| `cora routes` | List detected HTTP routes (Axum, Actix, Express, FastAPI, Flask, Go) |
 
 ### Config & Setup
 
@@ -203,8 +206,12 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora init` | Create project config + hook |
 | `cora auth login` | Save API key |
 | `cora config show` | Show resolved config |
+| `cora config validate` | Validate configuration |
 | `cora providers` | List available LLM providers |
-| `cora mcp` | Start MCP server (15 tools) for AI coding agents |
+| `cora profile list` | List quality profiles (strict, balanced, lax) |
+| `cora mcp` | Start MCP server (18 tools) for AI coding agents |
+| `cora serve` | Start MCP server + auto-reindex on startup |
+| `cora install` | Auto-detect and configure AI coding agents |
 | `cora hook install` | Install pre-commit hook |
 
 See **[CLI Reference →](https://codecora.dev/cora/docs/cli-reference)** for all flags and examples.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -21,37 +21,134 @@ Complete command reference for the cora CLI.
 
 ## Commands
 
+### Setup & Config
+
 | Command | Description |
 |---------|-------------|
-| `cora init` | Create `.cora.yaml` config file |
-| `cora commit` | Review staged + generate commit message + commit (HITL prompt) |
-| `cora commit --yolo` | Auto-commit without prompts (YOLO mode) |
-| `cora commit --force` | Commit even if quality gate fails |
-| `cora commit --no-review` | Skip review, only generate commit message |
-| `cora commit --edit` | Always open `$EDITOR` to edit message |
-| `cora review` | Review code changes (default: staged files) |
-| `cora review --staged` | Review staged git changes explicitly |
+| `cora init` | Create `.cora.yaml` config file and install pre-commit hook |
+| `cora init --force` | Overwrite existing config file |
+| `cora init --no-hook` | Skip pre-commit hook installation |
+| `cora config show` | Show resolved configuration |
+| `cora config show --global` | Show global config (`~/.cora/config.yaml`) |
+| `cora config show --project` | Show project config (`.cora.yaml`) |
+| `cora config set` `<key>` `<value>` | Set a config value |
+| `cora config set` `<key>` `<value>` `--global` | Write to global config instead of project |
+| `cora config validate` | Validate configuration and report status |
+| `cora auth login` | Save API key interactively |
+| `cora auth login --provider` `<name>` `--api-key` `<key>` | Non-interactive login |
+| `cora auth login --model` `<model>` | Set model with provider |
+| `cora auth login --base-url` `<url>` | Custom API endpoint |
+| `cora auth login --force` | Overwrite existing key without confirmation |
+| `cora auth status` | Check current auth status |
+| `cora auth remove` | Remove stored API key |
+| `cora providers` | List detected AI providers |
+| `cora install` | Auto-detect and configure AI coding agents for Cora MCP |
+| `cora install --list` | List detected agents without installing |
+| `cora install --agents` `"cline,cursor"` | Install specific agents |
+| `cora install --dry-run` | Show what would be changed |
+| `cora install --force` | Overwrite existing cora entry |
+| `cora install --yes` | Install ALL detected agents (non-interactive) |
+| `cora hook install` | Install pre-commit hook |
+| `cora hook uninstall` | Remove pre-commit hook |
+| `cora completion` `<shell>` | Generate shell completions (bash/zsh/fish/powershell) |
+
+### Review & Scan
+
+| Command | Description |
+|---------|-------------|
+| `cora review` | Review code changes (default: tries staged, then unpushed) |
+| `cora review --staged` | Review staged git changes |
 | `cora review --unstaged` | Review unstaged working changes |
 | `cora review --unpushed` | Review unpushed commits |
 | `cora review --base` `<branch>` | Compare current branch against target |
 | `cora review --commit` `<ref>` | Review specific commit or range |
 | `cora review --diff-file` `<path>` | Review from a diff file |
 | `cora review --upload` | Review and upload SARIF to GitHub Code Scanning |
-| `cora scan` `<path>` | Scan files for issues |
-| `cora scan .` `[--incremental]` | Scan only changed files |
-| `cora scan .` `[--batch-files N]` | Max files per LLM batch (default: 20). Lower to work around provider token limits |
-| `cora scan .` `[--no-continue-on-batch-error]` | Abort the scan when a batch fails to parse (default: skip and continue) |
-| `cora config show` | Show resolved configuration |
-| `cora config show --global` | Show global config (`~/.cora/config.yaml`) |
-| `cora config show --project` | Show project config (`.cora.yaml`) |
-| `cora config set` `<key>` `<value>` | Set a config value |
-| `cora hook install` | Install pre-commit hook |
-| `cora hook uninstall` | Remove pre-commit hook |
-| `cora auth login` | Save API key to `~/.cora/auth.toml` |
-| `cora auth status` | Check current auth status |
-| `cora auth remove` | Remove stored API key |
-| `cora providers` | List detected AI providers |
-| `cora upload-sarif` `<file>` | Upload SARIF to GitHub Code Scanning |
+| `cora review --no-auto-chunk` | Disable auto-chunking for large diffs |
+| `cora review --progress` | Output NDJSON progress events to stderr |
+| `cora review --quiet` | Suppress all output except result |
+| `cora review --output-file` `<path>` | Write output to file instead of stdout |
+| `cora review --severity` `<level>` | Filter by min severity (info/minor/major/critical) |
+| `cora review --no-cache` | Disable review caching |
+| `cora review --ci` | CI mode: skip diff size limit, exit 2 if any findings |
+| `cora review --max-diff-size` `<chars>` | Override max diff size |
+| `cora review --memory` | Recall project patterns from Uteke before review |
+| `cora review --learn` | Save findings to Uteke after review (implies `--memory`) |
+| `cora commit` | Review staged + generate commit message + commit (HITL prompt) |
+| `cora commit --yolo` | Auto-commit without prompts |
+| `cora commit --force` | Commit even if quality gate fails |
+| `cora commit --no-review` | Skip review, only generate commit message |
+| `cora commit --edit` | Always open `$EDITOR` to edit message |
+| `cora commit --stream` | Stream LLM response in real-time |
+| `cora commit --quiet` | Suppress all output except result |
+| `cora scan` `[--path <dir>]` | Scan files for issues (default: current directory) |
+| `cora scan --include` `"src/**/*.rs"` | Include glob patterns |
+| `cora scan --exclude` `"vendor/**"` | Exclude glob patterns |
+| `cora scan --extensions` `"ts,js"` | Additional file extensions to scan |
+| `cora scan --incremental` | Scan only files changed since last scan |
+| `cora scan --focus` `security` | Override focus areas |
+| `cora scan --batch-files` `N` | Max files per LLM batch (default: 20) |
+| `cora scan --no-continue-on-batch-error` | Abort on batch failure (default: skip and continue) |
+
+### Code Intelligence
+
+See [Code Intelligence](./code-intelligence) for detailed usage.
+
+| Command | Description |
+|---------|-------------|
+| `cora index` | Index project symbols into SQLite + usearch |
+| `cora index --rebuild` | Rebuild index from scratch |
+| `cora index --watch` | Auto-sync file watcher (2s poll interval) |
+| `cora index --stats` | Show index statistics (symbol count, languages, DB size) |
+| `cora index --prune` | Remove stale entries for deleted files |
+| `cora explore` `<query>` | Keyword search (FTS5) over symbol names |
+| `cora explore --kind` `function` | Filter by symbol kind |
+| `cora explore --file` `"src/"` | Filter by file path prefix |
+| `cora explore --language` `rust` | Filter by language |
+| `cora explore --limit` `N` | Max results (default: 50) |
+| `cora brain` `<query>` | Hybrid search: FTS5 + vector + graph → RRF fusion |
+| `cora brain --limit N` | Max results (default: 20) |
+| `cora callers` `<symbol>` | Find all callers of a symbol (reverse call graph) |
+| `cora callers --limit N` | Max callers to return (default: 50) |
+| `cora impact` `<symbol>` | Analyze blast radius of changing a symbol |
+| `cora impact --depth N` | Traversal depth (default: 3) |
+| `cora trace` `<symbol>` | Trace call chains (depth-limited BFS) |
+| `cora trace --direction incoming` | Trace callers instead of callees |
+| `cora trace --depth N` | Max hops (default: 3) |
+| `cora arch` | Architecture overview — modules, edge types, top connectors |
+| `cora affected` `<files...>` | Find test files affected by source changes |
+| `cora affected --stdin` | Read changed files from stdin (pipe from `git diff --name-only`) |
+| `cora affected --filter` `"*test*"` | Custom test file glob pattern |
+| `cora dead-code` | Detect dead code — functions/methods with zero callers |
+| `cora dead-code --include-tests` | Include test functions in results |
+| `cora dead-code --min-lines N` | Filter out tiny functions |
+| `cora query` `"main -> *"` | Query the code graph with simple patterns |
+| `cora query --limit N` | Max results (default: 50) |
+| `cora routes` | List detected HTTP routes (Axum, Actix, Express, FastAPI, Flask, Go) |
+| `cora routes --method GET` | Filter by HTTP method |
+| `cora routes --prefix /api` | Filter by path prefix |
+
+### Quality Profiles
+
+| Command | Description |
+|---------|-------------|
+| `cora profile list` | List available quality profiles |
+| `cora profile show` `<name>` | Show details of a specific profile |
+| `cora profile validate` `<path>` | Validate a custom profile YAML file |
+
+### Findings & Debt
+
+| Command | Description |
+|---------|-------------|
+| `cora findings list` | Show open findings |
+| `cora findings list --all` | Show all findings including resolved |
+| `cora findings list --severity major` | Filter by severity |
+| `cora findings list --file "src/main.rs"` | Filter by file |
+| `cora findings list --json` | JSON output |
+| `cora findings stats` | Summary counts with resolution rate |
+| `cora findings dismiss <id>` | Mark finding as won't-fix |
+| `cora findings dismiss <id> --reason "..."` | Dismiss with reason |
+| `cora findings reopen <id>` | Reopen a dismissed/resolved finding |
 | `cora debt` | Show tech debt report from review history |
 | `cora debt --json` | Debt report as JSON (for CI/dashboards) |
 | `cora debt --trend` | Quality score trend graph |
@@ -59,27 +156,14 @@ Complete command reference for the cora CLI.
 | `cora debt --estimate` | Show estimated fix time |
 | `cora debt --since v0.4.5` | Filter by git tag or date |
 | `cora debt --branch main` | Filter by branch |
-| `cora findings list` | Show open findings (use `--all`, `--severity`, `--file`, `--json`) |
-| `cora findings stats` | Summary counts with resolution rate (`--json`) |
-| `cora findings dismiss <id>` | Mark finding as won't-fix (optional `--reason`) |
-| `cora findings reopen <id>` | Reopen a dismissed/resolved finding |
-| `cora arch` | Architecture overview — modules, edge types, top connectors |
-| `cora trace` `<symbol>` | Trace call chains from a symbol (depth-limited BFS) |
-| `cora brain` `<query>` | Hybrid search: FTS5 + vector + graph → RRF fusion |
-| `cora brain` `--json` | Brain search as JSON |
-| `cora brain` `--limit N` | Max results (default: 20) |
-| `cora index` | Index project symbols into SQLite + usearch |
-| `cora index --rebuild` | Rebuild index from scratch |
-| `cora index --watch` | Auto-sync file watcher (2s poll interval) |
-| `cora index --stats` | Show index statistics (symbol count, languages, DB size) |
-| `cora index --prune` | Remove stale entries for deleted files |
-| `cora callers` `<symbol>` | Find all callers of a symbol (reverse call graph) |
-| `cora callers` `--limit N` | Max callers to return (default: 50) |
-| `cora impact` `<symbol>` | Analyze blast radius of changing a symbol |
-| `cora impact` `--depth N` | Traversal depth (default: 3) |
-| `cora affected` `<files...>` | Find test files affected by source changes |
-| `cora completion` `<shell>` | Generate shell completions (bash/zsh/fish) |
+| `cora upload-sarif` `<file>` | Upload SARIF to GitHub Code Scanning |
+
+### MCP Server
+
+| Command | Description |
+|---------|-------------|
 | `cora mcp` | Start MCP server for AI coding agents (Claude Code, Cursor, Windsurf) |
+| `cora serve` | Start MCP server with auto-reindex on startup |
 
 ## Quick Examples
 

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -110,7 +110,7 @@ FTS5 full-text search over symbol names and signatures.
 ```bash
 cora explore "authenticate"         # Search by name
 cora explore --kind function        # Filter by symbol kind
-cora explore --lang rust             # Filter by language
+cora explore --language rust        # Filter by language
 cora explore --limit 20              # Max results
 cora explore --json                 # JSON output
 ```
@@ -214,6 +214,43 @@ cora arch --json   # JSON output
 
 Shows: module breakdown, edge types (calls, imports), and top connector symbols.
 
+### `cora dead-code` — Dead Code Detection
+
+Find functions and methods that have zero callers — candidates for removal.
+
+```bash
+cora dead-code                     # Find dead functions
+cora dead-code --include-tests     # Include test functions (test_*, *_test)
+cora dead-code --min-lines 10      # Filter out tiny functions
+cora dead-code --json              # JSON output
+```
+
+> **Tip:** Use `analysis.entry_point_patterns` in `.cora.yaml` to mark entry points (e.g. `*Handler`, `main`) so they're not flagged as dead code.
+
+### `cora query` — Code Graph Query
+
+Query the call graph with simple pattern syntax.
+
+```bash
+cora query "main -> *"             # What does main call?
+cora query "* -> authenticate"     # What calls authenticate?
+cora query "MyStruct"              # Find all edges involving MyStruct
+cora query --limit 100 "main -> *"
+```
+
+Pattern syntax: `source -> target`, where each side can be a symbol name or `*` (wildcard).
+
+### `cora routes` — HTTP Route Listing
+
+List detected HTTP routes from framework annotations. Supports Axum, Actix, Express, FastAPI, Flask, and Go (net/http, gin, echo, chi).
+
+```bash
+cora routes                        # All routes
+cora routes --method GET           # Filter by HTTP method
+cora routes --prefix /api          # Filter by path prefix
+cora routes --json                 # JSON output
+```
+
 ## Test Impact Analysis
 
 ### `cora affected`
@@ -223,8 +260,9 @@ Find tests that are impacted by changed files.
 ```bash
 cora affected                              # From git diff
 cora affected src/auth.rs src/api.rs      # Specific files
-cora affected --test-glob "*test*"         # Custom test file pattern
-cora affected --json                     # JSON output
+cora affected --stdin                      # Pipe from git diff --name-only
+cora affected --filter "*test*"            # Custom test file pattern
+cora affected --json                       # JSON output
 ```
 
 ## MCP Integration
@@ -266,11 +304,13 @@ cora index --rebuild
 
 ## Schema Versioning
 
-The database uses automatic migrations. Current schema version: **v4**.
+The database uses automatic migrations. Current schema version: **v6**.
 
 | Version | Changes |
----------|---------|
+|---------|---------|
 | v1 | Initial symbols table + FTS5 |
 | v2 | Added language column |
 | v3 | Added `edges` table for call graph |
 | v4 | Added `embedding_tier`, `embedding_dims`, `embedding_model`, `last_embedded_at` to projects |
+| v5 | Added `reviews`, `findings`, `finding_events` tables for review history and findings tracking |
+| v6 | Added index config hash column for fingerprint invalidation on config changes |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ provider:
 llm:
   temperature: 0
   max_tokens: 4096
+  max_tokens_param: auto       # auto | max_tokens | max_output_tokens | max_completion_tokens
   timeout: 120
   cache_ttl: 1440
 
@@ -56,6 +57,9 @@ review:
   system_prompt: "You are a senior code reviewer."
   # system_prompt_file: ./review-prompt.md
   response_format: json_object
+  static_analysis:
+    auto_clippy: false       # auto-run `cargo clippy` (Rust only)
+    clippy_output_file: ""   # or read clippy output from file
 
 focus: security, performance, bugs
 
@@ -63,11 +67,37 @@ hook:
   mode: warn
   min_severity: major
   max_diff_size: 51200
+  on_violation: warn           # warn | disallow (blocks commit if violations found)
 
 ignore:
   files:
     - "vendor/**"
-    - "*.min.js"
+    - "*.generated.ts"
+  rules: []                    # rule IDs to skip (e.g. ["no-unwrap", "sql-injection"])
+
+output:
+  format: pretty               # pretty | json | compact | sarif
+  color: true                  # ANSI colors in terminal output
+
+quality_gate:
+  enabled: true
+  thresholds:
+    max_critical: 0
+    max_security: 0
+
+bundling:
+  max_chars_per_group: 12000
+  max_files_per_group: 20
+  strategy: directory        # directory | language
+  coalesce_by_directory: true
+  coalesce_by_language: true
+
+analysis:
+  entry_point_patterns:
+    - "*Handler"
+    - "resolve_*"
+
+profile: clean-code        # security-first | performance | clean-code | beginner-friendly | minimal | rust-strict | typescript-strict | go-pragmatic
 ```
 
 ## Environment Variables
@@ -173,6 +203,9 @@ review:
     follow_depth: 1             # outbound resolution depth (1 = direct refs only)
     include_tests: true         # resolve test files via naming convention
     include_callers: true       # resolve callers of changed code (blast radius)
+    use_brain: true             # enrich prompt with symbol-index intelligence
+    impact_depth: 2             # blast-radius traversal depth (2 = callers of callers)
+    prefer_index: true          # prefer symbol index (FTS5 + call graph) over regex
 ```
 
 | Field | Default | Notes |
@@ -182,6 +215,9 @@ review:
 | `follow_depth` | `1` | Outbound recursion depth (`1` = direct references). |
 | `include_tests` | `true` | Map changed source to its test files. |
 | `include_callers` | `true` | Inbound caller resolution. Scans source files (gitignore-aware — `target/`, `node_modules/` are never scanned), bounded to ≤400 files and ≤3 call-sites per symbol. |
+| `use_brain` | `true` | Enrich prompt with symbol-index intelligence (impact analysis, affected tests, semantic search). Only active when `cora index` has been run. |
+| `impact_depth` | `2` | Blast-radius traversal depth (`1` = direct callers, `2` = callers of callers). |
+| `prefer_index` | `true` | Prefer symbol index (FTS5 + call graph) over regex scanning for outbound resolution. |
 
 ## Quality Gate
 
@@ -345,18 +381,25 @@ No configuration needed — language context is auto-detected from file extensio
 
 ## Quality Profiles
 
-cora includes built-in quality profiles for different review strictness:
+cora includes built-in quality profiles for different review focus:
 
 | Profile | Description |
 |---------|------------|
-| `strict` | All categories enabled, low tolerance for issues |
-| `balanced` | *(default)* Security + bugs + performance, moderate thresholds |
-| `lax` | Only critical issues, high tolerance |
+| `security-first` | Strict security focus — zero tolerance for vulnerabilities |
+| `performance` | Focus on speed, memory, and allocation patterns — best for hot-path code |
+| `clean-code` | *(default)* Broad quality — readability, naming, complexity — best for team projects |
+| `beginner-friendly` | Gentle review — focus on common mistakes and learning opportunities |
+| `minimal` | Only critical + security — best for quick PRs and hotfixes |
+| `rust-strict` | Rust-specific: unsafe, unwrap, panic, lifetime, error handling, idiomatic patterns |
+| `typescript-strict` | TypeScript-specific: any types, null safety, proper typing, async patterns |
+| `go-pragmatic` | Go-specific: error handling, goroutine safety, interface design, idiomatic Go |
+
+Run `cora profile list` to see all profiles. Cora auto-detects the best profile based on your project's primary language (Rust → `rust-strict`, Go → `go-pragmatic`, others → `clean-code`).
 
 Set in `.cora.yaml`:
 
 ```yaml
-profile: strict
+profile: security-first
 ```
 
 ## Custom Rule Engine
@@ -388,7 +431,7 @@ Control how index-based scanners (unused imports, dead code, breaking changes) b
 ```yaml
 rules_engine:
   enabled: true
-  max_findings: 50
+  max_findings: 5
   index_skip_files:
     - "*.config.ts"
     - "vite.config.*"
@@ -404,7 +447,7 @@ rules_engine:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `true` | Enable/disable the rule engine |
-| `max_findings` | `int` | `50` | Max findings per scan |
+| `max_findings` | `int` | `5` | Max findings per scan |
 | `index_skip_files` | `[string]` | *(see below)* | Glob patterns for files to skip during index scanning |
 
 Default `index_skip_files` patterns (bundled with cora):
@@ -417,6 +460,87 @@ Default `index_skip_files` patterns (bundled with cora):
 > **Why skip these?** Entry-point files and bundler configs often import symbols that are consumed by the bundler/compiler, not by other source code. Index scanners detect these as "unused" because there are no code-level references. Skipping them eliminates the most common source of false positives.
 
 Glob patterns support: exact match (`main.rs`), wildcard suffix (`*.config.ts`), wildcard prefix (`vite.*`), and any-directory (`**/main.ts`).
+
+## Ignore Files
+
+Exclude files or directories from **all** cora operations — review, scan, and indexing. This is the broadest exclusion mechanism.
+
+```yaml
+ignore:
+  files:
+    - "vendor/**"
+    - "*.min.js"
+    - "**/generated/**"
+    - "*.lock"
+```
+
+| Pattern | Matches |
+|---------|---------|
+| `src/main.ts` | Exact path — only `src/main.ts` |
+| `*.config.ts` | Suffix wildcard — any file ending in `.config.ts` |
+| `vite.config.*` | Prefix wildcard — `vite.config.js`, `vite.config.ts` |
+| `**/main.ts` | Any-dir name — `src/main.ts`, `app/main.ts`, `a/b/main.ts` |
+| `**/phaser/**` | Any-dir wildcard — any path containing a `phaser/` directory |
+| `src/engine/**` | Prefix-dir — everything under `src/engine/` |
+| `**/*.test.ts` | Double wildcard ext — any `.test.ts` file anywhere |
+
+**Auto-skipped by default** (gitignore-aware): `node_modules/`, `target/`, `.git/`, `dist/`, `build/`.
+
+> **`ignore.files` vs `rules_engine.index_skip_files`:** `ignore.files` excludes files from **everything** (review, scan, index). `rules_engine.index_skip_files` excludes files from **index scanners only** (dead code, unused imports) — they're still reviewed by the LLM.
+
+## Static Analysis
+
+Run language-specific static analysis tools automatically during review and feed their output to the LLM for better findings.
+
+```yaml
+review:
+  static_analysis:
+    auto_clippy: false       # auto-run `cargo clippy` (Rust only)
+    clippy_output_file: ""   # or read clippy output from a file
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `auto_clippy` | `false` | Auto-run `cargo clippy --message-format=json` and inject warnings into review context (Rust projects only) |
+| `clippy_output_file` | `""` | Read clippy JSON output from a file instead of running clippy (useful for CI where clippy runs separately) |
+
+## Bundling
+
+Control how multiple files are grouped into LLM batches during `cora scan`. Cora automatically chunks large file sets into groups that fit within provider token limits.
+
+```yaml
+bundling:
+  max_chars_per_group: 60000  # max source characters per LLM batch
+  max_files_per_group: 20      # max files per batch
+  strategy: smart              # grouping strategy: smart | flat
+  coalesce_by_directory: true  # merge small batches from the same directory
+  coalesce_by_language: true   # merge small batches with the same language
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `max_chars_per_group` | `60000` | Soft limit on source characters per batch |
+| `max_files_per_group` | `20` | Max files per batch before splitting |
+| `strategy` | `smart` | Grouping strategy: `smart` (coalesce by directory + language within limits) or `flat` (first-fit by character count, legacy) |
+| `coalesce_by_directory` | `true` | Merge small batches from the same directory into one LLM call |
+| `coalesce_by_language` | `true` | Merge small batches with the same primary language |
+
+## Analysis
+
+Configure entry-point symbol patterns for architecture and call-graph analysis. Entry points are treated as roots when tracing execution paths and detecting dead code.
+
+```yaml
+analysis:
+  entry_point_patterns:
+    - "*Handler"
+    - "resolve_*"
+    - "*Middleware"
+    - "main"
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `entry_point_patterns` | `[]` | Glob patterns identifying entry-point symbols (used by `dead-code`, `trace`, and `arch` commands to avoid false positives on intentionally-unreachable functions) |
 
 ## Tech Debt Tracker
 
@@ -451,7 +575,8 @@ cora includes a built-in MCP (Model Context Protocol) server that exposes rules 
 ### Start the server
 
 ```bash
-cora mcp
+cora mcp      # Start MCP server
+cora serve    # Start MCP server + auto-reindex on startup (ensures fresh index)
 ```
 
 ### Available tools
@@ -463,6 +588,19 @@ cora mcp
 | `cora.get_quality_gate` | Get quality gate config and thresholds |
 | `cora.get_config` | Get effective project config (no secrets exposed) |
 | `cora.list_profiles` | List all quality profiles |
+| `cora.search_symbols` | Search the symbol index (requires `cora index`) |
+| `cora.find_callers` | Find all callers of a symbol (reverse call graph) |
+| `cora.find_impact` | Analyze blast radius of changing a symbol |
+| `cora.find_affected_tests` | Find test files affected by changed source files |
+| `cora.index_status` | Check if a symbol index exists and get statistics |
+| `cora.review_diff` | Review a git diff using cora's full pipeline (makes LLM call) |
+| `cora.get_debt` | Get tech debt report from review history |
+| `cora.get_project_info` | Get project context (repo, branch, cora version, index status) |
+| `cora.get_memory` | Recall project patterns from Uteke (requires `uteke` CLI) |
+| `cora.brain_search` | Hybrid code search: FTS5 + vector + graph → RRF fusion |
+| `cora.install` | Detect installed AI agents and configure cora as MCP server |
+| `cora.dead_code` | Find potentially dead code (functions with no callers) |
+| `cora.query` | Query the code graph with simple patterns (e.g. `main -> *`) |
 
 ### Configure in Claude Code
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ features:
     details: "AST-based symbol extraction for 13 languages: Rust, Go, Python, TypeScript/TSX, Java, C, C++, C#, Ruby, PHP, Scala, JavaScript, Svelte."
   - icon: 🔌
     title: MCP Server
-    details: 15 tools for AI coding agents — review, search, brain, debt, trace. Works with Claude, GPT, and other MCP clients.
+    details: 18 tools for AI coding agents — review, search, brain, debt, trace, dead code, graph query. Works with Claude, Cursor, Windsurf, and other MCP clients.
   - icon: 📐
     title: Quality Profiles
     details: Strict, balanced, or lax presets. Configurable quality gate with pass/fail thresholds for CI enforcement.

--- a/src/commands/agent_config.rs
+++ b/src/commands/agent_config.rs
@@ -1,0 +1,549 @@
+//! Agent configuration read/write module.
+//!
+//! Provides format-agnostic read, write, merge, and removal operations for
+//! AI coding agent config files (JSON, JSONC, YAML).
+//!
+//! Used by `cora install` to inject the Cora MCP server entry into agent
+//! configs without destroying existing data.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+/// Config file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigFormat {
+    Json,
+    Jsonc,
+    #[allow(dead_code)]
+    Yaml,
+}
+
+/// The Cora MCP server entry injected into agent configs.
+fn cora_mcp_entry_json() -> serde_json::Value {
+    serde_json::json!({
+        "command": "cora",
+        "args": ["mcp"],
+        "description": "Cora Code — AI code review, code intelligence, dead code detection"
+    })
+}
+
+// ─── Pre-processing helpers ──────────────────────────────────────────
+
+/// Strip a UTF-8 BOM (EF BB BF) if present.
+fn strip_bom(input: &str) -> &str {
+    input.strip_prefix('\u{FEFF}').unwrap_or(input)
+}
+
+/// Strip JSONC comments (`// line` and `/* block */`).
+///
+/// Uses a state machine that tracks whether the cursor is inside a string
+/// literal so that `//` or `/*` inside JSON string values are preserved.
+fn strip_jsonc_comments(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        if in_string {
+            // Handle escape sequences inside strings
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                result.push(bytes[i] as char);
+                result.push(bytes[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if bytes[i] == b'"' {
+                in_string = false;
+            }
+            result.push(bytes[i] as char);
+            i += 1;
+            continue;
+        }
+
+        // Not inside a string
+        if bytes[i] == b'"' {
+            in_string = true;
+            result.push('"');
+            i += 1;
+            continue;
+        }
+
+        // Check for line comment //
+        if bytes[i] == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            // Skip until end of line
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // Check for block comment /* */
+        if bytes[i] == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i += 2; // skip closing */
+            continue;
+        }
+
+        result.push(bytes[i] as char);
+        i += 1;
+    }
+
+    result
+}
+
+/// Remove trailing commas before `}` or `]` so lenient JSON configs parse.
+///
+/// Uses a state machine that tracks string context so commas inside string
+/// literals are not affected.
+fn strip_trailing_commas(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        if in_string {
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                result.push(bytes[i] as char);
+                result.push(bytes[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if bytes[i] == b'"' {
+                in_string = false;
+            }
+            result.push(bytes[i] as char);
+            i += 1;
+            continue;
+        }
+
+        if bytes[i] == b'"' {
+            in_string = true;
+            result.push('"');
+            i += 1;
+            continue;
+        }
+
+        // Check for comma followed by optional whitespace then } or ]
+        if bytes[i] == b',' {
+            // Look ahead past whitespace
+            let mut j = i + 1;
+            while j < bytes.len()
+                && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r')
+            {
+                j += 1;
+            }
+            if j < bytes.len() && (bytes[j] == b'}' || bytes[j] == b']') {
+                // Skip the comma, keep the whitespace
+                i += 1;
+                continue;
+            }
+        }
+
+        result.push(bytes[i] as char);
+        i += 1;
+    }
+
+    result
+}
+
+/// Full pre-processing pipeline for JSON/JSONC text.
+fn preprocess_json(input: &str) -> String {
+    let no_bom = strip_bom(input);
+    let no_comments = strip_jsonc_comments(no_bom);
+    strip_trailing_commas(&no_comments)
+}
+
+// ─── Public API: JSON ────────────────────────────────────────────────
+
+/// Read a JSON/JSONC config file into a `serde_json::Value`.
+pub fn read_json_config(path: &Path) -> Result<serde_json::Value> {
+    let raw = fs_read(path)?;
+    let clean = preprocess_json(&raw);
+    serde_json::from_str(&clean)
+        .with_context(|| format!("Failed to parse JSON in {}", path.display()))
+}
+
+/// Write a JSON config with pretty-printing (2-space indent).
+pub fn write_json_config(path: &Path, config: &serde_json::Value) -> Result<()> {
+    let output = serde_json::to_string_pretty(config)?;
+    fs_write(path, &output)
+}
+
+/// Check whether a JSON config already contains a `mcpServers.cora` entry.
+pub fn json_has_cora(config: &serde_json::Value) -> bool {
+    config
+        .get("mcpServers")
+        .and_then(|m| m.get("cora"))
+        .is_some()
+}
+
+/// Insert or overwrite the `mcpServers.cora` entry in a JSON config.
+pub fn json_add_cora(config: &mut serde_json::Value) -> Result<()> {
+    let obj = config
+        .as_object_mut()
+        .context("Config root is not a JSON object")?;
+
+    if !obj.contains_key("mcpServers") {
+        obj.insert("mcpServers".to_string(), serde_json::json!({}));
+    }
+
+    config
+        .get_mut("mcpServers")
+        .and_then(|m| m.as_object_mut())
+        .context("mcpServers is not an object")?
+        .insert("cora".to_string(), cora_mcp_entry_json());
+
+    Ok(())
+}
+
+/// Remove the `mcpServers.cora` entry. Returns `true` if it was present.
+#[allow(dead_code)]
+pub fn json_remove_cora(config: &mut serde_json::Value) -> bool {
+    if let Some(servers) = config.get_mut("mcpServers").and_then(|m| m.as_object_mut()) {
+        servers.remove("cora").is_some()
+    } else {
+        false
+    }
+}
+
+// ─── Public API: YAML ────────────────────────────────────────────────
+
+/// Read a YAML config file into a `serde_yaml_ng::Value`.
+pub fn read_yaml_config(path: &Path) -> Result<serde_yaml_ng::Value> {
+    let raw = fs_read(path)?;
+    let no_bom = strip_bom(&raw);
+    serde_yaml_ng::from_str(no_bom)
+        .with_context(|| format!("Failed to parse YAML in {}", path.display()))
+}
+
+/// Write a YAML config.
+pub fn write_yaml_config(path: &Path, config: &serde_yaml_ng::Value) -> Result<()> {
+    let output = serde_yaml_ng::to_string(config)?;
+    fs_write(path, &output)
+}
+
+/// Check whether a YAML config already contains a `mcpServers.cora` entry.
+pub fn yaml_has_cora(config: &serde_yaml_ng::Value) -> bool {
+    config
+        .get("mcpServers")
+        .and_then(|m| m.get("cora"))
+        .is_some()
+}
+
+/// Insert or overwrite the `mcpServers.cora` entry in a YAML config.
+pub fn yaml_add_cora(config: &mut serde_yaml_ng::Value) -> Result<()> {
+    let mapping = config
+        .as_mapping_mut()
+        .context("Config root is not a YAML mapping")?;
+
+    let key = serde_yaml_ng::Value::String("mcpServers".to_string());
+    if !mapping.contains_key(&key) {
+        mapping.insert(
+            key.clone(),
+            serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new()),
+        );
+    }
+
+    let cora_entry: serde_yaml_ng::Value = serde_yaml_ng::from_str(
+        "command: cora\nargs:\n  - mcp\ndescription: 'Cora Code — AI code review, code intelligence, dead code detection'",
+    )
+    .expect("valid yaml");
+
+    config
+        .get_mut("mcpServers")
+        .and_then(|m| m.as_mapping_mut())
+        .context("mcpServers is not a mapping")?
+        .insert(serde_yaml_ng::Value::String("cora".to_string()), cora_entry);
+
+    Ok(())
+}
+
+/// Remove the `mcpServers.cora` entry from YAML. Returns `true` if present.
+#[allow(dead_code)]
+pub fn yaml_remove_cora(config: &mut serde_yaml_ng::Value) -> bool {
+    if let Some(mapping) = config
+        .get_mut("mcpServers")
+        .and_then(|m| m.as_mapping_mut())
+    {
+        let key = serde_yaml_ng::Value::String("cora".to_string());
+        mapping.remove(&key).is_some()
+    } else {
+        false
+    }
+}
+
+// ─── Format-agnostic helpers ─────────────────────────────────────────
+
+/// Read a config file, dispatching on the detected format.
+#[allow(dead_code)]
+pub fn read_config(path: &Path, format: ConfigFormat) -> Result<serde_json::Value> {
+    match format {
+        ConfigFormat::Json | ConfigFormat::Jsonc => read_json_config(path),
+        ConfigFormat::Yaml => {
+            let yaml = read_yaml_config(path)?;
+            // Convert YAML → JSON for a unified return type
+            let json_str = serde_yaml_ng::to_string(&yaml)?;
+            Ok(serde_json::from_str(&json_str)?)
+        }
+    }
+}
+
+/// Write a config file in the specified format.
+#[allow(dead_code)]
+pub fn write_config(path: &Path, format: ConfigFormat, config: &serde_json::Value) -> Result<()> {
+    match format {
+        ConfigFormat::Json | ConfigFormat::Jsonc => write_json_config(path, config),
+        ConfigFormat::Yaml => {
+            let yaml_str = serde_json::to_string(config)?;
+            let yaml: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml_str)?;
+            write_yaml_config(path, &yaml)
+        }
+    }
+}
+
+// ─── File I/O wrappers with context ──────────────────────────────────
+
+fn fs_read(path: &Path) -> Result<String> {
+    std::fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))
+}
+
+fn fs_write(path: &Path, content: &str) -> Result<()> {
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+    std::fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tmp_file(name: &str, content: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("cora_test_{}_{}.json", name, std::process::id()));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        path
+    }
+
+    fn cleanup(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+    }
+
+    // ── BOM stripping ──
+
+    #[test]
+    fn strip_bom_removes_utf8_bom() {
+        let with_bom = "\u{FEFF}{\"key\": \"value\"}";
+        assert_eq!(strip_bom(with_bom), "{\"key\": \"value\"}");
+    }
+
+    #[test]
+    fn strip_bom_preserves_without_bom() {
+        assert_eq!(strip_bom("hello"), "hello");
+    }
+
+    // ── JSONC comment stripping ──
+
+    #[test]
+    fn strip_line_comments() {
+        let input = "{\n  // comment\n  \"key\": \"value\"\n}";
+        let result = strip_jsonc_comments(input);
+        assert!(!result.contains("comment"));
+        assert!(result.contains("\"key\""));
+    }
+
+    #[test]
+    fn strip_block_comments() {
+        let input = "{\n  /* block\n     comment */\n  \"key\": \"value\"\n}";
+        let result = strip_jsonc_comments(input);
+        assert!(!result.contains("block"));
+        assert!(result.contains("\"key\""));
+    }
+
+    // ── Trailing comma tolerance ──
+
+    #[test]
+    fn strip_trailing_comma_in_object() {
+        let input = r#"{"a": 1, "b": 2,}"#;
+        let result = strip_trailing_commas(input);
+        // The trailing comma after "b": 2 should be removed so JSON parses.
+        assert!(!result.contains("2,}"));
+        serde_json::from_str::<serde_json::Value>(&result).unwrap();
+    }
+
+    #[test]
+    fn strip_jsonc_preserves_url_in_string() {
+        let input = r#"{"url": "https://example.com"} // trailing comment"#;
+        let result = strip_jsonc_comments(input);
+        assert!(result.contains("https://example.com"));
+        assert!(!result.contains("trailing comment"));
+    }
+
+    #[test]
+    fn strip_trailing_comma_preserves_comma_in_string() {
+        let input = r#"{"key": "a,b}"}"#;
+        let result = strip_trailing_commas(input);
+        assert!(result.contains("a,b}"));
+    }
+
+    #[test]
+    fn strip_jsonc_block_comment() {
+        let input = r#"{"a": 1 /* block */}"#;
+        let result = strip_jsonc_comments(input);
+        assert!(!result.contains("block"));
+        assert!(result.contains("\"a\""));
+    }
+
+    #[test]
+    fn strip_trailing_comma_in_array() {
+        let input = r#"{"items": [1, 2, 3,]}"#;
+        let result = strip_trailing_commas(input);
+        serde_json::from_str::<serde_json::Value>(&result).unwrap();
+    }
+
+    // ── Full pipeline ──
+
+    #[test]
+    fn preprocess_jsonc_with_bom_and_comments() {
+        let input = "\u{FEFF}{\n  // hello\n  \"key\": \"value\", /* inline */\n}";
+        let result = preprocess_json(input);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["key"], "value");
+    }
+
+    // ── JSON add/remove cora ──
+
+    #[test]
+    fn json_add_cora_creates_mcp_servers() {
+        let mut config = serde_json::json!({"version": 1});
+        json_add_cora(&mut config).unwrap();
+        assert!(json_has_cora(&config));
+        assert_eq!(config["mcpServers"]["cora"]["command"], "cora");
+    }
+
+    #[test]
+    fn json_add_cora_preserves_existing_servers() {
+        let mut config = serde_json::json!({
+            "mcpServers": {
+                "other": {"command": "other-tool"}
+            }
+        });
+        json_add_cora(&mut config).unwrap();
+        assert!(json_has_cora(&config));
+        assert_eq!(config["mcpServers"]["other"]["command"], "other-tool");
+    }
+
+    #[test]
+    fn json_remove_cora_returns_true_when_present() {
+        let mut config = serde_json::json!({
+            "mcpServers": {"cora": {"command": "cora"}}
+        });
+        assert!(json_remove_cora(&mut config));
+        assert!(!json_has_cora(&config));
+    }
+
+    #[test]
+    fn json_remove_cora_returns_false_when_absent() {
+        let mut config = serde_json::json!({"mcpServers": {}});
+        assert!(!json_remove_cora(&mut config));
+    }
+
+    #[test]
+    fn json_has_cora_false_without_mcp_servers() {
+        let config = serde_json::json!({"version": 1});
+        assert!(!json_has_cora(&config));
+    }
+
+    // ── YAML add/remove cora ──
+
+    #[test]
+    fn yaml_add_cora_creates_mcp_servers() {
+        let mut config: serde_yaml_ng::Value = serde_yaml_ng::from_str("version: 1\n").unwrap();
+        yaml_add_cora(&mut config).unwrap();
+        assert!(yaml_has_cora(&config));
+    }
+
+    #[test]
+    fn yaml_remove_cora_returns_true_when_present() {
+        let mut config: serde_yaml_ng::Value =
+            serde_yaml_ng::from_str("mcpServers:\n  cora:\n    command: cora\n").unwrap();
+        assert!(yaml_remove_cora(&mut config));
+        assert!(!yaml_has_cora(&config));
+    }
+
+    #[test]
+    fn yaml_has_cora_false_without_mcp_servers() {
+        let config: serde_yaml_ng::Value = serde_yaml_ng::from_str("version: 1\n").unwrap();
+        assert!(!yaml_has_cora(&config));
+    }
+
+    // ── Round-trip: read → add → write → read → verify ──
+
+    #[test]
+    fn json_round_trip_preserves_data() {
+        let original = r#"{
+            "version": 1,
+            "mcpServers": {
+                "other": {"command": "other"}
+            }
+        }"#;
+        let path = tmp_file("roundtrip", original);
+        let result = (|| -> Result<()> {
+            let mut config = read_json_config(&path)?;
+            json_add_cora(&mut config)?;
+            write_json_config(&path, &config)?;
+
+            let reread = read_json_config(&path)?;
+            assert!(json_has_cora(&reread));
+            assert_eq!(reread["version"], 1);
+            assert_eq!(reread["mcpServers"]["other"]["command"], "other");
+            Ok(())
+        })();
+        cleanup(&path);
+        result.unwrap();
+    }
+
+    #[test]
+    fn jsonc_round_trip_with_comments() {
+        let original = "\u{FEFF}{\n  // my config\n  \"version\": 1,\n}";
+        let path = tmp_file("jsonc", original);
+        let result = (|| -> Result<()> {
+            let mut config = read_json_config(&path)?;
+            assert_eq!(config["version"], 1);
+            json_add_cora(&mut config)?;
+            write_json_config(&path, &config)?;
+
+            let reread = read_json_config(&path)?;
+            assert!(json_has_cora(&reread));
+            assert_eq!(reread["version"], 1);
+            Ok(())
+        })();
+        cleanup(&path);
+        result.unwrap();
+    }
+
+    // ── Nonexistent file ──
+
+    #[test]
+    fn read_nonexistent_file_returns_error() {
+        let path = std::path::Path::new("/nonexistent/cora_test_432.json");
+        let result = read_json_config(path);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Failed to read"));
+    }
+}

--- a/src/commands/commit_cmd.rs
+++ b/src/commands/commit_cmd.rs
@@ -241,10 +241,16 @@ async fn generate_commit_message(
 
 /// Build the user prompt for commit message generation.
 fn build_commit_prompt(diff: &str) -> String {
-    // Truncate very long diffs for commit message generation
+    // Truncate very long diffs for commit message generation.
+    // Use floor_char_boundary to avoid panicking on multi-byte UTF-8
+    // (e.g. emoji or non-ASCII characters in code/comments).
     let max_chars = 8000;
     let truncated = if diff.len() > max_chars {
-        &diff[..max_chars]
+        let mut end = max_chars;
+        while !diff.is_char_boundary(end) {
+            end -= 1;
+        }
+        &diff[..end]
     } else {
         diff
     };
@@ -344,9 +350,13 @@ fn parse_commit_message(raw: &str) -> Result<CommitMessage> {
         format!("chore: {subject}")
     };
 
-    // Enforce max length on subject
+    // Enforce max length on subject (char-boundary safe for UTF-8)
     let subject = if subject.len() > 72 {
-        format!("{}…", &subject[..69])
+        let mut end = 69;
+        while !subject.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &subject[..end])
     } else {
         subject
     };
@@ -533,6 +543,19 @@ mod tests {
     }
 
     #[test]
+    fn parse_truncates_long_subject_with_multibyte() {
+        // Subject with emoji near the truncation boundary (byte 69).
+        // Without char-boundary checking, &subject[..69] would split the
+        // 4-byte emoji at positions 67–70 and panic.
+        let mut long = "x".repeat(67);
+        long.push_str("🎉rest_of_subject_here"); // emoji at bytes 67-70
+        let raw = format!(r#"{{"subject":"{long}","body":""}}"#);
+        // Must not panic:
+        let msg = parse_commit_message(&raw).unwrap();
+        assert!(msg.subject.contains('…'));
+    }
+
+    #[test]
     fn parse_invalid_json_fails() {
         let result = parse_commit_message("not json at all");
         assert!(result.is_err());
@@ -546,6 +569,23 @@ mod tests {
         let prompt = build_commit_prompt(diff);
         assert!(prompt.contains("foo.rs"));
         assert!(prompt.contains("conventional commit"));
+    }
+
+    #[test]
+    fn commit_prompt_truncates_multibyte_utf8_without_panic() {
+        // Fill 7998 ASCII bytes, then a 4-byte emoji, then more text.
+        // Without char-boundary checking, slicing at 8000 would land
+        // mid-codepoint and panic with "byte index is not a char boundary".
+        let mut diff = "a".repeat(7998);
+        diff.push('🎉'); // 4 bytes: positions 7998..8002
+        diff.push_str(&"b".repeat(200));
+
+        // This must not panic:
+        let prompt = build_commit_prompt(&diff);
+        assert!(prompt.contains("conventional commit"));
+        // Truncated output should not contain the partial emoji bytes
+        // (it ends before the emoji because the boundary floors to 7998).
+        assert!(!prompt.contains('🎉'));
     }
 
     // ─── diff_stats ───

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -11,7 +11,11 @@ use crate::config::schema::{CoraFile, HookSection, OutputSection, ProviderSectio
 /// `--global` shows only ~/.cora/config.yaml
 /// `--project` shows only .cora.yaml
 /// (default) shows the fully merged effective config
-pub fn execute_config_show(global_only: bool, project_only: bool) -> Result<()> {
+pub fn execute_config_show(
+    global_only: bool,
+    project_only: bool,
+    config_path: Option<&str>,
+) -> Result<()> {
     // Clap conflicts_with handles the --global + --project case,
     // but add a defensive check in case of programmatic invocation.
     if global_only {
@@ -20,12 +24,12 @@ pub fn execute_config_show(global_only: bool, project_only: bool) -> Result<()> 
     if project_only {
         return show_project_config();
     }
-    show_effective_config()
+    show_effective_config(config_path)
 }
 
 /// Show the fully merged effective config (default behavior).
-fn show_effective_config() -> Result<()> {
-    let config = loader::load_config(None, None, None, None, None, false)?;
+fn show_effective_config(config_path: Option<&str>) -> Result<()> {
+    let config = loader::load_config(config_path, None, None, None, None, false)?;
 
     // Resolve effective values (env vars can override config file)
     let eff_provider = std::env::var("CORA_PROVIDER")
@@ -438,20 +442,28 @@ pub fn execute_config_set(key: &str, value: &str, global: bool) -> Result<()> {
 /// Execute `cora config validate` — load config and report validity.
 ///
 /// Returns exit code: 0 if valid, 2 if issues found.
-pub fn execute_config_validate() -> Result<i32> {
+pub fn execute_config_validate(config_path: Option<&str>) -> Result<i32> {
     // 1. Load resolved config (same as other commands)
-    let config = loader::load_config(None, None, None, None, None, false)?;
+    let config = loader::load_config(config_path, None, None, None, None, false)?;
 
-    // 2. Find the raw config file to check which fields were explicitly set
-    let cora_file = loader::find_cora_file(&std::env::current_dir().unwrap_or_default())
-        .unwrap_or_else(|e| {
+    // 2. Find the raw config file to check which fields were explicitly set.
+    //    Prefer --config path, then fall back to auto-discovery.
+    let cora_file = if let Some(path) = config_path {
+        std::fs::read_to_string(path).ok().and_then(|content| {
+            CoraFile::from_str(&content)
+                .ok()
+                .map(|cf| (std::path::PathBuf::from(path), cf))
+        })
+    } else {
+        loader::find_cora_file(&std::env::current_dir().unwrap_or_default()).unwrap_or_else(|e| {
             eprintln!(
                 "{} Warning: could not search for config file: {}",
                 "⚠️".yellow(),
                 e
             );
             None
-        });
+        })
+    };
 
     // Also check global config for fields set there
     let global_cora = load_global_cora_file();

--- a/src/commands/debt.rs
+++ b/src/commands/debt.rs
@@ -25,11 +25,20 @@ pub struct DebtOptions {
     pub badge: bool,
     /// Show estimated debt fix time.
     pub estimate: bool,
+    /// Config file path (from --config global flag).
+    pub config_path: Option<String>,
 }
 
 /// Execute the `cora debt` subcommand.
 pub fn execute_debt(opts: &DebtOptions) -> Result<i32> {
-    let config = crate::config::loader::load_config(None, None, None, None, None, false)?;
+    let config = crate::config::loader::load_config(
+        opts.config_path.as_deref(),
+        None,
+        None,
+        None,
+        None,
+        false,
+    )?;
 
     if !config.debt.enabled {
         println!(

--- a/src/commands/findings.rs
+++ b/src/commands/findings.rs
@@ -120,27 +120,33 @@ fn list_findings(
         JOIN reviews r ON f.review_id = r.id",
     );
 
-    let mut wheres: Vec<String> = Vec::new();
+    // Build WHERE clause with parameterized placeholders to prevent SQL injection.
+    let mut wheres: Vec<&str> = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
     if !all {
-        wheres.push("f.status = 'open'".to_string());
+        wheres.push("f.status = 'open'");
     }
     if let Some(s) = severity {
-        wheres.push(format!("f.severity = '{}'", s.to_uppercase()));
+        wheres.push("f.severity = ?");
+        params.push(Box::new(s.to_uppercase()));
     }
     if let Some(f) = file {
-        wheres.push(format!("f.file_path LIKE '%{}%'", f.replace('"', "'")));
+        wheres.push("f.file_path LIKE ?");
+        params.push(Box::new(format!("%{f}%")));
     }
 
     if !wheres.is_empty() {
         sql.push_str(" WHERE ");
         sql.push_str(&wheres.join(" AND "));
     }
-    sql.push_str(" ORDER BY f.id DESC");
-    sql.push_str(&format!(" LIMIT {}", limit));
+    sql.push_str(" ORDER BY f.id DESC LIMIT ?");
+    params.push(Box::new(limit as i64));
 
+    let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows: Vec<ListRow> = stmt
-        .query([])?
+        .query(param_refs.as_slice())?
         .mapped(|r| {
             Ok(ListRow {
                 id: r.get(0)?,

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,20 +1,14 @@
-//! `cora install` subcommand — auto-detect and configure AI coding agents for Cora MCP.//!
+//! `cora install` subcommand — auto-detect and configure AI coding agents for Cora MCP.
+//!
 //! Detects installed AI coding agents by checking for known config files/directories,
 //! then writes MCP server config pointing to `cora mcp` for each detected agent.
 
+use super::agent_config::{
+    ConfigFormat, json_add_cora, json_has_cora, read_json_config, write_json_config,
+};
 use anyhow::{Context, Result};
 use colored::Colorize;
-use std::fs;
 use std::path::PathBuf;
-
-/// Config file format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConfigFormat {
-    Json,
-    Jsonc,
-    #[allow(dead_code)]
-    Yaml,
-}
 
 /// Information about a detected AI coding agent.
 #[derive(Debug, Clone)]
@@ -37,15 +31,6 @@ pub struct InstallOptions {
     /// Non-interactive mode.
     #[allow(dead_code)]
     pub yes: bool,
-}
-
-/// The Cora MCP server entry we inject into agent configs.
-fn cora_mcp_entry() -> serde_json::Value {
-    serde_json::json!({
-        "command": "cora",
-        "args": ["mcp"],
-        "description": "Cora Code — AI code review, code intelligence, dead code detection"
-    })
 }
 
 /// Build the list of known agents and their config paths.
@@ -115,31 +100,11 @@ fn detect_agents() -> Result<Vec<AgentInfo>> {
     Ok(detected)
 }
 
-/// Strip JSONC comments (// line comments and /* block comments */).
-/// Simple regex approach — sufficient for config files.
-fn strip_jsonc_comments(input: &str) -> String {
-    let re = regex::Regex::new(r"//.*|/\*[\s\S]*?\*/").expect("valid regex");
-    re.replace_all(input, "").to_string()
-}
+/// Install the cora MCP server entry into a JSON/JSONC agent config.
+fn install_json_agent(path: &std::path::Path, force: bool, dry_run: bool) -> Result<String> {
+    let mut config = read_json_config(path)?;
 
-/// Merge the cora MCP server entry into a JSON/JSONC config file.
-fn merge_json_config(path: &std::path::Path, force: bool, dry_run: bool) -> Result<String> {
-    let raw =
-        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
-
-    // For JSONC, strip comments before parsing
-    let clean = strip_jsonc_comments(&raw);
-
-    let mut config: serde_json::Value =
-        serde_json::from_str(&clean).context("Failed to parse JSON config")?;
-
-    let is_jsonc = raw.contains("//") || raw.contains("/*");
-    let has_existing = config
-        .get("mcpServers")
-        .and_then(|m| m.get("cora"))
-        .is_some();
-
-    if has_existing && !force {
+    if json_has_cora(&config) && !force {
         return Ok(format!(
             "  {} {} — cora entry already exists (use --force to overwrite)",
             "⏭ ".dimmed(),
@@ -147,17 +112,7 @@ fn merge_json_config(path: &std::path::Path, force: bool, dry_run: bool) -> Resu
         ));
     }
 
-    // Ensure mcpServers object exists
-    let servers = config
-        .as_object_mut()
-        .context("Config root is not a JSON object")?
-        .entry("mcpServers")
-        .or_insert_with(|| serde_json::json!({}));
-
-    servers
-        .as_object_mut()
-        .context("mcpServers is not an object")?
-        .insert("cora".to_string(), cora_mcp_entry());
+    json_add_cora(&mut config)?;
 
     if dry_run {
         Ok(format!(
@@ -166,71 +121,7 @@ fn merge_json_config(path: &std::path::Path, force: bool, dry_run: bool) -> Resu
             path.display()
         ))
     } else {
-        let output = if is_jsonc {
-            // Write back as JSONC with a header comment
-            format!(
-                "// Modified by cora install\n{}",
-                serde_json::to_string_pretty(&config)?
-            )
-        } else {
-            serde_json::to_string_pretty(&config)?
-        };
-        fs::write(path, &output).with_context(|| format!("Failed to write {}", path.display()))?;
-        Ok(format!(
-            "  {} {} — cora MCP server entry added",
-            "✓ ".green(),
-            path.display()
-        ))
-    }
-}
-
-/// Merge the cora MCP server entry into a YAML config file.
-fn merge_yaml_config(path: &std::path::Path, force: bool, dry_run: bool) -> Result<String> {
-    let raw =
-        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
-
-    let mut config: serde_yaml_ng::Value =
-        serde_yaml_ng::from_str(&raw).context("Failed to parse YAML config")?;
-
-    let has_existing = config
-        .get("mcpServers")
-        .and_then(|m| m.get("cora"))
-        .is_some();
-
-    if has_existing && !force {
-        return Ok(format!(
-            "  {} {} — cora entry already exists (use --force to overwrite)",
-            "⏭ ".dimmed(),
-            path.display()
-        ));
-    }
-
-    // Ensure mcpServers mapping exists
-    let servers = config
-        .as_mapping_mut()
-        .context("Config root is not a YAML mapping")?
-        .entry(serde_yaml_ng::Value::String("mcpServers".to_string()))
-        .or_insert_with(|| serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new()));
-
-    if let Some(mapping) = servers.as_mapping_mut() {
-        let cora_entry_yaml: serde_yaml_ng::Value =
-            serde_yaml_ng::from_str("command: cora\nargs:\n  - mcp\ndescription: 'Cora Code — AI code review, code intelligence, dead code detection'")
-                .expect("valid yaml");
-        mapping.insert(
-            serde_yaml_ng::Value::String("cora".to_string()),
-            cora_entry_yaml,
-        );
-    }
-
-    if dry_run {
-        Ok(format!(
-            "  {} {} — would write cora MCP server entry",
-            "🔍 ".cyan(),
-            path.display()
-        ))
-    } else {
-        let output = serde_yaml_ng::to_string(&config)?;
-        fs::write(path, output).with_context(|| format!("Failed to write {}", path.display()))?;
+        write_json_config(path, &config)?;
         Ok(format!(
             "  {} {} — cora MCP server entry added",
             "✓ ".green(),
@@ -243,9 +134,38 @@ fn merge_yaml_config(path: &std::path::Path, force: bool, dry_run: bool) -> Resu
 fn install_agent(agent: &AgentInfo, opts: &InstallOptions) -> Result<String> {
     match agent.format {
         ConfigFormat::Json | ConfigFormat::Jsonc => {
-            merge_json_config(&agent.config_path, opts.force, opts.dry_run)
+            install_json_agent(&agent.config_path, opts.force, opts.dry_run)
         }
-        ConfigFormat::Yaml => merge_yaml_config(&agent.config_path, opts.force, opts.dry_run),
+        ConfigFormat::Yaml => {
+            // YAML agents are rare; delegate to agent_config module.
+            use super::agent_config;
+            let mut config = agent_config::read_yaml_config(&agent.config_path)?;
+
+            if agent_config::yaml_has_cora(&config) && !opts.force {
+                return Ok(format!(
+                    "  {} {} — cora entry already exists (use --force to overwrite)",
+                    "⏭ ".dimmed(),
+                    agent.config_path.display()
+                ));
+            }
+
+            agent_config::yaml_add_cora(&mut config)?;
+
+            if opts.dry_run {
+                Ok(format!(
+                    "  {} {} — would write cora MCP server entry",
+                    "🔍 ".cyan(),
+                    agent.config_path.display()
+                ))
+            } else {
+                agent_config::write_yaml_config(&agent.config_path, &config)?;
+                Ok(format!(
+                    "  {} {} — cora MCP server entry added",
+                    "✓ ".green(),
+                    agent.config_path.display()
+                ))
+            }
+        }
     }
 }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -20,7 +20,7 @@ struct AgentInfo {
 
 /// Install subcommand options.
 pub struct InstallOptions {
-    /// List detected agents without installing.
+    /// List detected agents only.
     pub list: bool,
     /// Specific agents to install (comma-separated).
     pub agents: Option<String>,
@@ -31,6 +31,10 @@ pub struct InstallOptions {
     /// Non-interactive mode.
     #[allow(dead_code)]
     pub yes: bool,
+    /// Remove cora MCP entry (uninstall mode).
+    pub remove: bool,
+    /// Validate agent configs after install/remove.
+    pub validate: bool,
 }
 
 /// Build the list of known agents and their config paths.
@@ -100,6 +104,14 @@ fn detect_agents() -> Result<Vec<AgentInfo>> {
     Ok(detected)
 }
 
+/// Validate that a config file still parses correctly after modification.
+fn validate_json_config(path: &std::path::Path) -> Result<()> {
+    let config = read_json_config(path)?;
+    // If it parses without error, it's valid.
+    let _ = serde_json::to_string(&config)?;
+    Ok(())
+}
+
 /// Install the cora MCP server entry into a JSON/JSONC agent config.
 fn install_json_agent(path: &std::path::Path, force: bool, dry_run: bool) -> Result<String> {
     let mut config = read_json_config(path)?;
@@ -130,40 +142,98 @@ fn install_json_agent(path: &std::path::Path, force: bool, dry_run: bool) -> Res
     }
 }
 
-/// Install the cora MCP server entry for a single agent.
+/// Remove the cora MCP server entry from a JSON/JSONC agent config.
+fn uninstall_json_agent(path: &std::path::Path, dry_run: bool) -> Result<String> {
+    use super::agent_config;
+
+    let mut config = read_json_config(path)?;
+
+    if !agent_config::json_has_cora(&config) {
+        return Ok(format!(
+            "  {} {} — no cora entry found",
+            "⏭ ".dimmed(),
+            path.display()
+        ));
+    }
+
+    agent_config::json_remove_cora(&mut config);
+
+    if dry_run {
+        Ok(format!(
+            "  {} {} — would remove cora MCP server entry",
+            "🔍 ".cyan(),
+            path.display()
+        ))
+    } else {
+        write_json_config(path, &config)?;
+        Ok(format!(
+            "  {} {} — cora MCP server entry removed",
+            "✓ ".green(),
+            path.display()
+        ))
+    }
+}
+
+/// Install or remove the cora MCP server entry for a single agent.
 fn install_agent(agent: &AgentInfo, opts: &InstallOptions) -> Result<String> {
     match agent.format {
         ConfigFormat::Json | ConfigFormat::Jsonc => {
-            install_json_agent(&agent.config_path, opts.force, opts.dry_run)
+            if opts.remove {
+                uninstall_json_agent(&agent.config_path, opts.dry_run)
+            } else {
+                install_json_agent(&agent.config_path, opts.force, opts.dry_run)
+            }
         }
         ConfigFormat::Yaml => {
-            // YAML agents are rare; delegate to agent_config module.
             use super::agent_config;
             let mut config = agent_config::read_yaml_config(&agent.config_path)?;
 
-            if agent_config::yaml_has_cora(&config) && !opts.force {
-                return Ok(format!(
-                    "  {} {} — cora entry already exists (use --force to overwrite)",
-                    "⏭ ".dimmed(),
-                    agent.config_path.display()
-                ));
-            }
-
-            agent_config::yaml_add_cora(&mut config)?;
-
-            if opts.dry_run {
-                Ok(format!(
-                    "  {} {} — would write cora MCP server entry",
-                    "🔍 ".cyan(),
-                    agent.config_path.display()
-                ))
+            if opts.remove {
+                if !agent_config::yaml_has_cora(&config) {
+                    return Ok(format!(
+                        "  {} {} — no cora entry found",
+                        "⏭ ".dimmed(),
+                        agent.config_path.display()
+                    ));
+                }
+                agent_config::yaml_remove_cora(&mut config);
+                if opts.dry_run {
+                    Ok(format!(
+                        "  {} {} — would remove cora MCP server entry",
+                        "🔍 ".cyan(),
+                        agent.config_path.display()
+                    ))
+                } else {
+                    agent_config::write_yaml_config(&agent.config_path, &config)?;
+                    Ok(format!(
+                        "  {} {} — cora MCP server entry removed",
+                        "✓ ".green(),
+                        agent.config_path.display()
+                    ))
+                }
             } else {
-                agent_config::write_yaml_config(&agent.config_path, &config)?;
-                Ok(format!(
-                    "  {} {} — cora MCP server entry added",
-                    "✓ ".green(),
-                    agent.config_path.display()
-                ))
+                if agent_config::yaml_has_cora(&config) && !opts.force {
+                    return Ok(format!(
+                        "  {} {} — cora entry already exists (use --force to overwrite)",
+                        "⏭ ".dimmed(),
+                        agent.config_path.display()
+                    ));
+                }
+                agent_config::yaml_add_cora(&mut config)?;
+                if opts.dry_run {
+                    Ok(format!(
+                        "  {} {} — would write cora MCP server entry",
+                        "🔍 ".cyan(),
+                        agent.config_path.display()
+                    ))
+                } else {
+                    agent_config::write_yaml_config(&agent.config_path, &config)?;
+                    Ok(format!(
+                        "  {} {} — cora MCP server entry added",
+                        "✓ ".green(),
+                        agent.config_path.display()
+                    ))
+                }
             }
         }
     }
@@ -217,9 +287,17 @@ pub fn execute_install(opts: &InstallOptions) -> Result<String> {
         return Ok(lines.join("\n"));
     }
 
-    // Install mode
+    // Install or remove mode
+    let action = if opts.remove {
+        "Removing"
+    } else {
+        "Configuring"
+    };
+    let noun = if opts.remove { "from" } else { "for" };
     let mut lines = vec![format!(
-        "Configuring cora MCP for {} agent(s)…{}",
+        "{} cora MCP {} {} agent(s)…{}",
+        action,
+        noun,
         agents.len(),
         if opts.dry_run { " (dry run)" } else { "" }
     )];
@@ -230,8 +308,53 @@ pub fn execute_install(opts: &InstallOptions) -> Result<String> {
         lines.push(format!("{} {}", agent.name.bold(), result));
     }
 
+    // Post-install validation
+    if opts.validate && !opts.dry_run {
+        lines.push(String::new());
+        lines.push("Validating agent configs…".to_string());
+        let mut errors = 0;
+        for agent in &agents {
+            match agent.format {
+                ConfigFormat::Json | ConfigFormat::Jsonc => {
+                    if let Err(e) = validate_json_config(&agent.config_path) {
+                        lines.push(format!(
+                            "  {} {} — INVALID: {}",
+                            "✗ ".red(),
+                            agent.config_path.display(),
+                            e
+                        ));
+                        errors += 1;
+                    } else {
+                        lines.push(format!(
+                            "  {} {} — valid JSON",
+                            "✓ ".green(),
+                            agent.config_path.display()
+                        ));
+                    }
+                }
+                ConfigFormat::Yaml => {
+                    lines.push(format!(
+                        "  {} {} — skipped (YAML validation not implemented)",
+                        "⏭ ".dimmed(),
+                        agent.config_path.display()
+                    ));
+                }
+            }
+        }
+        if errors > 0 {
+            lines.push(format!(
+                "\n{} {errors} config(s) failed validation!",
+                "⚠ ".yellow()
+            ));
+        }
+    }
+
     lines.push(String::new());
-    lines.push("Done. Restart your AI agent to pick up the new MCP server.".to_string());
+    if opts.remove {
+        lines.push("Done. Restart your AI agent to pick up the changes.".to_string());
+    } else {
+        lines.push("Done. Restart your AI agent to pick up the new MCP server.".to_string());
+    }
 
     Ok(lines.join("\n"))
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_config;
 pub mod auth;
 pub mod commit_cmd;
 pub mod completion;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,3 +16,4 @@ pub mod routes;
 pub mod scan;
 pub mod serve;
 pub mod upload;
+pub mod watch;

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -33,12 +33,7 @@ pub fn run_watch(
     filter: Option<&str>,
     verbose: bool,
 ) -> Result<()> {
-    let db_path = project_root.join(".cora/index.db");
-    if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-    let conn = rusqlite::Connection::open(&db_path)
-        .with_context(|| format!("Failed to open index database at {}", db_path.display()))?;
+    let conn = crate::index::open_global_index()?;
     // Load skip patterns from config
     let skip_patterns: Option<Vec<String>> =
         crate::config::loader::load_config(config_path, None, None, None, None, false)
@@ -131,7 +126,10 @@ fn detect_changes(
     glob_matcher: Option<&glob::Pattern>,
 ) -> Result<Vec<PathBuf>> {
     let mut changed = Vec::new();
-    let extensions: &[&str] = &["rs", "py", "js", "ts", "go", "java", "c", "cpp", "h", "rb"];
+    let extensions: &[&str] = &[
+        "rs", "py", "js", "ts", "go", "java", "c", "cpp", "h", "rb", "php", "scala", "cs", "kt",
+        "svelte", "jsx", "tsx",
+    ];
 
     let mut walker = |path: &Path| {
         // Skip files inside hidden directories (relative to project root)

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -34,11 +34,19 @@ pub fn run_watch(
     verbose: bool,
 ) -> Result<()> {
     let conn = crate::index::open_global_index()?;
-    // Load skip patterns from config
-    let skip_patterns: Option<Vec<String>> =
-        crate::config::loader::load_config(config_path, None, None, None, None, false)
-            .ok()
-            .map(|c| c.rules_config.index_skip_files);
+    // Load skip patterns + brain embedding backend from config
+    let config =
+        crate::config::loader::load_config(config_path, None, None, None, None, false).ok();
+    let skip_patterns: Option<Vec<String>> = config
+        .as_ref()
+        .map(|c| c.rules_config.index_skip_files.clone());
+
+    // Resolve embedding backend
+    let brain_mode = config
+        .as_ref()
+        .map(|c| c.brain.embedding.to_string())
+        .unwrap_or_else(|| "auto".to_string());
+    crate::embed::resolve_backend(&brain_mode);
 
     let skip_ref: Option<&[String]> = skip_patterns.as_deref();
 

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -1,0 +1,311 @@
+//! `cora watch` — standalone file-system watcher with auto-reindex.
+//!
+//! Watches the project directory for file changes and re-indexes on save.
+//! Supports debounce window, git-only filtering, and glob patterns.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::index;
+
+/// Entry point for `cora watch`.
+///
+/// Runs an initial index, then polls for changes at the debounce interval.
+/// On each poll cycle, re-indexes the project and reports updated files/symbols.
+///
+/// # Arguments
+/// * `project_root` — Root directory to watch
+/// * `config_path` — Optional path to `.cora.yaml`
+/// * `debounce_ms` — Minimum time between reindex cycles (default 500ms)
+/// * `git_only` — If true, only process files tracked by git
+/// * `filter` — Optional glob pattern (e.g. `src/**/*.rs`)
+/// * `verbose` — Verbose output
+#[allow(clippy::too_many_arguments)]
+pub fn run_watch(
+    project_root: &Path,
+    config_path: Option<&str>,
+    debounce_ms: u64,
+    git_only: bool,
+    filter: Option<&str>,
+    verbose: bool,
+) -> Result<()> {
+    let db_path = project_root.join(".cora/index.db");
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let conn = rusqlite::Connection::open(&db_path)
+        .with_context(|| format!("Failed to open index database at {}", db_path.display()))?;
+    // Load skip patterns from config
+    let skip_patterns: Option<Vec<String>> =
+        crate::config::loader::load_config(config_path, None, None, None, None, false)
+            .ok()
+            .map(|c| c.rules_config.index_skip_files);
+
+    let skip_ref: Option<&[String]> = skip_patterns.as_deref();
+
+    // Build git-tracked file set if --git-only
+    let git_files: Option<HashSet<PathBuf>> = if git_only {
+        Some(get_git_tracked_files(project_root)?)
+    } else {
+        None
+    };
+
+    // Compile glob filter if provided
+    let glob_matcher = filter.map(|p| {
+        glob::Pattern::new(p).unwrap_or_else(|e| {
+            eprintln!("{} Invalid glob pattern '{p}': {e}", "⚠ ".yellow());
+            std::process::exit(1);
+        })
+    });
+
+    let debounce = Duration::from_millis(debounce_ms);
+
+    // Initial index
+    eprintln!("{}", "🔍 Initial index...".cyan());
+    let stats = index::index_project_with_skip(&conn, project_root, verbose, skip_ref)?;
+    eprintln!(
+        "{}",
+        format!(
+            "✅ Indexed {} symbols across {} files.",
+            stats.symbols_indexed, stats.files_indexed
+        )
+        .green()
+    );
+    eprintln!(
+        "{}",
+        format!(
+            "👀 Watching for changes... (debounce: {}ms, git-only: {}, filter: {}) (Ctrl+C to stop)",
+            debounce_ms,
+            git_only,
+            filter.unwrap_or("none")
+        )
+        .dimmed()
+    );
+
+    // Poll loop
+    let mut last_reindex = Instant::now();
+    loop {
+        std::thread::sleep(debounce);
+
+        let now = Instant::now();
+        if now.duration_since(last_reindex) < debounce {
+            continue;
+        }
+
+        // Check for changed files
+        let changed = detect_changes(project_root, &git_files, glob_matcher.as_ref())?;
+        if changed.is_empty() {
+            continue;
+        }
+
+        last_reindex = now;
+
+        if verbose {
+            eprintln!("{}", format!("Changed files: {}", changed.len()).dimmed());
+        }
+
+        // Re-index
+        let stats = index::index_project_with_skip(&conn, project_root, verbose, skip_ref)?;
+
+        if stats.files_indexed > 0 {
+            eprintln!(
+                "{}",
+                format!(
+                    "🔄 Reindexed: {} files, {} symbols updated",
+                    stats.files_indexed, stats.symbols_indexed
+                )
+                .cyan()
+            );
+        }
+    }
+}
+
+/// Detect files that changed since last check by comparing modification times.
+fn detect_changes(
+    project_root: &Path,
+    git_files: &Option<HashSet<PathBuf>>,
+    glob_matcher: Option<&glob::Pattern>,
+) -> Result<Vec<PathBuf>> {
+    let mut changed = Vec::new();
+    let extensions: &[&str] = &["rs", "py", "js", "ts", "go", "java", "c", "cpp", "h", "rb"];
+
+    let mut walker = |path: &Path| {
+        // Skip files inside hidden directories (relative to project root)
+        let rel = path.strip_prefix(project_root).unwrap_or(path);
+        if rel
+            .components()
+            .any(|c| matches!(c, std::path::Component::Normal(n) if n.to_str().is_some_and(|s| s.starts_with('.'))))
+        {
+            return;
+        }
+
+        // Check extension
+        let ext_match = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| extensions.contains(&e));
+        if !ext_match {
+            return;
+        }
+
+        // Apply git-only filter
+        if let Some(git_set) = git_files {
+            if !git_set.contains(path) {
+                return;
+            }
+        }
+
+        // Apply glob filter
+        if let Some(pattern) = glob_matcher {
+            if !pattern.matches_path(rel) {
+                return;
+            }
+        }
+
+        changed.push(path.to_path_buf());
+    };
+    walk_files(project_root, &mut walker)?;
+
+    Ok(changed)
+}
+
+/// Recursively walk directory and call `f` for each file path.
+fn walk_files(root: &Path, f: &mut dyn FnMut(&Path)) -> Result<()> {
+    walk_dir_recursive(root, f)
+}
+
+fn walk_dir_recursive(current: &Path, f: &mut dyn FnMut(&Path)) -> Result<()> {
+    if !current.is_dir() {
+        if current.is_file() {
+            f(current);
+        }
+        return Ok(());
+    }
+
+    let entries = match std::fs::read_dir(current) {
+        Ok(e) => e,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip hidden directories
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with('.') || name == "node_modules" || name == "target" {
+                    continue;
+                }
+            }
+            walk_dir_recursive(&path, f)?;
+        } else if path.is_file() {
+            f(&path);
+        }
+    }
+
+    Ok(())
+}
+
+/// Get the set of git-tracked files in the repository.
+fn get_git_tracked_files(root: &Path) -> Result<HashSet<PathBuf>> {
+    let output = std::process::Command::new("git")
+        .args(["ls-files", "--cached", "--no-others"])
+        .current_dir(root)
+        .output()
+        .context("Failed to run `git ls-files`")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "git ls-files failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let files: HashSet<PathBuf> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| root.join(line))
+        .collect();
+
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_walk_files_finds_source() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        fs::write(root.join("main.rs"), "fn main() {}").unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), "pub fn lib() {}").unwrap();
+
+        // Hidden dir should be skipped
+        fs::create_dir_all(root.join(".hidden")).unwrap();
+        fs::write(root.join(".hidden/secret.rs"), "// skip").unwrap();
+
+        let mut found = Vec::new();
+        walk_files(root, &mut |p| {
+            found.push(
+                p.strip_prefix(root)
+                    .unwrap_or(p)
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        })
+        .unwrap();
+
+        assert!(found.iter().any(|p| p.ends_with("main.rs")));
+        assert!(found.iter().any(|p| p.ends_with("lib.rs")));
+        // Hidden files should NOT be found (directory skip)
+        // Note: walk_files itself doesn't skip hidden at top-level, only in subdirs
+    }
+
+    #[test]
+    fn test_get_git_tracked_files_no_repo() {
+        let tmp = TempDir::new().unwrap();
+        let result = get_git_tracked_files(tmp.path());
+        // Should fail gracefully (no git repo)
+        assert!(result.is_err() || result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_detect_changes_empty_dir() {
+        let tmp = TempDir::new().unwrap();
+        let changed = detect_changes(tmp.path(), &None, None).unwrap();
+        assert!(changed.is_empty());
+    }
+
+    #[test]
+    fn test_detect_changes_with_source_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        fs::write(root.join("main.rs"), "fn main() {}").unwrap();
+
+        let changed = detect_changes(root, &None, None).unwrap();
+        assert!(!changed.is_empty());
+        assert!(changed.iter().any(|p| p.ends_with("main.rs")));
+    }
+
+    #[test]
+    fn test_detect_changes_filters_non_source() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        fs::write(root.join("README.md"), "# readme").unwrap();
+        fs::write(root.join("main.rs"), "fn main() {}").unwrap();
+
+        let changed = detect_changes(root, &None, None).unwrap();
+        // .md should not be detected, .rs should
+        assert!(changed.iter().any(|p| p.ends_with("main.rs")));
+        assert!(!changed.iter().any(|p| p.ends_with("README.md")));
+    }
+}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -56,6 +56,9 @@ pub struct Config {
     /// Analysis configuration — dead-code detection, entry-point patterns.
     #[serde(default, skip_serializing_if = "is_default")]
     pub analysis: AnalysisConfig,
+    /// Brain Mode configuration — embedding backend selection.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub brain: BrainConfig,
 }
 
 /// Provider configuration.
@@ -141,6 +144,7 @@ impl Default for Config {
             debt: crate::engine::debt_tracker::DebtConfig::default(),
             profile: None,
             analysis: AnalysisConfig::default(),
+            brain: BrainConfig::default(),
         }
     }
 }
@@ -412,6 +416,62 @@ pub struct AnalysisConfig {
     /// Example: `["*Handler", "resolve_*", "*Middleware"]`
     #[serde(default, skip_serializing_if = "is_default")]
     pub entry_point_patterns: Vec<String>,
+}
+
+/// Brain Mode configuration — controls embedding backend for vector search.
+///
+/// By default (`auto`), cora selects the best available backend at runtime:
+/// pretrained 768d (if compiled with `pretrained-embed` feature) → hashing 256d fallback.
+/// Users can force a specific backend via `.cora.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct BrainConfig {
+    /// Embedding backend selection.
+    ///
+    /// - `"auto"` (default) — best available: pretrained → hashing
+    /// - `"hashing"` — force 256d hashing trick (zero dependency)
+    /// - `"pretrained"` — force nomic 768d (requires `--features pretrained-embed`)
+    ///
+    /// Invalid values fall back to `"auto"` with a warning.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub embedding: BrainEmbeddingMode,
+}
+
+/// Embedding backend mode for Brain Mode.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BrainEmbeddingMode {
+    /// Best available backend (pretrained if compiled, else hashing).
+    #[default]
+    Auto,
+    /// Force 256d hashing trick (zero dependency).
+    Hashing,
+    /// Force nomic 768d pretrained (requires feature flag).
+    Pretrained,
+}
+
+impl std::fmt::Display for BrainEmbeddingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::Hashing => write!(f, "hashing"),
+            Self::Pretrained => write!(f, "pretrained"),
+        }
+    }
+}
+
+impl std::str::FromStr for BrainEmbeddingMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "hashing" => Ok(Self::Hashing),
+            "pretrained" => Ok(Self::Pretrained),
+            other => Err(format!(
+                "unknown brain.embedding value '{other}' — expected auto, hashing, or pretrained"
+            )),
+        }
+    }
 }
 
 fn is_default<T: Default + PartialEq>(val: &T) -> bool {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -528,9 +528,21 @@ impl CoraFile {
         }
         if let Some(ig) = &self.ignore {
             if let Some(v) = &ig.files {
-                config.ignore.files.clone_from(v);
+                // Merge user-specified ignore patterns with defaults.
+                // Previously this used clone_from, which OVERWROTE the default
+                // patterns (node_modules/**, target/**, dist/**, .git/**).
+                // When a user set any custom ignore file, all defaults were
+                // silently lost — causing build artifacts and dependencies to
+                // leak into review context, scan walks, and resolver output.
+                // Deduplicate to avoid redundant entries.
+                for f in v {
+                    if !config.ignore.files.contains(f) {
+                        config.ignore.files.push(f.clone());
+                    }
+                }
             }
             if let Some(v) = &ig.rules {
+                // ignore.rules defaults to empty, so clone is safe here.
                 config.ignore.rules.clone_from(v);
             }
         }
@@ -608,7 +620,16 @@ impl CoraFile {
                 config.rules_config.custom_rules = re.custom.clone();
             }
             if !re.index_skip_files.is_empty() {
-                config.rules_config.index_skip_files = re.index_skip_files.clone();
+                // Merge user-specified skip patterns with defaults.
+                // Previously this used clone, which OVERWROTE the default
+                // skip files (*.config.ts, *.config.js, etc.). When a user
+                // set any custom skip file, all defaults were silently lost,
+                // causing false positives on bundler/framework entry points.
+                for f in &re.index_skip_files {
+                    if !config.rules_config.index_skip_files.contains(f) {
+                        config.rules_config.index_skip_files.push(f.clone());
+                    }
+                }
             }
         }
         if let Some(b) = &self.bundling {
@@ -833,8 +854,91 @@ provider: zai
             ..Default::default()
         };
         cora.merge_into(&mut cfg).unwrap();
-        assert_eq!(cfg.ignore.files, vec!["vendor/**"]);
+        // User-specified ignore file should be present.
+        assert!(
+            cfg.ignore.files.contains(&"vendor/**".to_string()),
+            "user ignore file should be merged in"
+        );
+        // Default ignore files must be preserved (not overwritten).
+        assert!(
+            cfg.ignore.files.contains(&"node_modules/**".to_string()),
+            "default node_modules/** must be preserved"
+        );
+        assert!(
+            cfg.ignore.files.contains(&"target/**".to_string()),
+            "default target/** must be preserved"
+        );
+        assert!(
+            cfg.ignore.files.contains(&"dist/**".to_string()),
+            "default dist/** must be preserved"
+        );
+        assert!(
+            cfg.ignore.files.contains(&".git/**".to_string()),
+            "default .git/** must be preserved"
+        );
+        // ignore.rules defaults to empty, so clone is a full replacement.
         assert_eq!(cfg.ignore.rules, vec!["skip-rule-1"]);
+    }
+
+    #[test]
+    fn merge_ignore_files_dedup() {
+        // User lists a pattern that's already a default — should not duplicate.
+        let mut cfg = Config::default();
+        let cora = CoraFile {
+            ignore: Some(IgnoreSection {
+                files: Some(vec![
+                    "node_modules/**".to_string(), // already a default
+                    "my-vendor/**".to_string(),
+                ]),
+                rules: None,
+            }),
+            ..Default::default()
+        };
+        cora.merge_into(&mut cfg).unwrap();
+        let nm_count = cfg
+            .ignore
+            .files
+            .iter()
+            .filter(|f| *f == "node_modules/**")
+            .count();
+        assert_eq!(nm_count, 1, "duplicate entry should be deduplicated");
+    }
+
+    #[test]
+    fn merge_index_skip_files_preserves_defaults() {
+        let mut cfg = Config::default();
+        let cora = CoraFile {
+            rules_engine: Some(RulesSection {
+                enabled: true,
+                max_findings: 10,
+                custom: Vec::new(),
+                index_skip_files: vec!["my-generated/**".to_string()],
+            }),
+            ..Default::default()
+        };
+        cora.merge_into(&mut cfg).unwrap();
+        // User pattern should be present.
+        assert!(
+            cfg.rules_config
+                .index_skip_files
+                .contains(&"my-generated/**".to_string()),
+            "user skip pattern should be merged in"
+        );
+        // Default skip patterns must be preserved.
+        assert!(
+            cfg.rules_config
+                .index_skip_files
+                .iter()
+                .any(|f| f == "*.config.ts"),
+            "default *.config.ts must be preserved"
+        );
+        assert!(
+            cfg.rules_config
+                .index_skip_files
+                .iter()
+                .any(|f| f == "*.config.js"),
+            "default *.config.js must be preserved"
+        );
     }
 
     #[test]

--- a/src/data_dir.rs
+++ b/src/data_dir.rs
@@ -71,21 +71,37 @@ pub fn ensure_data_dir() -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Ensure tests that mutate CODECORA_HOME don't run concurrently.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_codecora_home_returns_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = codecora_home();
         assert!(path.ends_with(".codecora"));
     }
 
     #[test]
     fn test_product_data_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = product_data_dir("cora-code");
         assert!(path.ends_with(".codecora/cora-code"));
     }
 
     #[test]
     fn test_graph_db_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = graph_db_path();
         assert!(
             path.ends_with(".codecora/cora-code/cora.db")
@@ -96,6 +112,10 @@ mod tests {
 
     #[test]
     fn test_cora_data_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(CODECORA_HOME_ENV);
+        }
         let path = cora_data_dir();
         assert!(path.ends_with(".codecora/cora-code"));
         // Should not have trailing slash
@@ -105,6 +125,7 @@ mod tests {
 
     #[test]
     fn test_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var(CODECORA_HOME_ENV, "/tmp/test-codecora");
         }

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -10,8 +10,10 @@
 //!    compiled into the binary via `include_bytes!` / `include_str!`.
 //!    Higher quality at the cost of ~30 MB binary size.
 //!
-//! The [`embed_code_dispatch`] function selects the best available backend at
-//! compile time: pretrained-embed (768d) → hashing trick (256d) → FTS5-only.
+//! The active backend is selected at **runtime** via [`resolve_backend`],
+//! which reads the `brain.embedding` config value. At compile time, only
+//! the availability of the pretrained path is gated by the `pretrained-embed`
+//! feature flag.
 
 pub mod tokens;
 
@@ -27,63 +29,162 @@ pub use tokens::EMBEDDING_DIM;
 #[cfg(feature = "pretrained-embed")]
 pub use token_vocab::{PRETRAINED_DIM, embed_code_pretrained};
 
-/// Returns the embedding dimensionality used by the active backend.
+/// Runtime embedding backend selector.
 ///
-/// - `pretrained-embed` feature → 768
-/// - default (hashing trick) → 256
-pub const fn active_dims() -> usize {
-    #[cfg(feature = "pretrained-embed")]
-    {
-        PRETRAINED_DIM
+/// Resolved from `brain.embedding` config value at call time.
+/// Falls back gracefully when a requested backend is not compiled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    /// 256-dim hashing trick (always available, zero dependency).
+    Hashing,
+    /// 768-dim nomic distilled pretrained (requires `pretrained-embed` feature).
+    #[allow(dead_code)]
+    Pretrained,
+}
+
+impl Backend {
+    /// Returns the embedding dimensionality for this backend.
+    pub const fn dims(self) -> usize {
+        match self {
+            Self::Hashing => EMBEDDING_DIM,
+            #[cfg(feature = "pretrained-embed")]
+            Self::Pretrained => PRETRAINED_DIM,
+            #[cfg(not(feature = "pretrained-embed"))]
+            Self::Pretrained => EMBEDDING_DIM, // unreachable — resolve never returns Pretrained without feature
+        }
     }
-    #[cfg(not(feature = "pretrained-embed"))]
-    {
-        EMBEDDING_DIM
+
+    /// Returns a human-readable label for this backend.
+    pub const fn provider_name(self) -> &'static str {
+        match self {
+            Self::Hashing => "hashing-trick (256d, static)",
+            #[cfg(feature = "pretrained-embed")]
+            Self::Pretrained => "nomic-embed-code (768d, pretrained)",
+            #[cfg(not(feature = "pretrained-embed"))]
+            Self::Pretrained => "hashing-trick (256d, pretrained not compiled)",
+        }
     }
 }
 
+/// Thread-local active backend — set once at index/brain-search time.
+static ACTIVE_BACKEND: std::sync::OnceLock<Backend> = std::sync::OnceLock::new();
+
+/// Resolve the runtime backend from config string.
+///
+/// Logic:
+/// - `"auto"` → pretrained if compiled, else hashing
+/// - `"hashing"` → always hashing
+/// - `"pretrained"` → pretrained if compiled, else hashing + warning
+///
+/// The result is cached process-wide via `OnceLock`.
+pub fn resolve_backend(config_embedding: &str) -> Backend {
+    // Already resolved? Return cached value.
+    if let Some(&b) = ACTIVE_BACKEND.get() {
+        return b;
+    }
+
+    let backend = match config_embedding {
+        "hashing" => Backend::Hashing,
+        "pretrained" => {
+            #[cfg(feature = "pretrained-embed")]
+            {
+                Backend::Pretrained
+            }
+            #[cfg(not(feature = "pretrained-embed"))]
+            {
+                tracing::warn!(
+                    "brain.embedding=pretrained but cora was not compiled with --features pretrained-embed; \
+                     falling back to hashing-trick 256d"
+                );
+                Backend::Hashing
+            }
+        }
+        // "auto" or any unknown value
+        _ => {
+            #[cfg(feature = "pretrained-embed")]
+            {
+                Backend::Pretrained
+            }
+            #[cfg(not(feature = "pretrained-embed"))]
+            {
+                Backend::Hashing
+            }
+        }
+    };
+
+    let _ = ACTIVE_BACKEND.set(backend);
+    tracing::debug!(
+        config = config_embedding,
+        backend = ?backend,
+        "resolved embedding backend"
+    );
+    backend
+}
+
+/// Returns the embedding dimensionality used by the active backend.
+///
+/// Convenience wrapper around `resolve_backend().dims()`.
+pub fn active_dims() -> usize {
+    // Use a sensible default if resolve_backend hasn't been called yet.
+    ACTIVE_BACKEND.get().map(|b| b.dims()).unwrap_or_else(|| {
+        #[cfg(feature = "pretrained-embed")]
+        {
+            PRETRAINED_DIM
+        }
+        #[cfg(not(feature = "pretrained-embed"))]
+        {
+            EMBEDDING_DIM
+        }
+    })
+}
+
 /// Returns a human-readable label for the active embedding provider.
-pub const fn active_provider_name() -> &'static str {
-    #[cfg(feature = "pretrained-embed")]
-    {
-        "nomic-embed-code (768d, pretrained)"
-    }
-    #[cfg(not(feature = "pretrained-embed"))]
-    {
-        "hashing-trick (256d, static)"
-    }
+pub fn active_provider_name() -> &'static str {
+    ACTIVE_BACKEND
+        .get()
+        .map(|b| b.provider_name())
+        .unwrap_or_else(|| {
+            #[cfg(feature = "pretrained-embed")]
+            {
+                "nomic-embed-code (768d, pretrained)"
+            }
+            #[cfg(not(feature = "pretrained-embed"))]
+            {
+                "hashing-trick (256d, static)"
+            }
+        })
 }
 
 /// Embed a code snippet using the best available backend.
 ///
 /// Returns an f32 vector that can be passed directly to usearch.
 ///
-/// - **Pretrained path** (`pretrained-embed` feature): tokenises → looks up
-///   each token in the nomic vocabulary → accumulates int8 vectors → L2-normalises.
-///   Returns 768-dim vector.
-///
-/// - **Hashing-trick fallback**: tokenises → hashes each token into a
-///   pseudo-random 256-dim vector → accumulates → L2-normalises.
-///   Returns 256-dim vector.
-///
-/// Both paths share the same [`tokenize_code`] tokenizer.
+/// Dispatches to the backend set by [`resolve_backend`]. If no backend has
+/// been explicitly resolved, falls back to compile-time default.
 pub fn embed_code_dispatch(code: &str) -> Vec<f32> {
-    #[cfg(feature = "pretrained-embed")]
-    {
-        embed_code_pretrained(code)
-    }
-    #[cfg(not(feature = "pretrained-embed"))]
-    {
-        let embedding = tokens::embed_code(code);
-        embedding.as_slice().iter().map(|&v| v as f32).collect()
+    let backend = ACTIVE_BACKEND.get().copied().unwrap_or_else(|| {
+        // Lazy resolve with "auto" if not yet set
+        resolve_backend("auto")
+    });
+
+    match backend {
+        Backend::Hashing => {
+            let embedding = tokens::embed_code(code);
+            embedding.as_slice().iter().map(|&v| v as f32).collect()
+        }
+        #[cfg(feature = "pretrained-embed")]
+        Backend::Pretrained => embed_code_pretrained(code),
+        #[cfg(not(feature = "pretrained-embed"))]
+        Backend::Pretrained => {
+            // Should never happen — resolve_backend never returns Pretrained without feature
+            let embedding = tokens::embed_code(code);
+            embedding.as_slice().iter().map(|&v| v as f32).collect()
+        }
     }
 }
 
 /// Whether the pretrained embedding backend is available (compile-time).
-#[expect(
-    dead_code,
-    reason = "used by Phase 3+ features; embed module not yet wired at call sites"
-)]
+#[allow(dead_code)]
 pub const fn has_pretrained() -> bool {
     cfg!(feature = "pretrained-embed")
 }

--- a/src/engine/cache.rs
+++ b/src/engine/cache.rs
@@ -14,12 +14,15 @@ fn cache_dir() -> std::result::Result<PathBuf, CoraError> {
 }
 
 /// Compute SHA-256 hex digest of the diff content + config parameters.
-/// Includes model and temperature so config changes invalidate the cache.
+/// Includes model, provider, base_url, and temperature so config changes
+/// invalidate the cache (e.g., switching providers with the same model name).
 #[allow(clippy::format_collect)]
-fn cache_key(diff: &str, model: &str, temperature: f32) -> String {
+fn cache_key(diff: &str, model: &str, temperature: f32, provider: &str, base_url: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(diff.as_bytes());
     hasher.update(model.as_bytes());
+    hasher.update(provider.as_bytes());
+    hasher.update(base_url.as_bytes());
     hasher.update(temperature.to_le_bytes());
     let result = hasher.finalize();
     result.iter().map(|b| format!("{b:02x}")).collect()
@@ -34,8 +37,10 @@ pub fn get_cached_review(
     model: &str,
     temperature: f32,
     ttl: u64,
+    provider: &str,
+    base_url: &str,
 ) -> Option<ReviewResponse> {
-    let hash = cache_key(diff, model, temperature);
+    let hash = cache_key(diff, model, temperature, provider, base_url);
     let dir = cache_dir().ok()?;
     let path = dir.join(format!("{hash}.json"));
 
@@ -78,11 +83,13 @@ pub fn save_cached_review(
     model: &str,
     temperature: f32,
     response: &ReviewResponse,
+    provider: &str,
+    base_url: &str,
 ) -> std::result::Result<(), CoraError> {
     let dir = cache_dir()?;
     std::fs::create_dir_all(&dir).map_err(CoraError::CacheIo)?;
 
-    let hash = cache_key(diff, model, temperature);
+    let hash = cache_key(diff, model, temperature, provider, base_url);
     let path = dir.join(format!("{hash}.json"));
 
     let now = SystemTime::now()
@@ -136,24 +143,54 @@ mod tests {
 
     #[test]
     fn cache_key_is_deterministic() {
-        let hash1 = cache_key("hello world", "gpt-4", 0.0);
-        let hash2 = cache_key("hello world", "gpt-4", 0.0);
+        let hash1 = cache_key(
+            "hello world",
+            "gpt-4",
+            0.0,
+            "openai",
+            "https://api.openai.com/v1",
+        );
+        let hash2 = cache_key(
+            "hello world",
+            "gpt-4",
+            0.0,
+            "openai",
+            "https://api.openai.com/v1",
+        );
         assert_eq!(hash1, hash2);
         assert_eq!(hash1.len(), 64); // SHA-256 hex = 64 chars
     }
 
     #[test]
     fn cache_key_differs_for_different_inputs() {
-        let hash1 = cache_key("hello world", "gpt-4", 0.0);
-        let hash2 = cache_key("hello earth", "gpt-4", 0.0);
+        let hash1 = cache_key(
+            "hello world",
+            "gpt-4",
+            0.0,
+            "openai",
+            "https://api.openai.com/v1",
+        );
+        let hash2 = cache_key(
+            "hello earth",
+            "gpt-4",
+            0.0,
+            "openai",
+            "https://api.openai.com/v1",
+        );
         assert_ne!(hash1, hash2);
     }
 
     #[test]
     fn cache_key_includes_model_and_temperature() {
-        let h1 = cache_key("diff", "gpt-4", 0.0);
-        let h2 = cache_key("diff", "gpt-3.5", 0.0);
-        let h3 = cache_key("diff", "gpt-4", 0.7);
+        let h1 = cache_key("diff", "gpt-4", 0.0, "openai", "https://api.openai.com/v1");
+        let h2 = cache_key(
+            "diff",
+            "gpt-3.5",
+            0.0,
+            "openai",
+            "https://api.openai.com/v1",
+        );
+        let h3 = cache_key("diff", "gpt-4", 0.7, "openai", "https://api.openai.com/v1");
         assert_ne!(h1, h2, "different models should differ");
         assert_ne!(h1, h3, "different temperatures should differ");
     }
@@ -161,7 +198,7 @@ mod tests {
     #[test]
     fn cache_key_len_is_64() {
         let diff = "diff --git a/file.txt b/file.txt\n+ hello";
-        let hash = cache_key(diff, "model", 0.0);
+        let hash = cache_key(diff, "model", 0.0, "openai", "https://api.openai.com/v1");
         assert_eq!(hash.len(), 64);
     }
 
@@ -169,9 +206,41 @@ mod tests {
     fn cache_miss_on_different_diff() {
         let diff1 = "diff --git a/a.txt b/a.txt\n+ hello";
         let diff2 = "diff --git a/b.txt b/b.txt\n+ world";
-        let hash1 = cache_key(diff1, "model", 0.0);
-        let hash2 = cache_key(diff2, "model", 0.0);
+        let hash1 = cache_key(diff1, "model", 0.0, "openai", "https://api.openai.com/v1");
+        let hash2 = cache_key(diff2, "model", 0.0, "openai", "https://api.openai.com/v1");
         assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_providers() {
+        let h1 = cache_key("diff", "gpt-4", 0.0, "openai", "https://api.openai.com/v1");
+        let h2 = cache_key(
+            "diff",
+            "gpt-4",
+            0.0,
+            "azure",
+            "https://my-azure.openai.azure.com",
+        );
+        assert_ne!(
+            h1, h2,
+            "different providers should produce different cache keys"
+        );
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_base_urls() {
+        let h1 = cache_key("diff", "gpt-4", 0.0, "openai", "https://api.openai.com/v1");
+        let h2 = cache_key(
+            "diff",
+            "gpt-4",
+            0.0,
+            "openai",
+            "https://proxy.example.com/v1",
+        );
+        assert_ne!(
+            h1, h2,
+            "different base_urls should produce different cache keys"
+        );
     }
 
     #[test]
@@ -246,7 +315,7 @@ mod tests {
 
         // Manually set up a cache entry in the temp dir
         let diff = "test diff content";
-        let hash = cache_key(diff, "model", 0.0);
+        let hash = cache_key(diff, "model", 0.0, "openai", "https://api.openai.com/v1");
         let path = dir.join(format!("{hash}.json"));
 
         let response = make_response();

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -106,6 +106,8 @@ async fn review_diff_inner(
             &llm_config.model,
             llm_config.temperature,
             config.cache_ttl,
+            &llm_config.provider,
+            &llm_config.base_url,
         ) {
             debug!("returning cached review response");
             return Ok(cached);
@@ -453,6 +455,8 @@ async fn review_diff_inner(
             &llm_config.model,
             llm_config.temperature,
             &response,
+            &llm_config.provider,
+            &llm_config.base_url,
         ) {
             debug!("failed to save review to cache: {}", e);
         }

--- a/src/engine/rules/builtin.rs
+++ b/src/engine/rules/builtin.rs
@@ -133,6 +133,8 @@ pub fn post_match_filter(rule_id: &str, line: &str) -> bool {
         "sec-hardcoded-secret" | "crypto/hardcoded-secret" => is_false_positive_secret(line),
         "sec-hardcoded-url" => is_false_positive_url(line),
         "config/cors-wildcard" => is_false_positive_cors(line),
+        "injection/sql-concat" => is_false_positive_sql_concat(line),
+        "config/debug-enabled" => is_false_positive_debug(line),
         _ => false,
     }
 }
@@ -243,6 +245,69 @@ fn is_false_positive_secret(line: &str) -> bool {
                 return true;
             }
         }
+    }
+
+    false
+}
+
+/// Check if a `sql-concat` match is a false positive.
+///
+/// Suppresses: comment lines, string literal descriptions, and lines where
+/// the "+" is not actually string concatenation (e.g., arithmetic).
+fn is_false_positive_sql_concat(line: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Comment lines — SQL keywords in comments are not injection
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("--")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+    {
+        return true;
+    }
+
+    // Python/Rust docstrings
+    if trimmed.contains("\"\"\"") || trimmed.contains("'''") {
+        return true;
+    }
+
+    false
+}
+
+/// Check if a `debug-enabled` match is a false positive.
+///
+/// Suppresses: comment lines documenting debug config, argument parser
+/// definitions, and environment variable references.
+fn is_false_positive_debug(line: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Comment lines
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("--")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+    {
+        return true;
+    }
+
+    // Argument parser definitions (Python argparse, JS commander, etc.)
+    let lower = line.to_lowercase();
+    if lower.contains("add_argument")
+        || lower.contains("addoption")
+        || lower.contains("argument(")
+        || lower.contains(".option(")
+        || lower.contains("parser.")
+    {
+        return true;
+    }
+
+    // Environment variable references (DEBUG from env, not hardcoded)
+    if lower.contains("env")
+        && (lower.contains("getenv") || lower.contains("environ") || lower.contains("from_env"))
+    {
+        return true;
     }
 
     false

--- a/src/engine/rules/builtin.rs
+++ b/src/engine/rules/builtin.rs
@@ -127,8 +127,8 @@ pub fn builtin_rules() -> Vec<CustomRule> {
 /// Returns `true` to suppress a finding that the regex matched but should be ignored.
 pub fn post_match_filter(rule_id: &str, line: &str) -> bool {
     match rule_id {
+        "sec-hardcoded-secret" | "crypto/hardcoded-secret" => is_false_positive_secret(line),
         "sec-hardcoded-url" => is_false_positive_url(line),
-        "crypto/hardcoded-secret" => is_false_positive_secret(line),
         _ => false,
     }
 }
@@ -403,7 +403,37 @@ mod tests {
         ));
         assert!(!post_match_filter(
             "crypto/hardcoded-secret",
-            "const API_KEY = \"sk-abc123def456gh\""
+            "const API_KEY = \"***\""
+        ));
+    }
+
+    // ─── sec-hardcoded-secret (builtin rule ID) false positive tests ───
+
+    #[test]
+    fn builtin_rule_id_secret_empty_string_is_false_positive() {
+        assert!(post_match_filter(
+            "sec-hardcoded-secret",
+            "let formAppSecret = $state('');"
+        ));
+        assert!(post_match_filter(
+            "sec-hardcoded-secret",
+            "let password = '';"
+        ));
+    }
+
+    #[test]
+    fn builtin_rule_id_secret_svelte_state_is_false_positive() {
+        assert!(post_match_filter(
+            "sec-hardcoded-secret",
+            "let formPassword = $state('default12345678');"
+        ));
+    }
+
+    #[test]
+    fn builtin_rule_id_secret_actual_hardcoded_is_real_finding() {
+        assert!(!post_match_filter(
+            "sec-hardcoded-secret",
+            "let password = supersecret12345"
         ));
     }
 }

--- a/src/engine/rules/builtin.rs
+++ b/src/engine/rules/builtin.rs
@@ -135,6 +135,9 @@ pub fn post_match_filter(rule_id: &str, line: &str) -> bool {
         "config/cors-wildcard" => is_false_positive_cors(line),
         "injection/sql-concat" => is_false_positive_sql_concat(line),
         "config/debug-enabled" => is_false_positive_debug(line),
+        "injection/eval" => is_false_positive_eval(line),
+        "crypto/weak-hash" => is_false_positive_weak_hash(line),
+        "crypto/ssl-verify-disabled" => is_false_positive_ssl_verify(line),
         _ => false,
     }
 }
@@ -307,6 +310,135 @@ fn is_false_positive_debug(line: &str) -> bool {
     if lower.contains("env")
         && (lower.contains("getenv") || lower.contains("environ") || lower.contains("from_env"))
     {
+        return true;
+    }
+
+    false
+}
+
+/// Check if an `eval` match is a false positive.
+///
+/// Suppresses: comment lines, documentation, `evaluate` (not `eval`),
+/// and safe eval with literal expressions.
+fn is_false_positive_eval(line: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Comment lines
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("--")
+    {
+        return true;
+    }
+
+    // Python/Rust docstrings
+    if trimmed.contains("\"\"\"") || trimmed.contains("'''") {
+        return true;
+    }
+
+    let lower = line.to_lowercase();
+
+    // "evaluate" or "evaluation" is not "eval"
+    if lower.contains("evaluate") || lower.contains("evaluation") {
+        return true;
+    }
+
+    // Imports of eval from ast/json (safe parsing utilities)
+    if lower.contains("ast.literal_eval") || lower.contains("json.") {
+        return true;
+    }
+
+    false
+}
+
+/// Check if a `weak-hash` match is a false positive.
+///
+/// Suppresses: comment lines, documentation, and import statements
+/// that merely reference the API without calling it.
+fn is_false_positive_weak_hash(line: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Comment lines
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("--")
+    {
+        return true;
+    }
+
+    // Python/Rust docstrings
+    if trimmed.contains("\"\"\"") || trimmed.contains("'''") {
+        return true;
+    }
+
+    let lower = line.to_lowercase();
+
+    // Import/use statements (Python, Rust use, JS import)
+    if lower.contains("import ")
+        || lower.contains("use ")
+        || lower.contains("require(")
+        || lower.contains("#include")
+    {
+        return true;
+    }
+
+    // Type annotations or trait bounds (Rust)
+    if lower.contains("impl ") || lower.contains("fn ") || lower.contains("type ") {
+        return true;
+    }
+
+    false
+}
+
+/// Check if an `ssl-verify-disabled` match is a false positive.
+///
+/// Suppresses: comment lines, documentation, config schema definitions,
+/// and environment variable references.
+fn is_false_positive_ssl_verify(line: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Comment lines
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("--")
+    {
+        return true;
+    }
+
+    // Python/Rust docstrings
+    if trimmed.contains("\"\"\"") || trimmed.contains("'''") {
+        return true;
+    }
+
+    let lower = line.to_lowercase();
+
+    // Environment variable references (verify from env config, not hardcoded)
+    if lower.contains("env")
+        && (lower.contains("getenv")
+            || lower.contains("environ")
+            || lower.contains("from_env")
+            || lower.contains("process.env"))
+    {
+        return true;
+    }
+
+    // Config schema/validation definitions (e.g., TypeScript interfaces, Pydantic)
+    if lower.contains("interface ")
+        || lower.contains("schema")
+        || lower.contains("field(")
+        || lower.contains("default:")
+    {
+        return true;
+    }
+
+    // Negation patterns — "verify = True" or "do not disable"
+    if lower.contains("verify") && lower.contains("true") && !lower.contains("false") {
         return true;
     }
 

--- a/src/engine/rules/builtin.rs
+++ b/src/engine/rules/builtin.rs
@@ -1,4 +1,7 @@
 /// Built-in rules for the rule engine.
+use regex::Regex;
+use std::sync::LazyLock;
+
 use crate::engine::Severity;
 use crate::engine::rules::types::CustomRule;
 
@@ -245,44 +248,84 @@ fn is_false_positive_secret(line: &str) -> bool {
     false
 }
 
+/// Negation markers that indicate a line is documenting that wildcards
+/// are disallowed. Matched against the comment-stripped, lowercased line.
+/// Plain strings use `contains`; patterns ending with `.*` use regex.
+const CORS_NEGATION_MARKERS: &[&str] = &[
+    "no wildcard",
+    "no catch-all",
+    "no catch all",
+    "not.*wildcard",
+    "do not.*wildcard",
+    "do not.*\\*",
+    "without.*wildcard",
+    "never.*wildcard",
+    "disallow.*wildcard",
+    "prohibit.*wildcard",
+    "avoid.*wildcard",
+    "except.*wildcard",
+];
+
+static CORS_NEGATION_RE: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    CORS_NEGATION_MARKERS
+        .iter()
+        .filter_map(|m| Regex::new(m).ok())
+        .collect()
+});
+
+/// Strip comment prefix from a line for negation checking.
+/// Handles: `//`, `#`, `--`, `/*`, `*` (block comment continuation).
+fn strip_comment_prefix(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    for prefix in &["//", "#", "--", "/*", "*"] {
+        if let Some(stripped) = trimmed.strip_prefix(prefix) {
+            return stripped.trim_start();
+        }
+    }
+    trimmed
+}
+
 /// Check if a CORS wildcard match is a false positive.
 ///
-/// Suppresses: negation contexts ("no wildcard", "do not use *"), comments
-/// documenting that wildcards are disallowed, and env var names that contain
-/// "cors" but are not wildcard assignments.
+/// Suppresses: negation contexts ("no wildcard", "do not use *") only when
+/// the negation appears in a **comment prefix** (not mixed with code), and
+/// env var *read* patterns (`env::var("...")`, `getenv("...")`).
+///
+/// Does NOT suppress actual wildcard assignments like `CORS_CONFIG = "*"`
+/// or code that appears after a comment on the same line.
 fn is_false_positive_cors(line: &str) -> bool {
     let lower = line.to_lowercase();
 
-    // Negation context — line says wildcards are NOT allowed.
-    // Examples: "no wildcard", "do not use *", "without wildcard"
-    let negation_markers = [
-        "no wildcard",
-        "no catch-all",
-        "no catch all",
-        "not.*wildcard",
-        "do not.*wildcard",
-        "do not.*\\*",
-        "without.*wildcard",
-        "never.*wildcard",
-        "disallow.*wildcard",
-        "prohibit.*wildcard",
-        "avoid.*wildcard",
-        "except.*wildcard",
-    ];
-    for marker in &negation_markers {
-        if let Ok(re) = regex::Regex::new(marker) {
-            if re.is_match(&lower) {
-                return true;
+    // Negation context — but ONLY in comment prefix, not mixed with code.
+    // First strip the comment prefix, then check if the remaining text
+    // is purely a negation statement (no assignment/code after it).
+    let comment_body = strip_comment_prefix(line);
+    let comment_lower = comment_body.to_lowercase();
+
+    // Only apply negation filter if the original line was a comment
+    // AND the comment body does NOT contain code indicators (=, ", ', wildcard *)
+    // after the negation phrase. This prevents suppressing mixed lines like
+    // `// no wildcard for now, but origin = "*"` where real code follows the comment.
+    let is_comment = line.trim_start() != comment_body;
+    if is_comment {
+        // Check for code indicators in the comment body — if present, the line
+        // contains actual code after the comment, so negation should NOT suppress.
+        let has_code = comment_body.contains('=')
+            || comment_body.contains("fn ")
+            || comment_body.contains("let ")
+            || comment_body.contains("const ");
+        if !has_code {
+            for re in CORS_NEGATION_RE.iter() {
+                if re.is_match(&comment_lower) {
+                    return true;
+                }
             }
         }
     }
 
-    // Env var or config key names containing "cors" — these are identifiers,
-    // not wildcard assignments. e.g., TITEN_CORS_ORIGINS, CORS_ALLOWED_ORIGINS
-    if lower.contains("cors_origins")
-        || lower.contains("cors_allowed")
-        || lower.contains("cors_config")
-    {
+    // Env var READ patterns (not bare assignments).
+    // e.g., env::var("TITEN_CORS_ORIGINS"), getenv("CORS_CONFIG")
+    if lower.contains("env::var(") || lower.contains("getenv(") || lower.contains("os.environ") {
         return true;
     }
 
@@ -510,13 +553,44 @@ mod tests {
 
     #[test]
     fn cors_env_var_name_is_false_positive() {
+        // env::var() read pattern — should be suppressed
         assert!(post_match_filter(
             "config/cors-wildcard",
-            "TITEN_CORS_ORIGINS=https://example.com"
+            "let val = env::var(\"TITEN_CORS_ORIGINS\").unwrap();"
         ));
         assert!(post_match_filter(
             "config/cors-wildcard",
-            "CORS_ALLOWED_ORIGINS=https://example.com"
+            "let val = getenv(\"CORS_ALLOWED_ORIGINS\");"
+        ));
+        assert!(post_match_filter(
+            "config/cors-wildcard",
+            "os.environ.get(\"CORS_ORIGINS\")"
+        ));
+    }
+
+    #[test]
+    fn cors_config_assignment_is_not_false_positive() {
+        // Issue #488: bare CORS_CONFIG = "*" is a REAL finding, not env var read
+        assert!(!post_match_filter(
+            "config/cors-wildcard",
+            "CORS_CONFIG = \"*\""
+        ));
+        assert!(!post_match_filter(
+            "config/cors-wildcard",
+            "cors_origins = \"*\""
+        ));
+    }
+
+    #[test]
+    fn cors_mixed_comment_code_not_suppressed() {
+        // Issue #488: code after a comment should NOT be suppressed by negation
+        assert!(!post_match_filter(
+            "config/cors-wildcard",
+            "// no wildcard for now, but origin = \"*\""
+        ));
+        assert!(!post_match_filter(
+            "config/cors-wildcard",
+            "# except for wildcard endpoints: cors = \"*\""
         ));
     }
 

--- a/src/engine/rules/builtin.rs
+++ b/src/engine/rules/builtin.rs
@@ -129,6 +129,7 @@ pub fn post_match_filter(rule_id: &str, line: &str) -> bool {
     match rule_id {
         "sec-hardcoded-secret" | "crypto/hardcoded-secret" => is_false_positive_secret(line),
         "sec-hardcoded-url" => is_false_positive_url(line),
+        "config/cors-wildcard" => is_false_positive_cors(line),
         _ => false,
     }
 }
@@ -239,6 +240,50 @@ fn is_false_positive_secret(line: &str) -> bool {
                 return true;
             }
         }
+    }
+
+    false
+}
+
+/// Check if a CORS wildcard match is a false positive.
+///
+/// Suppresses: negation contexts ("no wildcard", "do not use *"), comments
+/// documenting that wildcards are disallowed, and env var names that contain
+/// "cors" but are not wildcard assignments.
+fn is_false_positive_cors(line: &str) -> bool {
+    let lower = line.to_lowercase();
+
+    // Negation context — line says wildcards are NOT allowed.
+    // Examples: "no wildcard", "do not use *", "without wildcard"
+    let negation_markers = [
+        "no wildcard",
+        "no catch-all",
+        "no catch all",
+        "not.*wildcard",
+        "do not.*wildcard",
+        "do not.*\\*",
+        "without.*wildcard",
+        "never.*wildcard",
+        "disallow.*wildcard",
+        "prohibit.*wildcard",
+        "avoid.*wildcard",
+        "except.*wildcard",
+    ];
+    for marker in &negation_markers {
+        if let Ok(re) = regex::Regex::new(marker) {
+            if re.is_match(&lower) {
+                return true;
+            }
+        }
+    }
+
+    // Env var or config key names containing "cors" — these are identifiers,
+    // not wildcard assignments. e.g., TITEN_CORS_ORIGINS, CORS_ALLOWED_ORIGINS
+    if lower.contains("cors_origins")
+        || lower.contains("cors_allowed")
+        || lower.contains("cors_config")
+    {
+        return true;
     }
 
     false
@@ -434,6 +479,64 @@ mod tests {
         assert!(!post_match_filter(
             "sec-hardcoded-secret",
             "let password = supersecret12345"
+        ));
+    }
+
+    // ─── config/cors-wildcard false positive tests (issue #483) ───
+
+    #[test]
+    fn cors_negation_no_wildcard_is_false_positive() {
+        assert!(post_match_filter(
+            "config/cors-wildcard",
+            "// No wildcard — only explicit origins"
+        ));
+    }
+
+    #[test]
+    fn cors_negation_no_catch_all_is_false_positive() {
+        assert!(post_match_filter(
+            "config/cors-wildcard",
+            "// No catch-all origin pattern is permitted"
+        ));
+    }
+
+    #[test]
+    fn cors_negation_do_not_use_wildcard_is_false_positive() {
+        assert!(post_match_filter(
+            "config/cors-wildcard",
+            "# Do not use * in production"
+        ));
+    }
+
+    #[test]
+    fn cors_env_var_name_is_false_positive() {
+        assert!(post_match_filter(
+            "config/cors-wildcard",
+            "TITEN_CORS_ORIGINS=https://example.com"
+        ));
+        assert!(post_match_filter(
+            "config/cors-wildcard",
+            "CORS_ALLOWED_ORIGINS=https://example.com"
+        ));
+    }
+
+    #[test]
+    fn cors_actual_wildcard_is_not_false_positive() {
+        assert!(!post_match_filter(
+            "config/cors-wildcard",
+            "Access-Control-Allow-Origin: *"
+        ));
+        assert!(!post_match_filter(
+            "config/cors-wildcard",
+            "let origin = \"*\";"
+        ));
+    }
+
+    #[test]
+    fn cors_unrelated_rule_not_affected() {
+        assert!(!post_match_filter(
+            "crypto/hardcoded-secret",
+            "No wildcard in this line"
         ));
     }
 }

--- a/src/engine/secrets_scanner.rs
+++ b/src/engine/secrets_scanner.rs
@@ -178,9 +178,28 @@ pub fn scan_secrets(chunks: &[FileChunk], max_findings: usize) -> Vec<RuleFindin
 /// Mask a secret value: show first 4 and last 4 chars, replace middle with ****.
 fn mask_secret(s: &str) -> String {
     if s.len() <= 12 {
-        return format!("{}****", &s[..s.len().min(4)]);
+        let end = floor_boundary(s, s.len().min(4));
+        return format!("{}****", &s[..end]);
     }
-    format!("{}****{}", &s[..4], &s[s.len() - 4..])
+    let head = floor_boundary(s, 4);
+    // For the tail, count back from the end until we have a valid boundary.
+    let tail_start = {
+        let mut idx = s.len() - 4;
+        while !s.is_char_boundary(idx) {
+            idx += 1;
+        }
+        idx
+    };
+    format!("{}****{}", &s[..head], &s[tail_start..])
+}
+
+/// Find the largest byte index <= `target` that is a valid UTF-8 char boundary.
+fn floor_boundary(s: &str, target: usize) -> usize {
+    let mut end = target.min(s.len());
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 #[cfg(test)]
@@ -383,6 +402,25 @@ mod tests {
     #[test]
     fn mask_secret_medium() {
         assert_eq!(mask_secret("ghp_abcdef"), "ghp_****");
+    }
+
+    #[test]
+    fn mask_secret_multibyte_no_panic() {
+        // Secret containing multi-byte UTF-8 characters.
+        // Without char-boundary checking, &s[..4] could split a codepoint.
+        let secret = "🔒secret-api-key-value-1234567890";
+        // Should not panic and should still mask the middle.
+        let masked = mask_secret(secret);
+        assert!(masked.contains("****"));
+    }
+
+    #[test]
+    fn mask_secret_multibyte_short_no_panic() {
+        // Short secret (≤12 bytes) with multi-byte chars.
+        // "🔒ab" = 4 + 1 + 1 = 6 bytes, 3 chars.
+        let secret = "🔒ab";
+        let masked = mask_secret(secret);
+        assert!(masked.ends_with("****"));
     }
 
     #[test]

--- a/src/engine/security_scanner.rs
+++ b/src/engine/security_scanner.rs
@@ -87,12 +87,42 @@ pub static PATTERNS: &[SecurityPattern] = &[
     SecurityPattern {
         id: "config/cors-wildcard",
         name: "CORS wildcard allows all origins",
-        // Match actual code patterns, not the word "cors" in prose/documentation.
-        // Require either the literal HTTP header with `*`, or a code assignment/call
-        // like `cors = "*"`, `origin: *`, `allowed_origins = "*"`, `allow_origin("*")`.
-        // The word "cors" alone is too broad — it appears in env var names
-        // (TITEN_CORS_ORIGINS), config keys, and documentation.
-        regex: r#"(?i)(?:Access-Control-Allow-Origin\s*:\s*\*|(?:cors|allow_origin|allowed_origins)\s*[=:(]\s*["']?\*["']?|origin\s*[=:]\s*["']?\*["']?)"#,
+        // Match real code patterns across frameworks — not the bare word "cors" in prose.
+        // Uses (?ix) for case-insensitive + extended (whitespace ignored, comments with #).
+        // Rust regex crate does NOT support lookahead (?!\w), so we use explicit
+        // trailing delimiters to prevent partial-word false positives.
+        regex: r#"(?ix)
+        (?:
+          # 1. HTTP response header (any spacing/quote style)
+          Access-Control-Allow-Origin \s* :? \s* ["']? \* ["']? (?: \s | ; | $ )
+        |
+          # 2. Generic keyword assignment with wildcard (covers quotes, brackets)
+          (?: cors | allow_origin | allowed_origins | allow_origins ) \s* [=:(\[] \s* ["'\[\{]{0,2} \* ["'\]\}]{0,2} (?: \s | ; | , | \) | \] | $ )
+        |
+          # 3. keyword origin assignment
+          origin \s* [:=] \s* ["']? \* ["']? (?: \s | ; | $ )
+        |
+          # 4. Django boolean flag
+          CORS_ALLOW_ALL_ORIGINS \s* = \s* True
+        |
+          # 5. Spring .allowedOrigins("*")
+          \. allowedOrigins \s* \( \s* ["'] \* ["'] \s* \)
+        |
+          # 6. .NET AllowAnyOrigin()
+          AllowAnyOrigin \s* \(
+        |
+          # 7. tower-http allow_origin(Any)
+          allow_origin \s* \( \s* Any \s* \)
+        |
+          # 8. Express cors({ origin: true })
+          cors \s* \( \s* \{ \s* origin \s* : \s* true
+        |
+          # 9. nginx add_header
+          add_header \s+ Access-Control-Allow-Origin \s+ \*
+        |
+          # 10. actix SetHeader
+          SetHeader \s* \( \s* ["'] Access-Control-Allow-Origin ["'] \s* , \s* ["'] \* ["']
+        )"#,
         severity: Severity::Major,
     },
     // ── TLS/SSL ──
@@ -236,8 +266,15 @@ fn is_test_file(path: &str) -> bool {
 /// keywords (CORS, secret, password) appear naturally in documentation prose.
 fn is_doc_file(path: &str) -> bool {
     let lower = path.to_lowercase();
+    // Ensure the path contains a dot before extracting extension.
+    // Without this, extensionless files like "org" or "tex" would
+    // be treated as documentation (rsplit returns the whole string).
+    let ext = match lower.rfind('.') {
+        Some(pos) => &lower[pos + 1..],
+        None => return false,
+    };
     matches!(
-        lower.rsplit('.').next().unwrap_or(""),
+        ext,
         "md" | "markdown" | "mdx" | "txt" | "rst" | "adoc" | "asciidoc" | "tex" | "org"
     )
 }
@@ -627,12 +664,144 @@ mod tests {
             .iter()
             .filter(|f| f.rule_id == "config/cors-wildcard")
             .collect();
-        // This should trigger because it's a code assignment pattern: origin = "*"
         assert_eq!(
             cors_findings.len(),
             1,
             "Real CORS wildcard in Rust code should be detected"
         );
+    }
+
+    // ─── Framework-specific CORS patterns (issue #488) ───
+
+    #[test]
+    fn detects_cors_wildcard_nginx_add_header() {
+        let chunks = vec![make_chunk(
+            "nginx.conf",
+            &["add_header Access-Control-Allow-Origin *;"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors.len(),
+            1,
+            "nginx add_header wildcard should be detected"
+        );
+    }
+
+    #[test]
+    fn detects_cors_wildcard_django() {
+        let chunks = vec![make_chunk(
+            "settings.py",
+            &["CORS_ALLOW_ALL_ORIGINS = True"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors.len(),
+            1,
+            "Django CORS_ALLOW_ALL_ORIGINS should be detected"
+        );
+    }
+
+    #[test]
+    fn detects_cors_wildcard_spring_boot() {
+        let chunks = vec![make_chunk("WebConfig.java", &[".allowedOrigins(\"*\")"])];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors.len(),
+            1,
+            "Spring .allowedOrigins(\"*\") should be detected"
+        );
+    }
+
+    #[test]
+    fn detects_cors_wildcard_dotnet_allowany() {
+        let chunks = vec![make_chunk("Startup.cs", &[".AllowAnyOrigin()"])];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(cors.len(), 1, ".NET AllowAnyOrigin() should be detected");
+    }
+
+    #[test]
+    fn detects_cors_wildcard_tower_http_any() {
+        let chunks = vec![make_chunk("src/main.rs", &[".allow_origin(Any)"])];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors.len(),
+            1,
+            "tower-http allow_origin(Any) should be detected"
+        );
+    }
+
+    #[test]
+    fn detects_cors_wildcard_express_origin_true() {
+        let chunks = vec![make_chunk("app.js", &["cors({ origin: true })"])];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors.len(),
+            1,
+            "Express cors({{ origin: true }}) should be detected"
+        );
+    }
+
+    #[test]
+    fn detects_cors_wildcard_fastapi_list() {
+        let chunks = vec![make_chunk("main.py", &["allow_origins=[\"*\"]"])];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors.len(),
+            1,
+            "FastAPI allow_origins=[\"*\"] should be detected"
+        );
+    }
+
+    #[test]
+    fn detects_cors_wildcard_nginx_set_header_actix() {
+        let chunks = vec![make_chunk(
+            "src/server.rs",
+            &["SetHeader(\"Access-Control-Allow-Origin\", \"*\")"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let cors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(cors.len(), 1, "actix SetHeader wildcard should be detected");
+    }
+
+    #[test]
+    fn is_doc_file_does_not_match_extensionless() {
+        // Issue #489: extensionless files should not be treated as docs
+        assert!(!is_doc_file("org"));
+        assert!(!is_doc_file("tex"));
+        assert!(!is_doc_file("md"));
+        assert!(!is_doc_file("src/org"));
+        assert!(!is_doc_file("bin/tex"));
     }
 
     #[test]

--- a/src/engine/security_scanner.rs
+++ b/src/engine/security_scanner.rs
@@ -87,7 +87,12 @@ pub static PATTERNS: &[SecurityPattern] = &[
     SecurityPattern {
         id: "config/cors-wildcard",
         name: "CORS wildcard allows all origins",
-        regex: r"(?i)(?:Access-Control-Allow-Origin|cors).*\*",
+        // Match actual code patterns, not the word "cors" in prose/documentation.
+        // Require either the literal HTTP header with `*`, or a code assignment/call
+        // like `cors = "*"`, `origin: *`, `allowed_origins = "*"`, `allow_origin("*")`.
+        // The word "cors" alone is too broad — it appears in env var names
+        // (TITEN_CORS_ORIGINS), config keys, and documentation.
+        regex: r#"(?i)(?:Access-Control-Allow-Origin\s*:\s*\*|(?:cors|allow_origin|allowed_origins)\s*[=:(]\s*["']?\*["']?|origin\s*[=:]\s*["']?\*["']?)"#,
         severity: Severity::Major,
     },
     // ── TLS/SSL ──
@@ -127,6 +132,14 @@ pub fn scan_security(chunks: &[FileChunk], max_findings: usize) -> Vec<RuleFindi
         // Skip test/spec/fixture/mock/example files
         if is_test_file(path) {
             debug!(file = path, "skipping test file in security scan");
+            continue;
+        }
+
+        // Skip documentation and non-code files — security patterns are designed
+        // for source code, not prose. Prevents false positives like flagging
+        // "CORS" in a markdown config guide (#483).
+        if is_doc_file(path) {
+            debug!(file = path, "skipping documentation file in security scan");
             continue;
         }
 
@@ -214,6 +227,19 @@ fn is_test_file(path: &str) -> bool {
         }
     }
     false
+}
+
+/// Check if a file path is a documentation or non-code file.
+///
+/// Security scanner patterns are designed for source code. Scanning markdown,
+/// plain text, or reStructuredText produces false positives because security
+/// keywords (CORS, secret, password) appear naturally in documentation prose.
+fn is_doc_file(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    matches!(
+        lower.rsplit('.').next().unwrap_or(""),
+        "md" | "markdown" | "mdx" | "txt" | "rst" | "adoc" | "asciidoc" | "tex" | "org"
+    )
 }
 
 #[cfg(test)]
@@ -449,7 +475,7 @@ mod tests {
     fn real_hardcoded_secret_still_detected_after_filter() {
         let chunks = vec![make_chunk(
             "src/config.py",
-            &["API_KEY = sk_live_abc123def456"],
+            &["API_KEY = \"sk_live_abc123def456ghi789\""],
         )];
         let findings = scan_security(&chunks, 10);
         let secret_findings: Vec<_> = findings
@@ -461,5 +487,176 @@ mod tests {
             1,
             "Real hardcoded secret should still be detected"
         );
+    }
+
+    // ─── CORS false positive tests (issue #483) ───
+
+    #[test]
+    fn detects_cors_wildcard_header() {
+        // The classic dangerous pattern — actual HTTP header with wildcard
+        let chunks = vec![make_chunk(
+            "src/server.rs",
+            &["Access-Control-Allow-Origin: *"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let cors_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(cors_findings.len(), 1, "Should detect wildcard CORS header");
+    }
+
+    #[test]
+    fn detects_cors_wildcard_assignment() {
+        // Code assignment like cors = "*" or origin = '*'
+        let chunks = vec![make_chunk("src/config.rs", &["let cors_origin = \"*\";"])];
+        let findings = scan_security(&chunks, 10);
+        let cors_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors_findings.len(),
+            1,
+            "Should detect cors assignment with wildcard"
+        );
+    }
+
+    #[test]
+    fn detects_allowed_origins_wildcard() {
+        // Pattern: allowed_origins = "*"
+        let chunks = vec![make_chunk("src/app.py", &["allowed_origins = \"*\""])];
+        let findings = scan_security(&chunks, 10);
+        let cors_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert_eq!(
+            cors_findings.len(),
+            1,
+            "Should detect allowed_origins with wildcard"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_cors_env_var_name() {
+        // Issue #483: TITEN_CORS_ORIGINS contains "cors" but is not a wildcard assignment.
+        // The * after it comes from markdown bold (**), not a CORS wildcard.
+        let chunks = vec![make_chunk(
+            "src/config.rs",
+            &["let val = std::env::var(\"TITEN_CORS_ORIGINS\").unwrap_or(\"*\");"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let cors_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert!(
+            cors_findings.is_empty(),
+            "TITEN_CORS_ORIGINS env var name should not trigger CORS wildcard"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_cors_in_prose() {
+        // Issue #483: "CORS" keyword in documentation prose near a `*` character
+        let chunks = vec![make_chunk(
+            "src/config.rs",
+            &["// CORS configured via TITEN_CORS_ORIGINS env var"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let cors_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        assert!(
+            cors_findings.is_empty(),
+            "CORS keyword in comment prose should not trigger"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_markdown_file() {
+        // Issue #483: .md files should be skipped entirely by security scanner
+        let chunks = vec![make_chunk(
+            "docs/deployment.md",
+            &["Access-Control-Allow-Origin: *"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "Markdown files should not be scanned by security scanner"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_txt_file() {
+        let chunks = vec![make_chunk(
+            "docs/security.txt",
+            &["Access-Control-Allow-Origin: *"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "Text files should not be scanned by security scanner"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_rst_file() {
+        let chunks = vec![make_chunk(
+            "docs/api.rst",
+            &["Access-Control-Allow-Origin: *"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "reStructuredText files should not be scanned"
+        );
+    }
+
+    #[test]
+    fn real_cors_wildcard_in_rust_still_detected() {
+        // Make sure we don't over-suppress — actual code patterns still trigger
+        let chunks = vec![make_chunk(
+            "src/server.rs",
+            &[".layer(CorsLayer::new().allow_origin(\"*\"))"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let cors_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id == "config/cors-wildcard")
+            .collect();
+        // This should trigger because it's a code assignment pattern: origin = "*"
+        assert_eq!(
+            cors_findings.len(),
+            1,
+            "Real CORS wildcard in Rust code should be detected"
+        );
+    }
+
+    #[test]
+    fn is_doc_file_recognizes_common_extensions() {
+        assert!(is_doc_file("README.md"));
+        assert!(is_doc_file("docs/guide.markdown"));
+        assert!(is_doc_file("docs/api.mdx"));
+        assert!(is_doc_file("notes.txt"));
+        assert!(is_doc_file("docs/spec.rst"));
+        assert!(is_doc_file("docs/manual.adoc"));
+        assert!(is_doc_file("docs/manual.asciidoc"));
+        assert!(is_doc_file("paper.tex"));
+        assert!(is_doc_file("notes.org"));
+    }
+
+    #[test]
+    fn is_doc_file_does_not_match_code_files() {
+        assert!(!is_doc_file("src/main.rs"));
+        assert!(!is_doc_file("src/app.py"));
+        assert!(!is_doc_file("src/server.ts"));
+        assert!(!is_doc_file("src/index.js"));
+        assert!(!is_doc_file("src/config.go"));
+        assert!(!is_doc_file("Dockerfile"));
+        assert!(!is_doc_file("docker-compose.yml"));
+        assert!(!is_doc_file("Makefile"));
     }
 }

--- a/src/engine/security_scanner.rs
+++ b/src/engine/security_scanner.rs
@@ -1052,4 +1052,211 @@ mod tests {
             "role === \"superuser\" must be detected"
         );
     }
+
+    // ── #487: injection/eval post-match filter tests ──
+
+    #[test]
+    fn eval_real_injection_still_detected() {
+        let chunks = vec![make_chunk("src/app.py", &["result = eval(request.data)"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "eval(request.data) must be detected");
+    }
+
+    #[test]
+    fn eval_user_input_still_detected() {
+        let chunks = vec![make_chunk("src/app.py", &["eval(user_input)"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "eval(user_input) must be detected");
+    }
+
+    #[test]
+    fn eval_comment_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/app.py",
+            &["// eval(request.body) — deprecated, use safe_parse()"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(findings.is_empty(), "eval in comment should be suppressed");
+    }
+
+    #[test]
+    fn evaluate_not_flagged_as_eval() {
+        let chunks = vec![make_chunk(
+            "src/app.py",
+            &["result = evaluate(request, context)"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(findings.is_empty(), "evaluate() should not match eval rule");
+    }
+
+    #[test]
+    fn eval_docstring_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/app.py",
+            &["\"\"\"Calls eval(params) for backwards compatibility.\"\"\""],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "eval in docstring should be suppressed"
+        );
+    }
+
+    #[test]
+    fn ast_literal_eval_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/app.py",
+            &["data = ast.literal_eval(request.body)"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "ast.literal_eval should be suppressed (safe)"
+        );
+    }
+
+    // ── #487: crypto/weak-hash post-match filter tests ──
+
+    #[test]
+    fn weak_hash_real_usage_still_detected() {
+        let chunks = vec![make_chunk(
+            "src/crypto.py",
+            &["hashlib.md5(data).hexdigest()"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "hashlib.md5(data) must be detected");
+    }
+
+    #[test]
+    fn weak_hash_comment_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/crypto.py",
+            &["// TODO: replace hashlib.md5 with sha256"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "hashlib.md5 in comment should be suppressed"
+        );
+    }
+
+    #[test]
+    fn weak_hash_import_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/crypto.py",
+            &["from hashlib import md5, sha1, sha256"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "import of hashlib.md5 should be suppressed"
+        );
+    }
+
+    #[test]
+    fn weak_hash_rust_use_suppressed() {
+        let chunks = vec![make_chunk("src/crypto.rs", &["use sha1::Sha1;"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "Rust use of Digest::SHA1 should be suppressed"
+        );
+    }
+
+    #[test]
+    fn weak_hash_docstring_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/crypto.py",
+            &["\"\"\"Uses hashlib.md5 for legacy compatibility.\"\"\""],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "hashlib.md5 in docstring should be suppressed"
+        );
+    }
+
+    // ── #487: crypto/ssl-verify-disabled post-match filter tests ──
+
+    #[test]
+    fn ssl_verify_disabled_real_still_detected() {
+        let chunks = vec![make_chunk(
+            "src/client.py",
+            &["requests.get(url, verify=False)"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "verify=False must be detected");
+    }
+
+    #[test]
+    fn ssl_verify_disabled_reject_unauthorized_still_detected() {
+        let chunks = vec![make_chunk(
+            "src/client.ts",
+            &["agent: new https.Agent({ rejectUnauthorized: false })"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "rejectUnauthorized: false must be detected"
+        );
+    }
+
+    #[test]
+    fn ssl_verify_comment_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/client.py",
+            &["# Do not set verify=False in production"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "verify=False in comment should be suppressed"
+        );
+    }
+
+    #[test]
+    fn ssl_verify_env_reference_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/client.py",
+            &["verify = os.environ.get('SSL_VERIFY', 'True')"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(findings.is_empty(), "verify from env should be suppressed");
+    }
+
+    #[test]
+    fn ssl_verify_schema_definition_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/config.ts",
+            &["interface HttpConfig { verify: false }"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        // The regex `verify:\s*false` matches inside interface — but the
+        // post-match filter should suppress schema definitions.
+        assert!(
+            findings.is_empty(),
+            "verify: false in interface/schema should be suppressed"
+        );
+    }
+
+    #[test]
+    fn ssl_verify_true_not_flagged() {
+        let chunks = vec![make_chunk("src/client.py", &["verify: true"])];
+        let findings = scan_security(&chunks, 10);
+        // verify: true should NOT trigger the rule at all (regex requires False)
+        assert!(findings.is_empty(), "verify: true should not be flagged");
+    }
+
+    #[test]
+    fn ssl_verify_docstring_suppressed() {
+        let chunks = vec![make_chunk(
+            "src/client.py",
+            &["\"\"\"Never use verify=False in production code.\"\"\""],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            findings.is_empty(),
+            "verify=False in docstring should be suppressed"
+        );
+    }
 }

--- a/src/engine/security_scanner.rs
+++ b/src/engine/security_scanner.rs
@@ -52,7 +52,10 @@ pub static PATTERNS: &[SecurityPattern] = &[
     SecurityPattern {
         id: "injection/sql-concat",
         name: "SQL injection via string concatenation",
-        regex: r"(?i)(?:SELECT|INSERT|UPDATE|DELETE)\s+.*\+",
+        // Require a SQL keyword inside a string literal, followed by concatenation.
+        // This prevents matching comments, prose, and non-SQL code that happens
+        // to contain SQL keywords + "+".
+        regex: r#"(?i)(?:(?:SELECT|INSERT|UPDATE|DELETE)\b[^"\']*["\x27`][^"\']*\+|format!\s*\(\s*["\x27`]\s*(?:SELECT|INSERT|UPDATE|DELETE))"#,
         severity: Severity::Critical,
     },
     SecurityPattern {
@@ -74,14 +77,19 @@ pub static PATTERNS: &[SecurityPattern] = &[
     SecurityPattern {
         id: "auth/hardcoded-role",
         name: "Hardcoded role or permission check",
-        regex: r"(?i)role\s*==\s*(?:admin|super|root)|is_admin\s*==\s*True",
+        // Match both quoted and unquoted role comparisons, property access
+        // (user.role), and strict equality (===) for JS/TS.
+        regex: r#"(?i)(?:\w+\.)*role\s*[=]{2,3}\s*["']?(?:admin|super|root|superuser)["']?|is_admin\s*==\s*True"#,
         severity: Severity::Major,
     },
     // ── Debug config ──
     SecurityPattern {
         id: "config/debug-enabled",
         name: "Debug mode enabled (production risk)",
-        regex: r"(?i)(?:DEBUG\s*=\s*True|debug:\s*true|--debug)",
+        // Only match actual config assignments, not CLI flag references.
+        // `--debug` is removed — it matches dev tooling, argument parsers,
+        // Dockerfiles, and documentation (too many false positives).
+        regex: r#"(?i)(?:DEBUG\s*=\s*True|debug\s*:\s*true|debug\s*=\s*true)"#,
         severity: Severity::Minor,
     },
     SecurityPattern {
@@ -827,5 +835,221 @@ mod tests {
         assert!(!is_doc_file("Dockerfile"));
         assert!(!is_doc_file("docker-compose.yml"));
         assert!(!is_doc_file("Makefile"));
+    }
+
+    // ── #485: sql-concat false positive tests ──
+
+    #[test]
+    fn sql_concat_real_injection_still_detected() {
+        let chunks = vec![make_chunk(
+            "src/db.py",
+            &["query = \"SELECT * FROM users WHERE id = \" + user_input"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "real SQL concat must be detected");
+        assert!(findings[0].rule_id.contains("sql"));
+    }
+
+    #[test]
+    fn sql_concat_format_macro_detected() {
+        let chunks = vec![make_chunk(
+            "src/db.rs",
+            &["let q = format!(\"SELECT * FROM users WHERE id = {}\", id);"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "format! with SELECT must be detected");
+    }
+
+    #[test]
+    fn sql_concat_comment_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/db.py",
+            &["// SELECT all users then concatenate results"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let sql_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("sql"))
+            .collect();
+        assert!(
+            sql_findings.is_empty(),
+            "comment with SQL keyword + '+' should not be flagged"
+        );
+    }
+
+    #[test]
+    fn sql_concat_python_comment_not_flagged() {
+        let chunks = vec![make_chunk("src/db.py", &["# SELECT a + b FROM joined"])];
+        let findings = scan_security(&chunks, 10);
+        let sql_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("sql"))
+            .collect();
+        assert!(sql_findings.is_empty());
+    }
+
+    #[test]
+    fn sql_concat_non_sql_plus_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/calc.rs",
+            &["let total = a + b; // UPDATE: not SQL"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let sql_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("sql"))
+            .collect();
+        assert!(sql_findings.is_empty());
+    }
+
+    // ── #486: debug-enabled false positive tests ──
+
+    #[test]
+    fn debug_real_assignment_still_detected() {
+        let chunks = vec![make_chunk("src/config.py", &["DEBUG = True"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "DEBUG = True must be detected");
+        assert!(findings[0].rule_id.contains("debug"));
+    }
+
+    #[test]
+    fn debug_yaml_true_still_detected() {
+        let chunks = vec![make_chunk("src/config.yml", &["debug: true"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "debug: true must be detected");
+    }
+
+    #[test]
+    fn debug_cli_flag_not_flagged() {
+        let chunks = vec![make_chunk(
+            "Dockerfile",
+            &["RUN cargo test -- --debug 2>/dev/null"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let debug_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("debug"))
+            .collect();
+        assert!(
+            debug_findings.is_empty(),
+            "--debug CLI flag should not be flagged"
+        );
+    }
+
+    #[test]
+    fn debug_argument_parser_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/cli.py",
+            &["parser.add_argument('--debug', help='Enable debug mode')"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let debug_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("debug"))
+            .collect();
+        assert!(
+            debug_findings.is_empty(),
+            "argument parser definition should not be flagged"
+        );
+    }
+
+    #[test]
+    fn debug_comment_not_flagged() {
+        let chunks = vec![make_chunk(
+            "src/config.py",
+            &["# Use --debug for verbose output"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        let debug_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.rule_id.contains("debug"))
+            .collect();
+        assert!(debug_findings.is_empty());
+    }
+
+    // ── #490: hardcoded-role quoted pattern tests ──
+
+    #[test]
+    fn hardcoded_role_unquoted_still_detected() {
+        let chunks = vec![make_chunk("src/auth.rb", &["if role == admin"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "unquoted role check must be detected");
+        assert!(findings[0].rule_id.contains("role"));
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_double_quotes_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.js",
+            &["if (role == \"admin\") return true;"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "quoted role == \"admin\" must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_single_quotes_detected() {
+        let chunks = vec![make_chunk("src/auth.py", &["if role == 'admin':"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "quoted role == 'admin' must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_strict_equality_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.ts",
+            &["if (role === \"admin\") return true;"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "strict equality role === must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_property_access_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.js",
+            &["if (user.role == \"admin\") return true;"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "user.role == \"admin\" must be detected"
+        );
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_super_detected() {
+        let chunks = vec![make_chunk("src/auth.py", &["if role == \"super\":"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "role == \"super\" must be detected");
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_root_detected() {
+        let chunks = vec![make_chunk("src/auth.py", &["if role == 'root':"])];
+        let findings = scan_security(&chunks, 10);
+        assert!(!findings.is_empty(), "role == 'root' must be detected");
+    }
+
+    #[test]
+    fn hardcoded_role_quoted_superuser_detected() {
+        let chunks = vec![make_chunk(
+            "src/auth.ts",
+            &["if (user.role === \"superuser\") grant_all();"],
+        )];
+        let findings = scan_security(&chunks, 10);
+        assert!(
+            !findings.is_empty(),
+            "role === \"superuser\" must be detected"
+        );
     }
 }

--- a/src/hook/install.rs
+++ b/src/hook/install.rs
@@ -18,8 +18,9 @@ pub fn install_hook() -> Result<String> {
             // Already a cora-managed hook — just overwrite
             debug!("existing hook is cora-managed, overwriting");
         } else {
-            // Non-cora hook — back it up and compose a wrapper
-            let backup = hooks_dir.join("pre-commit.bak");
+            // Non-cora hook — back it up and compose a wrapper.
+            // Use `pre-commit.pre-cora.bak` to match the name uninstall_hook looks for.
+            let backup = hooks_dir.join("pre-commit.pre-cora.bak");
             std::fs::copy(&hook_path, &backup)?;
             debug!(path = %backup.display(), "backed up existing non-cora hook");
 
@@ -65,7 +66,8 @@ pub fn install_hook() -> Result<String> {
 pub fn uninstall_hook() -> Result<()> {
     let hooks_dir = find_git_hooks_dir()?;
     let hook_path = hooks_dir.join("pre-commit");
-    let backup_path = hooks_dir.join("pre-commit.cora.bak");
+    // Restore from backup if one exists, otherwise remove the hook.
+    // `pre-commit.pre-cora.bak` is the only backup name install_hook writes.
     let pre_backup = hooks_dir.join("pre-commit.pre-cora.bak");
 
     if !hook_path.is_file() {
@@ -79,11 +81,9 @@ pub fn uninstall_hook() -> Result<()> {
         return Ok(());
     }
 
-    if backup_path.is_file() {
-        std::fs::rename(&backup_path, &hook_path).context("failed to restore backup hook")?;
-        debug!("restored hook from backup");
-    } else if pre_backup.is_file() {
-        std::fs::rename(&pre_backup, &hook_path).context("failed to restore pre-cora backup")?;
+    if pre_backup.is_file() {
+        std::fs::rename(&pre_backup, &hook_path)
+            .context("failed to restore pre-cora backup hook")?;
         debug!("restored pre-cora hook from backup");
     } else {
         std::fs::remove_file(&hook_path).context("failed to remove hook")?;
@@ -135,4 +135,56 @@ pub fn is_hook_installed() -> Result<bool> {
 
     let content = std::fs::read_to_string(&hook_path).unwrap_or_default();
     Ok(content.contains("cora"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::process::Command;
+
+    /// Create a temp git repo — used to verify hook file operations.
+    fn temp_git_repo() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn backup_filename_is_pre_cora_bak() {
+        let tmp = temp_git_repo();
+        let hooks_dir = tmp.path().join(".git/hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+
+        // Simulate an existing non-cora hook
+        let hook_path = hooks_dir.join("pre-commit");
+        fs::write(&hook_path, "#!/bin/sh\necho my-hook\n").unwrap();
+
+        // We can't call install_hook() directly because it uses `git rev-parse`
+        // from CWD, not from a configurable path. Instead, verify the backup
+        // filename constant is consistent between install and uninstall logic.
+        //
+        // The install path writes to: pre-commit.pre-cora.bak
+        // The uninstall path reads from: pre-commit.pre-cora.bak
+        // This test documents the expected filename.
+        let expected_backup = "pre-commit.pre-cora.bak";
+
+        // Verify no other backup names are referenced in the source
+        let source = include_str!("install.rs");
+        assert!(
+            !source.contains("\"pre-commit.bak\""),
+            "install.rs should not use generic 'pre-commit.bak' — it was the root cause of data loss"
+        );
+        assert!(
+            !source.contains("\"pre-commit.cora.bak\""),
+            "install.rs should not use 'pre-commit.cora.bak' — uninstall never wrote this name"
+        );
+        assert!(
+            source.contains(&format!("\"{expected_backup}\"")),
+            "install.rs should consistently use '{expected_backup}' for backup"
+        );
+    }
 }

--- a/src/index/ast.rs
+++ b/src/index/ast.rs
@@ -215,10 +215,43 @@ fn node_name(node: &tree_sitter::Node, source: &str) -> String {
     if let Some(n) = node.child_by_field_name("name") {
         return node_text(&n, source);
     }
-    if let Some(n) =
-        find_child_by_kind(node, &["identifier", "type_identifier", "field_identifier"])
-    {
+    if let Some(n) = find_child_by_kind(
+        node,
+        &[
+            "identifier",
+            "type_identifier",
+            "field_identifier",
+            "name",
+            "qualified_name",
+        ],
+    ) {
         return node_text(&n, source);
+    }
+    String::new()
+}
+
+/// Find the first type_identifier or generic_type descendant in a node (for extends clauses).
+fn first_type_identifier(node: &tree_sitter::Node, source: &str) -> String {
+    let mut c = node.walk();
+    if c.goto_first_child() {
+        loop {
+            let n = c.node();
+            if n.kind() == "type_identifier"
+                || n.kind() == "generic_type"
+                || n.kind() == "identifier"
+            {
+                return node_text(&n, source);
+            }
+            // Recurse one level for nested expressions
+            if let Some(inner) =
+                find_child_by_kind(&n, &["type_identifier", "generic_type", "identifier"])
+            {
+                return node_text(&inner, source);
+            }
+            if !c.goto_next_sibling() {
+                break;
+            }
+        }
     }
     String::new()
 }
@@ -730,6 +763,99 @@ fn extract_typescript(
                 let name = node_name(node, source);
                 if !name.is_empty() {
                     let line = (node.start_position().row + 1) as u32;
+                    // Inheritance: class Foo extends Bar
+                    // tree-sitter-ts wraps extends/implements in class_heritage
+                    let heritage = find_child_by_kind(node, &["class_heritage"]);
+                    // Some grammars put extends_clause directly on class_declaration
+                    let extends_direct = find_child_by_kind(node, &["extends_clause"]);
+                    if let Some(heritage) = heritage {
+                        let mut hc = heritage.walk();
+                        if hc.goto_first_child() {
+                            loop {
+                                let hn = hc.node();
+                                if hn.kind() == "extends_clause" {
+                                    // First type_identifier in extends = parent class
+                                    let parent = first_type_identifier(&hn, source);
+                                    if !parent.is_empty() {
+                                        edges.push(AstEdge {
+                                            source: name.clone(),
+                                            kind: EdgeKind::Inherits,
+                                            target: parent,
+                                            file: file_path.to_string(),
+                                            line,
+                                        });
+                                    }
+                                } else if hn.kind() == "implements_clause" {
+                                    // All type_identifiers in implements = interfaces
+                                    let mut tc = hn.walk();
+                                    if tc.goto_first_child() {
+                                        loop {
+                                            if tc.node().kind() == "type_identifier"
+                                                || tc.node().kind() == "generic_type"
+                                                || tc.node().kind() == "identifier"
+                                            {
+                                                let iface = node_text(&tc.node(), source);
+                                                if !iface.is_empty() {
+                                                    edges.push(AstEdge {
+                                                        source: name.clone(),
+                                                        kind: EdgeKind::Implements,
+                                                        target: iface,
+                                                        file: file_path.to_string(),
+                                                        line,
+                                                    });
+                                                }
+                                            }
+                                            if !tc.goto_next_sibling() {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                if !hc.goto_next_sibling() {
+                                    break;
+                                }
+                            }
+                        }
+                    } else if let Some(extends_clause) = extends_direct {
+                        // Direct extends_clause (no class_heritage wrapper)
+                        let parent = first_type_identifier(&extends_clause, source);
+                        if !parent.is_empty() {
+                            edges.push(AstEdge {
+                                source: name.clone(),
+                                kind: EdgeKind::Inherits,
+                                target: parent,
+                                file: file_path.to_string(),
+                                line,
+                            });
+                        }
+                        // Also check for implements_clause sibling
+                        if let Some(impl_clause) = find_child_by_kind(node, &["implements_clause"])
+                        {
+                            let mut tc = impl_clause.walk();
+                            if tc.goto_first_child() {
+                                loop {
+                                    if tc.node().kind() == "type_identifier"
+                                        || tc.node().kind() == "generic_type"
+                                        || tc.node().kind() == "identifier"
+                                    {
+                                        let iface = node_text(&tc.node(), source);
+                                        if !iface.is_empty() {
+                                            edges.push(AstEdge {
+                                                source: name.clone(),
+                                                kind: EdgeKind::Implements,
+                                                target: iface,
+                                                file: file_path.to_string(),
+                                                line,
+                                            });
+                                        }
+                                    }
+                                    if !tc.goto_next_sibling() {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
                     nodes.push(AstNode {
                         name: name.clone(),
                         kind: SymbolKind::Class,
@@ -2019,6 +2145,46 @@ fn extract_php(
                 let name = node_name(node, source);
                 if !name.is_empty() {
                     let line = (node.start_position().row + 1) as u32;
+                    // Inheritance: class Foo extends Bar
+                    // PHP grammar uses base_clause child (no "superclass" field)
+                    if let Some(base) = find_child_by_kind(node, &["base_clause"]) {
+                        let parent = node_name(&base, source);
+                        if !parent.is_empty() {
+                            edges.push(AstEdge {
+                                source: name.clone(),
+                                kind: EdgeKind::Inherits,
+                                target: parent,
+                                file: file_path.to_string(),
+                                line,
+                            });
+                        }
+                    }
+                    // Interfaces: class Foo implements Bar, Baz
+                    // PHP grammar uses class_interface_clause child
+                    if let Some(ifaces) = find_child_by_kind(node, &["class_interface_clause"]) {
+                        let mut ic = ifaces.walk();
+                        if ic.goto_first_child() {
+                            loop {
+                                let cn = ic.node();
+                                // PHP interface names are `name` or `qualified_name` nodes
+                                if cn.kind() == "name" || cn.kind() == "qualified_name" {
+                                    let iface = node_text(&cn, source);
+                                    if !iface.is_empty() {
+                                        edges.push(AstEdge {
+                                            source: name.clone(),
+                                            kind: EdgeKind::Implements,
+                                            target: iface,
+                                            file: file_path.to_string(),
+                                            line,
+                                        });
+                                    }
+                                }
+                                if !ic.goto_next_sibling() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
                     nodes.push(AstNode {
                         name: name.clone(),
                         kind: SymbolKind::Class,
@@ -2146,6 +2312,25 @@ fn extract_scala(
                     } else {
                         SymbolKind::Class
                     };
+                    // Inheritance and trait mixing: class Foo extends Bar with Baz
+                    if let Some(extends_clause) = find_child_by_kind(node, &["extends_clause"]) {
+                        // First type = parent class (Inherits)
+                        if let Some(base) = find_child_by_kind(
+                            &extends_clause,
+                            &["type_identifier", "generic_type", "class_type"],
+                        ) {
+                            let parent = node_text(&base, source);
+                            if !parent.is_empty() {
+                                edges.push(AstEdge {
+                                    source: name.clone(),
+                                    kind: EdgeKind::Inherits,
+                                    target: parent,
+                                    file: file_path.to_string(),
+                                    line,
+                                });
+                            }
+                        }
+                    }
                     nodes.push(AstNode {
                         name: name.clone(),
                         kind,
@@ -2525,6 +2710,90 @@ export const processForm = (data: string) => {
             names.contains(&"inline"),
             "inline script function should be extracted, got: {:?}",
             names
+        );
+    }
+
+    // ─── Edge extraction tests (#437) ───────────────────────────────
+
+    #[test]
+    fn test_extract_typescript_class_extends() {
+        let code = r#"class Dog extends Animal {
+    bark() { return; }
+}"#;
+        let (_nodes, edges) = extract(code, "ts", "dog.ts");
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.kind == EdgeKind::Inherits && e.source == "Dog" && e.target == "Animal"),
+            "expected Dog -> Animal Inherits edge, got edges: {:?}",
+            edges
+        );
+    }
+
+    #[test]
+    fn test_extract_typescript_class_implements() {
+        let code = r#"class Repository implements Comparable, Serializable {
+    compare() { return 0; }
+}"#;
+        let (_nodes, edges) = extract(code, "ts", "repo.ts");
+        assert!(
+            edges.iter().any(|e| e.kind == EdgeKind::Implements
+                && e.source == "Repository"
+                && e.target == "Comparable"),
+            "expected Repository -> Comparable Implements edge, got: {:?}",
+            edges
+        );
+        assert!(
+            edges.iter().any(|e| e.kind == EdgeKind::Implements
+                && e.source == "Repository"
+                && e.target == "Serializable"),
+            "expected Repository -> Serializable Implements edge, got: {:?}",
+            edges
+        );
+    }
+
+    #[test]
+    fn test_extract_php_class_extends() {
+        let code = r#"<?php
+class Dog extends Animal {
+    public function bark() { return; }
+}"#;
+        let (_nodes, edges) = extract(code, "php", "dog.php");
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.kind == EdgeKind::Inherits && e.source == "Dog" && e.target == "Animal"),
+            "expected Dog -> Animal Inherits edge, got edges: {:?}",
+            edges
+        );
+    }
+
+    #[test]
+    fn test_extract_php_class_implements() {
+        let code = r#"<?php
+class Repository implements Comparable, Serializable {
+    public function compare() { return 0; }
+}"#;
+        let (_nodes, edges) = extract(code, "php", "repo.php");
+        assert!(
+            edges.iter().any(|e| e.kind == EdgeKind::Implements
+                && e.source == "Repository"
+                && e.target == "Comparable"),
+            "expected Repository -> Comparable Implements edge, got: {:?}",
+            edges
+        );
+    }
+
+    #[test]
+    fn test_extract_scala_class_extends() {
+        let code = "class Dog extends Animal {\n  def bark(): Unit = {}\n}";
+        let (_nodes, edges) = extract(code, "scala", "dog.scala");
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.kind == EdgeKind::Inherits && e.source == "Dog" && e.target == "Animal"),
+            "expected Dog -> Animal Inherits edge, got edges: {:?}",
+            edges
         );
     }
 }

--- a/src/index/brain.rs
+++ b/src/index/brain.rs
@@ -120,9 +120,15 @@ fn check_dimension_compat(vi_path: &std::path::Path, expected_dims: usize) {
 
 /// Embed all symbols for a project into the vector index.
 ///
-/// Uses the best available embedding backend (selected at compile time):
-/// - `pretrained-embed` → nomic-embed-code 768-dim vectors
-/// - default → hashing-trick 256-dim vectors
+/// Uses the embedding backend selected at runtime via [`resolve_backend`]:
+/// - `"pretrained"` → nomic-embed-code 768-dim vectors
+/// - `"hashing"` → hashing-trick 256-dim vectors
+/// - `"auto"` → best available
+///
+/// **Incremental**: Only symbols whose `name + signature` fingerprint has
+/// changed since the last embed are re-embedded. This dramatically reduces
+/// embedding time when a single file is modified (e.g. 10 changed symbols
+/// out of 1100 total).
 ///
 /// Detects dimension mismatch between existing on-disk index and current
 /// backend, warning the user to re-index if dimensions changed.
@@ -152,27 +158,65 @@ pub fn embed_project(conn: &Connection, project_id: i64) -> Result<usize> {
         cache.as_mut().unwrap()
     };
 
-    let mut stmt =
-        conn.prepare("SELECT id, name, kind, signature FROM symbols WHERE project_id = ?1")?;
-    let rows: Vec<(i64, String, String, String)> = stmt
+    // ── Incremental: fetch stored fingerprints ──────────────────────
+    // Only re-embed symbols whose name+signature has changed.
+    let mut stmt = conn.prepare(
+        "SELECT id, name, kind, signature, embed_fingerprint \
+         FROM symbols WHERE project_id = ?1",
+    )?;
+    let rows: Vec<(i64, String, String, String, Option<String>)> = stmt
         .query_map(rusqlite::params![project_id], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
         })?
         .filter_map(|r| r.ok())
         .collect();
 
-    // ── Parallel embedding computation (Rayon) ─────────────────────────
-    // embed_code_dispatch is pure + CPU-bound. usearch insert is serial.
-    let t_compute = std::time::Instant::now();
-    let embedded: Vec<(i64, Vec<f32>)> = rows
-        .par_iter()
-        .map(|(sym_id, name, _kind, signature)| {
+    // Compute current fingerprints and filter to only changed symbols
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let changed: Vec<(i64, String)> = rows
+        .iter()
+        .filter_map(|(sym_id, name, _kind, signature, stored_fp)| {
             let text = if signature.is_empty() || signature == name {
                 name.clone()
             } else {
                 format!("{name} {signature}")
             };
-            let vec = embed_code_dispatch(&text);
+            let mut hasher = DefaultHasher::new();
+            text.hash(&mut hasher);
+            let current_fp = format!("{:016x}", hasher.finish());
+
+            if stored_fp.as_deref() == Some(&current_fp) {
+                None // unchanged — skip
+            } else {
+                Some((*sym_id, text))
+            }
+        })
+        .collect();
+
+    let total_symbols = rows.len();
+    let skipped = total_symbols - changed.len();
+    if skipped > 0 {
+        tracing::info!(
+            "Incremental embed: {total_symbols} total, {skipped} unchanged (skipped), {} changed (re-embedding)",
+            changed.len()
+        );
+    }
+
+    // ── Parallel embedding computation (Rayon) ─────────────────────────
+    // embed_code_dispatch is pure + CPU-bound. usearch insert is serial.
+    let t_compute = std::time::Instant::now();
+    let embedded: Vec<(i64, Vec<f32>)> = changed
+        .par_iter()
+        .map(|(sym_id, text)| {
+            let vec = embed_code_dispatch(text);
             (*sym_id, vec)
         })
         .collect();
@@ -181,19 +225,24 @@ pub fn embed_project(conn: &Connection, project_id: i64) -> Result<usize> {
     // ── Serial usearch insert ────────────────────────────────────────
     let t_insert = std::time::Instant::now();
     let mut count = 0;
-    let mut new_ids: HashSet<i64> = HashSet::with_capacity(embedded.len());
+    let mut new_ids: HashSet<i64> = HashSet::with_capacity(rows.len());
+    // Populate new_ids with ALL symbol IDs for this project (for search filtering)
+    for (sym_id, _, _, _, _) in &rows {
+        new_ids.insert(*sym_id);
+    }
     for (sym_id, vec) in &embedded {
         vi.insert(*sym_id, vec).context("insert symbol embedding")?;
-        new_ids.insert(*sym_id);
         count += 1;
     }
     let insert_ms = t_insert.elapsed().as_millis();
 
     tracing::debug!(
-        "embed_compute={}ms, usearch_insert={}ms, symbols={}, dims={}, provider={}",
+        "embed_compute={}ms, usearch_insert={}ms, re-embedded={}, total={}, skipped={}, dims={}, provider={}",
         compute_ms,
         insert_ms,
         count,
+        total_symbols,
+        skipped,
         active,
         active_provider_name()
     );
@@ -202,26 +251,36 @@ pub fn embed_project(conn: &Connection, project_id: i64) -> Result<usize> {
         vi.save().context("save vector index")?;
     }
 
+    // ── Update fingerprints for embedded symbols ─────────────────────
+    let mut update_fp = conn.prepare("UPDATE symbols SET embed_fingerprint = ?2 WHERE id = ?1")?;
+    for (sym_id, text) in &changed {
+        let mut hasher = DefaultHasher::new();
+        text.hash(&mut hasher);
+        let fp = format!("{:016x}", hasher.finish());
+        update_fp.execute(rusqlite::params![sym_id, fp])?;
+    }
+
     // Cache project → symbol IDs for fast search-time filtering
     PROJECT_ID_CACHE
         .write()
         .unwrap()
         .insert(project_id, new_ids);
 
-    let tier = if cfg!(feature = "pretrained-embed") {
+    // Determine tier label
+    let provider = active_provider_name();
+    let tier = if provider.contains("pretrained") {
         "pretrained"
     } else {
         "static"
     };
     conn.execute(
         "UPDATE projects SET embedding_tier = ?3, embedding_dims = ?1, \
-         last_embedded_at = datetime('now') WHERE id = ?2",
-        rusqlite::params![active, project_id, tier],
+         embedding_provider = ?4, last_embedded_at = datetime('now') WHERE id = ?2",
+        rusqlite::params![active, project_id, tier, provider],
     )?;
 
     tracing::info!(
-        "Embedded {count} symbols for project {project_id} (provider={}, dims={active})",
-        active_provider_name()
+        "Embedded {count}/{total_symbols} symbols for project {project_id} ({skipped} unchanged, provider={provider}, dims={active})",
     );
     Ok(count)
 }

--- a/src/index/schema.rs
+++ b/src/index/schema.rs
@@ -4,7 +4,7 @@ use rusqlite::Connection;
 
 /// Current schema version.
 #[allow(dead_code)]
-const SCHEMA_VERSION: i32 = 6;
+const SCHEMA_VERSION: i32 = 7;
 
 /// Run database migrations (creates tables if not exist).
 pub fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
@@ -39,6 +39,9 @@ pub fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
     }
     if current < 6 {
         migrate_v6(conn)?;
+    }
+    if current < 7 {
+        migrate_v7(conn)?;
     }
 
     Ok(())
@@ -346,6 +349,45 @@ fn migrate_v6(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Migration v7: Add `embed_fingerprint` column to symbols for incremental re-embedding.
+///
+/// Stores a hash of `name + signature` per symbol. On re-index, only symbols
+/// whose fingerprint has changed need to be re-embedded — dramatically reducing
+/// embedding time when a single file is modified.
+fn migrate_v7(conn: &Connection) -> anyhow::Result<()> {
+    // SQLite ALTER TABLE ADD COLUMN is idempotent-safe with IF NOT EXISTS? No —
+    // SQLite doesn't support IF NOT EXISTS for ADD COLUMN. Use pragma check instead.
+    let cols: Vec<String> = conn
+        .prepare("PRAGMA table_info(symbols)")?
+        .query_map([], |row| row.get::<_, String>(1))? // column 1 = name
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if !cols.iter().any(|c| c == "embed_fingerprint") {
+        conn.execute_batch("ALTER TABLE symbols ADD COLUMN embed_fingerprint TEXT;")?;
+    }
+
+    // Also add to projects table: track which embedding backend was used.
+    // This allows detecting dimension mismatch when switching backends.
+    let pcols: Vec<String> = conn
+        .prepare("PRAGMA table_info(projects)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if !pcols.iter().any(|c| c == "embedding_provider") {
+        conn.execute_batch("ALTER TABLE projects ADD COLUMN embedding_provider TEXT;")?;
+    }
+
+    if !pcols.iter().any(|c| c == "embedding_dims") {
+        conn.execute_batch("ALTER TABLE projects ADD COLUMN embedding_dims INTEGER;")?;
+    }
+
+    conn.execute("INSERT INTO schema_version (version) VALUES (7)", [])?;
+
+    Ok(())
+}
+
 /// Compute a stable hash of the indexing-relevant config.
 ///
 /// Any change to these fields will invalidate all stored fingerprints,
@@ -644,7 +686,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(version, SCHEMA_VERSION);
-        assert_eq!(version, 6);
+        assert_eq!(version, 7);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1511,6 +1511,7 @@ async fn main() -> Result<()> {
             filter,
         } => {
             let project_root = std::env::current_dir()?;
+            let project_root = index::resolve_project_root(&project_root).unwrap_or(project_root);
             let config_path = cli.global.config.as_deref();
             commands::watch::run_watch(
                 &project_root,

--- a/src/main.rs
+++ b/src/main.rs
@@ -738,8 +738,8 @@ async fn main() -> Result<()> {
                     }
                 }
             } else {
-                // Load config for config-hash invalidation
-                let skip_patterns = crate::config::loader::load_config(
+                // Load config for config-hash invalidation + brain embedding backend
+                let config = crate::config::loader::load_config(
                     cli.global.config.as_deref(),
                     None,
                     None,
@@ -747,8 +747,17 @@ async fn main() -> Result<()> {
                     None,
                     false,
                 )
-                .ok()
-                .map(|c| c.rules_config.index_skip_files);
+                .ok();
+                let skip_patterns = config
+                    .as_ref()
+                    .map(|c| c.rules_config.index_skip_files.clone());
+
+                // Resolve embedding backend from brain config
+                let brain_mode = config
+                    .as_ref()
+                    .map(|c| c.brain.embedding.to_string())
+                    .unwrap_or_else(|| "auto".to_string());
+                crate::embed::resolve_backend(&brain_mode);
 
                 eprintln!("{}", "🔍 Indexing project...".cyan());
                 let stats = index::index_project_with_skip(
@@ -1109,6 +1118,20 @@ async fn main() -> Result<()> {
             }
             let conn = index::open_global_index()?;
             let project_id = index::ensure_project(&conn, &project_root)?;
+
+            // Resolve embedding backend from config for query embedding
+            let brain_mode = crate::config::loader::load_config(
+                cli.global.config.as_deref(),
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .ok()
+            .map(|c| c.brain.embedding.to_string())
+            .unwrap_or_else(|| "auto".to_string());
+            crate::embed::resolve_backend(&brain_mode);
 
             let results = index::brain::brain_search(&conn, project_id, &query_str, limit)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,6 +468,18 @@ enum Command {
         #[clap(long)]
         estimate: bool,
     },
+    /// Watch for file changes and auto-reindex (standalone real-time watcher)
+    Watch {
+        /// Debounce window in milliseconds (default: 500)
+        #[clap(long, default_value = "500")]
+        debounce: u64,
+        /// Only trigger on git-tracked files
+        #[clap(long)]
+        git_only: bool,
+        /// Glob filter pattern (e.g. 'src/**/*.rs')
+        #[clap(long)]
+        filter: Option<String>,
+    },
     /// Auto-detect and configure AI coding agents for Cora MCP
     Install {
         /// List detected agents without installing
@@ -1492,6 +1504,23 @@ async fn main() -> Result<()> {
                 config_path: cli.global.config.clone(),
             };
             debt::execute_debt(&opts)?
+        }
+        Command::Watch {
+            debounce,
+            git_only,
+            filter,
+        } => {
+            let project_root = std::env::current_dir()?;
+            let config_path = cli.global.config.as_deref();
+            commands::watch::run_watch(
+                &project_root,
+                config_path,
+                debounce,
+                git_only,
+                filter.as_deref(),
+                cli.global.verbose,
+            )?;
+            0
         }
         Command::Install {
             list,

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,6 +485,12 @@ enum Command {
         /// Install ALL detected agents (non-interactive)
         #[clap(long, short)]
         yes: bool,
+        /// Remove cora MCP entry from detected agents (uninstall)
+        #[clap(long)]
+        remove: bool,
+        /// Validate agent configs after install/remove
+        #[clap(long)]
+        validate: bool,
     },
 
     /// Detect dead code — functions/methods with no callers
@@ -1493,6 +1499,8 @@ async fn main() -> Result<()> {
             dry_run,
             force,
             yes,
+            remove,
+            validate,
         } => {
             let opts = commands::install::InstallOptions {
                 list,
@@ -1500,6 +1508,8 @@ async fn main() -> Result<()> {
                 dry_run,
                 force,
                 yes,
+                remove,
+                validate,
             };
             let output = commands::install::execute_install(&opts)?;
             println!("{output}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,10 +721,16 @@ async fn main() -> Result<()> {
                 }
             } else {
                 // Load config for config-hash invalidation
-                let skip_patterns =
-                    crate::config::loader::load_config(None, None, None, None, None, false)
-                        .ok()
-                        .map(|c| c.rules_config.index_skip_files);
+                let skip_patterns = crate::config::loader::load_config(
+                    cli.global.config.as_deref(),
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .ok()
+                .map(|c| c.rules_config.index_skip_files);
 
                 eprintln!("{}", "🔍 Indexing project...".cyan());
                 let stats = index::index_project_with_skip(
@@ -1438,14 +1444,16 @@ async fn main() -> Result<()> {
         }
         Command::Config { action } => match action {
             ConfigAction::Show { global, project } => {
-                config_cmd::execute_config_show(global, project)?;
+                config_cmd::execute_config_show(global, project, cli.global.config.as_deref())?;
                 0
             }
             ConfigAction::Set { key, value, global } => {
                 config_cmd::execute_config_set(&key, &value, global)?;
                 0
             }
-            ConfigAction::Validate => config_cmd::execute_config_validate()?,
+            ConfigAction::Validate => {
+                config_cmd::execute_config_validate(cli.global.config.as_deref())?
+            }
         },
         Command::Providers => {
             providers::execute_providers();
@@ -1475,6 +1483,7 @@ async fn main() -> Result<()> {
                 branch,
                 badge,
                 estimate,
+                config_path: cli.global.config.clone(),
             };
             debt::execute_debt(&opts)?
         }
@@ -1509,8 +1518,15 @@ async fn main() -> Result<()> {
             )?;
 
             // Load config for entry_point_patterns
-            let config = crate::config::loader::load_config(None, None, None, None, None, false)
-                .unwrap_or_default();
+            let config = crate::config::loader::load_config(
+                cli.global.config.as_deref(),
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .unwrap_or_default();
             let entry_point_patterns = config.analysis.entry_point_patterns.clone();
 
             let opts = index::graph::DeadCodeOptions {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -997,6 +997,8 @@ fn handle_install(params: &serde_json::Value) -> ToolResult {
         dry_run,
         force: false,
         yes: true, // MCP is non-interactive
+        remove: false,
+        validate: false,
     };
 
     match crate::commands::install::execute_install(&opts) {


### PR DESCRIPTION
## What

Sync 18 commits from `develop` to `main` for v0.13.0 release.

Includes:
- feat(brain): runtime embedding config + incremental per-symbol embedding (#501)
- chore(release): v0.13.0 version bump (#502)
- fix(watch): use global index DB with schema migrations (#498)

## Why

Per CONTRIBUTING.md release flow:
```
develop (default) → PR → main → tag vX.Y.Z → release workflow
```

Tags must be on `main`, not `develop`. This PR brings main up to date so the v0.13.0 tag is on the correct branch.

## Testing

All changes passed CI on develop (13/13 checks green on PR #501 and #502). main is behind by 18 commits and needs to catch up.

## Checklist

- [x] Branch is `develop` (release sync)
- [x] All commits passed CI individually
- [x] No secrets or credentials