### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-31
+
 ### Added
 
 - **Opt-in `vecq` vector store for Brain Mode.** Set `brain.vector_store: vecq` in `.cora.yaml` to replace the usearch HNSW index with a vecq quantized scan (pure Rust, deterministic, ~5x smaller). Keyed persistence included: symbol ids survive reload, so a fresh process serves the index as-is and `cora index` no longer re-embeds unchanged projects (#542, #547).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "cora-code"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cora-code"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "CLI-first AI code review — BYOK, diff/scan/branch, pre-commit hooks"
 license = "Apache-2.0"


### PR DESCRIPTION
## What

Release prep: bump `cora-code` 0.14.0 → 0.15.0 and stamp the CHANGELOG.

## Why

Version bump per release checklist (CHANGELOG entry is a tag-blocker). Content of 0.15.0 since v0.14.0:

- **feat(brain):** opt-in `vecq` vector store (#543) with keyed persistence, `residual` default width, and the `brain.vector_bits` knob (#548 / #547)
- **fix(brain):** vector signal dead in fresh processes (#546 / #545); stale embed fingerprints after a global index rebuild
- **docs(cli):** document `cora upgrade` (#549 / #541)

## Testing

Full suite green on develop; CI validates this PR.

## Release steps after merge

1. `develop` → `main` via `release/v0.15.0` branch PR
2. Tag `v0.15.0` on main → `release.yml` publishes