### PR TITLE
ci(cla): add CLA check workflow

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -14,18 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch CLA signatures
-        run: |
-          # Fetch via GitHub REST API (unauthenticated, public repo)
-          curl -sfL "https://api.github.com/repos/codecoradev/.github/contents/.cla/signatures.json" \
-            | python3 -c "import json,sys,base64; d=json.load(sys.stdin); sys.stdout.buffer.write(base64.b64decode(d['content']))" > signatures.json 2>/dev/null \
-            || echo '{"signatures":[]}' > signatures.json
-          # Validate JSON
-          python3 -c "import json; json.load(open('signatures.json'))" 2>/dev/null \
-            || echo '{"signatures":[]}' > signatures.json
+        uses: actions/checkout@v4
+        with:
+          repository: codecoradev/.github
+          path: cla-store
+          sparse-checkout: .cla
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check CLA signature
         id: check
         run: |
+          cp cla-store/.cla/signatures.json signatures.json 2>/dev/null || echo '{"signatures":[]}' > signatures.json
           python3 - << 'EOF'
           import json, os
 

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -14,8 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch CLA signatures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -sfL "https://raw.githubusercontent.com/codecoradev/.github/main/.cla/signatures.json" -o signatures.json \
+          # Use GitHub API (more reliable than raw CDN)
+          gh api repos/codecoradev/.github/contents/.cla/signatures.json --jq '.content' \
+            | base64 -d > signatures.json 2>/dev/null \
+            || echo '{"signatures":[]}' > signatures.json
+          # Validate JSON
+          python3 -c "import json; json.load(open('signatures.json'))" 2>/dev/null \
             || echo '{"signatures":[]}' > signatures.json
 
       - name: Check CLA signature

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  pull-requests: write
+  contents: read
+  statuses: write
+
 jobs:
   cla:
     uses: codecoradev/.github/.github/workflows/cla-check.yml@main

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -14,12 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch CLA signatures
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Use GitHub API (more reliable than raw CDN)
-          gh api repos/codecoradev/.github/contents/.cla/signatures.json --jq '.content' \
-            | base64 -d > signatures.json 2>/dev/null \
+          # Fetch via GitHub REST API (unauthenticated, public repo)
+          curl -sfL "https://api.github.com/repos/codecoradev/.github/contents/.cla/signatures.json" \
+            | python3 -c "import json,sys,base64; d=json.load(sys.stdin); sys.stdout.buffer.write(base64.b64decode(d['content']))" > signatures.json 2>/dev/null \
             || echo '{"signatures":[]}' > signatures.json
           # Validate JSON
           python3 -c "import json; json.load(open('signatures.json'))" 2>/dev/null \

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -10,10 +10,117 @@ permissions:
   statuses: write
 
 jobs:
-  cla:
-    uses: codecoradev/.github/.github/workflows/cla-check.yml@main
-    with:
-      pr-number: ${{ github.event.pull_request.number }}
-      pr-author: ${{ github.event.pull_request.user.login }}
-      pr-head-sha: ${{ github.event.pull_request.head.sha }}
-    secrets: inherit
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch CLA signatures
+        run: |
+          curl -sfL "https://raw.githubusercontent.com/codecoradev/.github/main/.cla/signatures.json" -o signatures.json \
+            || echo '{"signatures":[]}' > signatures.json
+
+      - name: Check CLA signature
+        id: check
+        run: |
+          python3 - << 'EOF'
+          import json, os
+
+          author = os.environ["PR_AUTHOR"]
+          with open("signatures.json") as f:
+              data = json.load(f)
+
+          signatures = data.get("signatures", [])
+          found = any(
+              s.get("github_username", "").lower() == author.lower()
+              for s in signatures
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"signed={'true' if found else 'false'}\n")
+
+          print(f"CLA signed by @{author}: {found}")
+          EOF
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const signed = '${{ steps.check.outputs.signed }}' === 'true';
+            const author = '${{ github.event.pull_request.user.login }}';
+            const prNumber = ${{ github.event.pull_request.number }};
+
+            // Find existing CLA bot comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.data.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('CodeCoraDev CLA Bot')
+            );
+
+            const body = signed
+              ? [
+                  '## ✅ CodeCoraDev CLA Bot',
+                  '',
+                  `Thank you @${author}! Your CLA is on file. 🎉`,
+                  '',
+                  'Your contribution can now be reviewed.',
+                ].join('\n')
+              : [
+                  '## ⚠️ CodeCoraDev CLA Bot',
+                  '',
+                  `Hi @${author}! Thanks for your contribution.`,
+                  '',
+                  'Before this PR can be reviewed, please sign our Contributor License Agreement:',
+                  '',
+                  '- 📋 **Individual?** → [Sign CLA Individual](https://codecoradev.github.io/cla/?type=individual)',
+                  '- 🏢 **Corporate?** → [Sign CLA Corporate](https://codecoradev.github.io/cla/?type=corporate)',
+                  '',
+                  '---',
+                  '<sub>By signing, you agree to the terms in [CLA_INDIVIDUAL.md](https://github.com/codecoradev/.github/blob/main/CLA_INDIVIDUAL.md) or [CLA_CORPORATE.md](https://github.com/codecoradev/.github/blob/main/CLA_CORPORATE.md).</sub>',
+                ].join('\n');
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+      - name: Set commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const signed = '${{ steps.check.outputs.signed }}' === 'true';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.pull_request.head.sha }}',
+              state: signed ? 'success' : 'failure',
+              context: 'CLA Check',
+              description: signed
+                ? '✅ CLA signed'
+                : '❌ CLA not signed — sign at https://codecoradev.github.io/cla',
+              target_url: signed
+                ? 'https://github.com/codecoradev/.github/blob/main/.cla/signatures.json'
+                : 'https://codecoradev.github.io/cla',
+            });
+
+      - name: Fail if not signed
+        if: steps.check.outputs.signed != 'true'
+        run: |
+          echo "❌ CLA not signed by ${{ github.event.pull_request.user.login }}"
+          exit 1

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -13,18 +13,16 @@ jobs:
   cla-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch CLA signatures
-        uses: actions/checkout@v4
-        with:
-          repository: codecoradev/.github
-          path: cla-store
-          sparse-checkout: .cla
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check CLA signature
+      - name: Fetch & check CLA signature
         id: check
         run: |
+          # Clone .cla/ folder from public repo (no auth needed)
+          git clone --no-checkout --depth 1 https://github.com/codecoradev/.github.git cla-store 2>&1
+          cd cla-store && git sparse-checkout set .cla && git checkout 2>&1
+          cd ..
           cp cla-store/.cla/signatures.json signatures.json 2>/dev/null || echo '{"signatures":[]}' > signatures.json
+          echo "Loaded signatures:"
+          python3 -c "import json; d=json.load(open('signatures.json')); print(f'  {len(d.get(\"signatures\",[]))} entries')"
           python3 - << 'EOF'
           import json, os
 

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -16,13 +16,14 @@ jobs:
       - name: Fetch & check CLA signature
         id: check
         run: |
-          # Clone .cla/ folder from public repo (no auth needed)
-          git clone --no-checkout --depth 1 https://github.com/codecoradev/.github.git cla-store 2>&1
-          cd cla-store && git sparse-checkout set .cla && git checkout 2>&1
-          cd ..
-          cp cla-store/.cla/signatures.json signatures.json 2>/dev/null || echo '{"signatures":[]}' > signatures.json
-          echo "Loaded signatures:"
-          python3 -c "import json; d=json.load(open('signatures.json')); print(f'  {len(d.get(\"signatures\",[]))} entries')"
+          # Fetch signatures.json directly from raw GitHub (public repo)
+          # Use wget as primary (handles 200-with-404-body better than curl)
+          wget -q -O signatures.json "https://raw.githubusercontent.com/codecoradev/.github/main/.cla/signatures.json" 2>/dev/null \
+            || curl -sfL "https://raw.githubusercontent.com/codecoradev/.github/main/.cla/signatures.json" -o signatures.json 2>/dev/null \
+            || echo '{"signatures":[]}' > signatures.json
+          # Validate JSON — if invalid, use empty
+          python3 -c "import json; json.load(open('signatures.json'))" 2>/dev/null \
+            || echo '{"signatures":[]}' > signatures.json
           python3 - << 'EOF'
           import json, os
 

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,14 @@
+name: CLA Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  cla:
+    uses: codecoradev/.github/.github/workflows/cla-check.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      pr-author: ${{ github.event.pull_request.user.login }}
+      pr-head-sha: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit


### PR DESCRIPTION
## What

Add CLA check workflow to cora-code. Calls org-level reusable workflow from `codecoradev/.github`.

## Why

Every PR must be checked for CLA signature before review. Contributors who haven't signed will get a bot comment with a link to the sign portal.

## Changes

- Add `.github/workflows/cla-check.yml` — 1 caller workflow pointing to org-level reusable workflow.

## How It Works

```
PR opened → This workflow triggers
         → Calls codecoradev/.github/.github/workflows/cla-check.yml@main
         → Fetches signatures.json from org repo
         → Checks if PR author is in the database
         → Signed? ✅ pass / Not signed? 🔴 fail + bot comment
```

Sign portal: https://codecoradev.github.io/cla

## Testing

- [x] Workflow YAML syntax validated
- [x] Sign portal deployed and reachable (HTTP 200)
- [x] Org-level reusable workflow merged (codecoradev/.github#1)
- [ ] End-to-end: this PR itself will trigger CLA check on next CI run

Signed-off-by: ajianaz <ajianaz@users.noreply.github.com>