### PR TITLE
ci: add CLA check workflow

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,121 @@
+name: CLA Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+  statuses: write
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch & check CLA signature
+        id: check
+        run: |
+          # Fetch signatures.json directly from raw GitHub (public repo)
+          # Use wget as primary (handles 200-with-404-body better than curl)
+          wget -q -O signatures.json "https://raw.githubusercontent.com/codecoradev/.github/main/.cla/signatures.json" 2>/dev/null \
+            || curl -sfL "https://raw.githubusercontent.com/codecoradev/.github/main/.cla/signatures.json" -o signatures.json 2>/dev/null \
+            || echo '{"signatures":[]}' > signatures.json
+          # Validate JSON — if invalid, use empty
+          python3 -c "import json; json.load(open('signatures.json'))" 2>/dev/null \
+            || echo '{"signatures":[]}' > signatures.json
+          python3 - << 'EOF'
+          import json, os
+
+          author = os.environ["PR_AUTHOR"]
+          with open("signatures.json") as f:
+              data = json.load(f)
+
+          signatures = data.get("signatures", [])
+          found = any(
+              s.get("github_username", "").lower() == author.lower()
+              for s in signatures
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"signed={'true' if found else 'false'}\n")
+
+          print(f"CLA signed by @{author}: {found}")
+          EOF
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+
+      - name: Comment on PR (unsigned only)
+        if: steps.check.outputs.signed != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = '${{ github.event.pull_request.user.login }}';
+            const prNumber = ${{ github.event.pull_request.number }};
+
+            const body = [
+                  '## ⚠️ CodeCoraDev CLA Bot',
+                  '',
+                  `Hi @${author}! Thanks for your contribution.`,
+                  '',
+                  'Before this PR can be reviewed, please sign our Contributor License Agreement:',
+                  '',
+                  '- 📋 **Individual?** → [Sign CLA Individual](https://codecoradev.github.io/cla/?type=individual)',
+                  '- 🏢 **Corporate?** → [Sign CLA Corporate](https://codecoradev.github.io/cla/?type=corporate)',
+                  '',
+                  '---',
+                  '<sub>By signing, you agree to the terms in [CLA_INDIVIDUAL.md](https://github.com/codecoradev/.github/blob/main/CLA_INDIVIDUAL.md) or [CLA_CORPORATE.md](https://github.com/codecoradev/.github/blob/main/CLA_CORPORATE.md).</sub>',
+                ].join('\n');
+
+            // Find existing CLA bot comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.data.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('CodeCoraDev CLA Bot')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+      - name: Set commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const signed = '${{ steps.check.outputs.signed }}' === 'true';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.pull_request.head.sha }}',
+              state: signed ? 'success' : 'failure',
+              context: 'CLA Check',
+              description: signed
+                ? '✅ CLA signed'
+                : '❌ CLA not signed — sign at https://codecoradev.github.io/cla',
+              target_url: signed
+                ? 'https://github.com/codecoradev/.github/blob/main/.cla/signatures.json'
+                : 'https://codecoradev.github.io/cla',
+            });
+
+      - name: Fail if not signed
+        if: steps.check.outputs.signed != 'true'
+        run: |
+          echo "❌ CLA not signed by ${{ github.event.pull_request.user.login }}"
+          exit 1


### PR DESCRIPTION
## What

Add `cla-check.yml` GitHub Actions workflow to `cora-code` repo.

## Why

cora-code is the only codecoradev repo without CLA enforcement on PRs. uteke and titen both already have this workflow. Adding it ensures **every** PR contributor has signed the CodeCoraDev CLA before merge — consistent across all repos.

## Changes

- New file: `.github/workflows/cla-check.yml`
- Triggers on PR `opened`, `synchronize`, `reopened`
- Fetches signatures from `codecoradev/.github` main branch
- Comments on PR if author hasn't signed
- Sets commit status (success/failure)
- Fails CI if unsigned

## Testing

Workflow is identical to the proven implementations in uteke & titen. No logic changes — just porting to cora-code.