### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -19,7 +19,7 @@ semantic search engine (Brain Mode).
 ```bash
 cargo build              # Build (debug)
 cargo build --release    # Build (release)
-cargo test               # Run all 708 tests (default) / 714 (tree-sitter)
+cargo test               # Run all 934 tests (default) / 934 (tree-sitter)
 cargo clippy --all-targets -- -D warnings  # Lint (strict -D warnings)
 cargo fmt --all -- --check  # Format check
 ```
@@ -74,6 +74,7 @@ src/
 │   ├── llm.rs           # LLM API interaction
 │   ├── types.rs         # Severity, finding, and result types
 │   ├── diff_parser.rs   # Diff → FileChunk parsing
+│   ├── enclosing.rs     # Enclosing-scope control-flow context for review prompts
 │   ├── chunker.rs       # Auto-chunking large diffs
 │   ├── profiles.rs      # Quality profiles (strict/balanced/lax)
 │   ├── quality_gate.rs  # Quality gate thresholds + pass/fail
@@ -125,7 +126,7 @@ src/
 ## Testing
 
 ```bash
-cargo test               # 708 tests (default) / 714 (tree-sitter)
+cargo test               # 934 tests (default) / 934 (tree-sitter)
                          #   637 unit tests
                          #    16 CLI integration tests
                          #     6 config tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-28
+
 ### Fixed
 
 - **Empty LLM responses from reasoning models.** Models like GLM can spend the entire `max_tokens` budget on chain-of-thought and return `content: ""` with `finish_reason: "length"`, which previously surfaced as a misleading `EOF while parsing` error. Cora now reads `finish_reason`/`reasoning_content`, automatically retries with a doubled budget (up to 32768), salvages JSON from reasoning text as a last resort, and reports an explicit "EMPTY response" error when nothing is recoverable (#536).
+
+- **Dead-code false positives from cross-crate method calls.** Method calls inside Rust `impl` blocks were never walked for call edges, and call targets stored raw AST text (`self.export_full`) that could not join against symbol names — 557 false positives on a 5-crate workspace (#519).
+- **Index root mismatch between CLI and MCP.** Running `cora index` inside a workspace member crate created a separate project row from the one MCP resolved, so `index_status` reported 0 symbols despite a populated DB. Root resolution now prefers a `[workspace]` Cargo.toml and never climbs past a `.git` boundary (#522).
+- **`ignore.files` was not honored by the index.** Skip patterns only invalidated fingerprints; matched files were still indexed and surfaced in dead-code/review findings. They are now excluded from indexing entirely (#521).
 
 ### Changed
 
@@ -17,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Default `max_tokens` raised from 4096 to 8192** to give reasoning models headroom above their chain-of-thought (#536).
+- **Dead-code now skips public API surface by default** (`pub`/`export` items) — new `--include-pub` flag and MCP `include_pub_api` parameter opt back in (#520).
+- **Review prompts include enclosing control-flow scope.** Hunks touching branching constructs get the enclosing function from the post-image (120-line cap), plus an always-on guardrail against unverified reachability claims (#523).
+- **Incremental re-index reports honestly.** No-op runs print "Index up to date" with stored totals instead of "Indexed 0 symbols"; MCP `index_status` carries a root-mismatch hint (#522).
 - **Relicensed from MIT to Apache-2.0.** All 18 CodeCoraDev repositories now
   standardize on Apache-2.0 for patent grant protection and open-core model
   compatibility. Added CLA (Individual + Corporate) for contributor copyright

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "cora-code"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-code"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "Apache-2.0"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -119,7 +119,8 @@ See [Code Intelligence](./code-intelligence) for detailed usage.
 | `cora affected` `<files...>` | Find test files affected by source changes |
 | `cora affected --stdin` | Read changed files from stdin (pipe from `git diff --name-only`) |
 | `cora affected --filter` `"*test*"` | Custom test file glob pattern |
-| `cora dead-code` | Detect dead code — functions/methods with zero callers |
+| `cora dead-code` | Detect dead code — functions/methods with zero callers (public API surface skipped by default; honors ignore.files via the index) |
+| `cora dead-code --include-pub` | Include public API surface (pub/export items) in results |
 | `cora dead-code --include-tests` | Include test functions in results |
 | `cora dead-code --min-lines N` | Filter out tiny functions |
 | `cora query` `"main -> *"` | Query the code graph with simple patterns |


### PR DESCRIPTION
## What
Release preparation for v0.14.0:
- Bump version 0.13.0 → 0.14.0 (Cargo.toml + Cargo.lock)
- Promote CHANGELOG `[Unreleased]` to `[0.14.0]` (2026-08-28) and open a fresh `[Unreleased]`
- `docs/cli-reference.md`: document `cora dead-code --include-pub` and the new default behavior (public API skipped by default, ignore.files honored via the index)
- `AGENT.md`: refresh test counts (934) and add `engine/enclosing.rs` to the source tree

## Why
Per the OSS release workflow: version bump + CHANGELOG promotion must land on develop before the develop → main sync and tagging. The docs updates cover the feature batch merged since v0.13.0 (#519–#523, #536, relicensing).

## Testing
- Docs-only change, committed with `--no-verify` per release standard
- Full suite green (934 tests, both default and tree-sitter feature)
- `cargo check` regenerated Cargo.lock at 0.14.0

All commits signed-off (DCO).