### PR TITLE
chore(lint): dedupe tree-sitter cfg gate; collapse nested else-if

### DIFF
--- a/src/index/ast.rs
+++ b/src/index/ast.rs
@@ -3,7 +3,6 @@
 // ! Provides proper AST-based symbol and edge extraction using tree-sitter.
 // ! Only compiled when the `tree-sitter` feature is enabled.
 
-#![cfg(feature = "tree-sitter")]
 #![allow(dead_code, unused)]
 
 use crate::index::extract::CallSite;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1201,28 +1201,26 @@ async fn main() -> Result<()> {
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&results)?);
+            } else if results.is_empty() {
+                println!("{}", "No results found.".dimmed());
             } else {
-                if results.is_empty() {
-                    println!("{}", "No results found.".dimmed());
-                } else {
+                println!(
+                    "{} {} results for '{}'",
+                    "🧠".magenta(),
+                    results.len().to_string().bold(),
+                    query_str
+                );
+                println!("{}", "─".repeat(60).dimmed());
+                for r in &results {
+                    let signals = r.signals.join(",");
+                    let score = format!("{:.4}", r.score);
                     println!(
-                        "{} {} results for '{}'",
-                        "🧠".magenta(),
-                        results.len().to_string().bold(),
-                        query_str
+                        "  {:<40} {:<15} {} {}",
+                        format!("{} ({})", r.name, r.file).green(),
+                        format!("[{}]", r.kind).dimmed(),
+                        format!("score={}", score).cyan(),
+                        format!("signals={}", signals).dimmed(),
                     );
-                    println!("{}", "─".repeat(60).dimmed());
-                    for r in &results {
-                        let signals = r.signals.join(",");
-                        let score = format!("{:.4}", r.score);
-                        println!(
-                            "  {:<40} {:<15} {} {}",
-                            format!("{} ({})", r.name, r.file).green(),
-                            format!("[{}]", r.kind).dimmed(),
-                            format!("score={}", score).cyan(),
-                            format!("signals={}", signals).dimmed(),
-                        );
-                    }
                 }
             }
             0


### PR DESCRIPTION
Fixes #532

## What

- Remove the redundant inner `#![cfg(feature = "tree-sitter")]` from `src/index/ast.rs` — the `mod ast;` declaration in `src/index/mod.rs` is already cfg-gated, so the file can never be compiled without the feature anyway (finding #1 of #532)
- Collapse the `else { if ... }` wrapper in the Brain-search output block of `src/main.rs` into `else if ... else` (finding #2 of #532, at its current location after the #529/#531 refactors shifted it)
- The second `else { if !opts.quiet { ... } }` site (~line 1822) is intentionally NOT collapsed: the block continues with a statement after the inner if, so collapsing would change semantics. Current clippy correctly does not flag it.

## Why

#532 reported two pre-existing `cargo clippy --all-targets -- -D warnings` findings that block contributors on stricter toolchains than CI's. Verification on rustc 1.97.1 showed both already lint-clean (see issue comment), so this PR applies the cleanups defensively as suggested in the issue — making the source shape match the lint bar on every toolchain, not just the current one.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features tree-sitter -- -D warnings` — 0 warnings
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --features tree-sitter` — 926 passed (904 unit + 16 CLI + 6 config), 0 failed

No behavior change: cfg removal only affects a file already feature-gated at its `mod` declaration; the else-if collapse is the standard clippy-validated transform.

All commits signed-off (DCO).