### PR TITLE
feat(review): moderate-explanation style in findings prompt

### DIFF
--- a/src/engine/llm.rs
+++ b/src/engine/llm.rs
@@ -226,6 +226,14 @@ Return a JSON array of objects with these fields:
 - "body": string — detailed explanation with specific code reference
 - "suggested_fix": string or null — optional fix suggestion
 
+EXPLANATION STYLE (moderate-explanation principle, arXiv:2607.24601):
+Keep each finding at moderate depth: severity + a short reason (1-3
+sentences) + the specific code evidence it points to. Do NOT include
+long reasoning chains, step-by-step derivations, or exhaustive
+justifications — overly long explanations reduce agreement with the
+finding without adding value. Trust the reader to reason from the
+evidence.
+
 If no issues are found, return: []
 
 Return ONLY the JSON array. No markdown code fences, no explanation, no conversational text.


### PR DESCRIPTION
## What

Add an EXPLANATION STYLE section to the review system prompt instructing findings at moderate depth: severity + short reason (1-3 sentences) + specific code evidence. Explicitly discourages long reasoning chains and exhaustive justifications.

## Why

Refs #525 (first checklist item). Empirical evidence (arXiv:2607.24601, n=34): full explanations yield highest *perceived* trust (3.99/5) but NOT highest agreement; moderate explanations achieve highest developer agreement (89.22%). No explanation scores lowest on both. Applying the moderate-explanation principle to cora's findings format.

The second checklist item (exemplar-guided reformulation from accept/dismiss history) is a larger, data-dependent feature — tracked for a future PR.

## Testing

- cargo fmt clean, clippy -D warnings clean
- Full test suite passing (prompt-only change)
- Live validation on this PR's cora review run