### PR TITLE
fix(ci): make cla-check work for fork PRs

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   pull-requests: write
   contents: read
-  statuses: write
 
 jobs:
   cla-check:
@@ -46,9 +45,10 @@ jobs:
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
-      - name: Comment on PR (unsigned only)
-        if: steps.check.outputs.signed != 'true'
-        uses: actions/github-script@v7
+      - name: Comment on PR (same-repo, best effort)
+        if: steps.check.outputs.signed != 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: actions/github-script@v9
         with:
           script: |
             const author = '${{ github.event.pull_request.user.login }}';
@@ -96,27 +96,9 @@ jobs:
               });
             }
 
-      - name: Set commit status
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const signed = '${{ steps.check.outputs.signed }}' === 'true';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ github.event.pull_request.head.sha }}',
-              state: signed ? 'success' : 'failure',
-              context: 'CLA Check',
-              description: signed
-                ? '✅ CLA signed'
-                : '❌ CLA not signed — sign at https://codecoradev.github.io/cla',
-              target_url: signed
-                ? 'https://github.com/codecoradev/.github/blob/main/.cla/signatures.json'
-                : 'https://codecoradev.github.io/cla',
-            });
-
       - name: Fail if not signed
         if: steps.check.outputs.signed != 'true'
         run: |
+          echo "::error title=CLA not signed::Sign the CodeCoraDev CLA at https://codecoradev.github.io/cla — once the signature PR is merged, this check turns green automatically (re-run it or wait ~1 hour)."
           echo "❌ CLA not signed by ${{ github.event.pull_request.user.login }}"
           exit 1


### PR DESCRIPTION
## What
- `cla-check.yml` no longer POSTs a commit status (context `CLA Check`); the CLA gate now rides on the job's own Actions check run (`cla-check`)
- Removes the `statuses: write` permission
- PR comment step becomes same-repo-only + `continue-on-error` (best effort)
- Unsigned path emits a `::error` annotation with the portal link
- github-script upgraded to v9

## Why
Fork PRs always run workflows with a read-only `GITHUB_TOKEN`, regardless of declared `permissions`. The old design gated CLA on a manually POSTed commit status, so every external fork PR failed the status step with 403 — permanently red even with a signed CLA. Verified on uteke PR #1221 (fork), run 34481899319: `signed='true'` yet `POST /statuses -> 403`; the comment step was also skipped (forks cannot comment at all).

The native Actions check run is created by GitHub itself and is not subject to the fork token restriction, making it the correct carrier for the gate. Semantics unchanged: signed -> green, unsigned -> red with an explanatory annotation. Fix was validated end-to-end on codecoradev/uteke (PR #1224 + E2E probe PR #1225: ruleset swapped to require `cla-check`, all checks green, merge CLEAN with an empty combined commit status).

## Testing
- Structural asserts: no `createCommitStatus`, no `statuses: write`, comment step same-repo-conditioned + `continue-on-error`, `::error` present, check-step body byte-identical to the original, trigger untouched
- Functional test of the check script against live `signatures.json`: signed and unsigned paths both correct
- Same patch validated live on uteke (#1224, merged); this PR applies the identical validated transformation
- Post-merge: ruleset required context swaps `CLA Check` -> `cla-check` (case-sensitive) via API, then the PR is mergeable

## Notes
Until the ruleset swap, new PRs show a missing `CLA Check` context — expected transitional state; this PR itself may show it. Sequence: merge this -> ruleset swap -> mergeable.
