### PR TITLE
docs(cli): document cora upgrade — self-upgrade was undocumented

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ cargo install --git https://github.com/codecoradev/cora-code
 
 > Pin a version: `CORA_VERSION=v0.6.1 curl -fsSL ... | sh`
 
+**Upgrading:** run `cora upgrade` (downloads the latest release, verifies its SHA-256 checksum, replaces the binary) or `cora upgrade --check` to just see if one is available. If you installed via `cargo install --path .`, re-run that instead.
+
 **Verify which `cora` you're running** — `which -a cora` will reveal stale copies from other channels:
 
 ```bash
@@ -213,6 +215,7 @@ Works on **all CI platforms** — [Gitea, GitLab, Bitbucket →](https://codecor
 | `cora serve` | Start MCP server + auto-reindex on startup |
 | `cora install` | Auto-detect and configure AI coding agents |
 | `cora hook install` | Install pre-commit hook |
+| `cora upgrade` | Self-upgrade from GitHub Releases (checksum-verified) |
 
 See **[CLI Reference →](https://codecora.dev/cora/docs/cli-reference)** for all flags and examples.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -166,6 +166,19 @@ See [Code Intelligence](./code-intelligence) for detailed usage.
 | `cora mcp` | Start MCP server for AI coding agents (Claude Code, Cursor, Windsurf) |
 | `cora serve` | Start MCP server with auto-reindex on startup |
 
+### Self-Upgrade
+
+| Command | Description |
+|---------|-------------|
+| `cora upgrade --check` | Check for a newer release; no download |
+| `cora upgrade` | Detect OS/arch, download the latest GitHub release asset, verify its SHA-256 checksum, and replace the running binary |
+| `cora upgrade -y` | Same, but skip the confirmation prompt (CI/automation) |
+
+Notes:
+
+- Background update notification: a non-blocking check runs on startup, cached for 24 h at `~/.codecora/cora-code/update-cache.json`. Notices go to stderr only. Disable with the `CORA_NO_UPDATE_CHECK=1` environment variable.
+- If the running binary came from `cargo install --path .`, prefer re-running that instead of `cora upgrade` (the release asset would shadow your source build).
+
 ## Quick Examples
 
 ```bash


### PR DESCRIPTION
## What

Closes #541: `cora upgrade` is implemented and wired but absent from the docs.

- `docs/cli-reference.md`: new **Self-Upgrade** section — `cora upgrade --check`, the default flow (OS/arch detection → latest GitHub release asset → SHA-256 checksum verification → binary replacement), and `cora upgrade -y` for CI/automation.
- Notes the background update notification (non-blocking startup check, 24 h cache at `~/.codecora/cora-code/update-cache.json`, stderr-only) and the cargo-from-source caveat.
- `README.md`: upgrade note under the install methods + a row in the command table.

## Why

Self-upgrade is a user-facing command with zero documentation: users have no discoverable way to update cora, and the startup update notification references behavior that is documented nowhere. This adds the missing reference so the command and its safety properties (checksum verification) are discoverable.

## Correction vs the issue body

The issue proposed documenting a `--no-update-check` flag — that flag does not exist. The background check is disabled via the `CORA_NO_UPDATE_CHECK=1` environment variable (main.rs), so the docs document the env var.

## Testing

Docs-only change; no code paths touched.